### PR TITLE
updated server_start.sh to remove some string duplication

### DIFF
--- a/bin/server_start.sh
+++ b/bin/server_start.sh
@@ -55,8 +55,8 @@ if [ -f "$PIDFILE" ] && kill -0 $(cat "$PIDFILE"); then
 fi
 
 if [ -z "$LOG_DIR" ]; then
-  echo "LOG_DIR empty; logging will go to /tmp/job-server"
   LOG_DIR=/tmp/job-server
+  echo "LOG_DIR empty; logging will go to $LOG_DIR"
 fi
 mkdir -p $LOG_DIR
 


### PR DESCRIPTION
As submitted earlier to ooyala/spark-jobserver:

If the default log directory changes and the user does not specify a default, now the warning message will actually display the actual value we set the log directory to.
