### PR TITLE
Update JobFileDAO.scala

### DIFF
--- a/job-server/src/spark.jobserver/io/JobFileDAO.scala
+++ b/job-server/src/spark.jobserver/io/JobFileDAO.scala
@@ -135,7 +135,7 @@ class JobFileDAO(config: Config) extends JobDAO {
   override def retrieveJarFile(appName: String, uploadTime: DateTime): String =
     new File(rootDir, createJarName(appName, uploadTime) + ".jar").getAbsolutePath
 
-  private def createJarName(appName: String, uploadTime: DateTime): String = appName + "-" + uploadTime
+  private def createJarName(appName: String, uploadTime: DateTime): String = appName + "-" + uploadTime.toString().replace(':', '_')
 
   override def saveJobInfo(jobInfo: JobInfo) {
     writeJobInfo(jobsOutputStream, jobInfo)


### PR DESCRIPTION
Compatibility change to run with MS-Windows 7. Windows doesn't allow colons ( : ) in file-names.
