### PR TITLE
Upgrade spark to 1.2.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,9 +20,9 @@ object Dependencies {
     // to use this one
     "com.typesafe.akka" %% "akka-slf4j" % "2.2.4" % "provided",
     "io.spray" %% "spray-json" % "1.2.5",
-    "io.spray" % "spray-can" % "1.3.2",
-    "io.spray" % "spray-routing" % "1.3.2",
-    "io.spray" % "spray-client" % "1.3.2",
+    "io.spray" % "spray-can" % "1.3.1",
+    "io.spray" % "spray-routing" % "1.3.1",
+    "io.spray" % "spray-client" % "1.3.1",
     yammerDeps
   ) ++ yodaDeps
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val excludeNetty = ExclusionRule(organization = "org.jboss.netty")
   val excludeAsm = ExclusionRule(organization = "asm")
 
-  lazy val typeSafeConfigDeps = "com.typesafe" % "config" % "1.0.0"
+  lazy val typeSafeConfigDeps = "com.typesafe" % "config" % "1.2.1"
   lazy val yammerDeps = "com.yammer.metrics" % "metrics-core" % "2.2.0"
 
   lazy val yodaDeps = Seq(
@@ -20,14 +20,14 @@ object Dependencies {
     // to use this one
     "com.typesafe.akka" %% "akka-slf4j" % "2.2.4" % "provided",
     "io.spray" %% "spray-json" % "1.2.5",
-    "io.spray" % "spray-can" % "1.2.1",
-    "io.spray" % "spray-routing" % "1.2.1",
-    "io.spray" % "spray-client" % "1.2.1",
+    "io.spray" % "spray-can" % "1.3.2",
+    "io.spray" % "spray-routing" % "1.3.2",
+    "io.spray" % "spray-client" % "1.3.2",
     yammerDeps
   ) ++ yodaDeps
 
   lazy val sparkDeps = Seq(
-    "org.apache.spark" %% "spark-core" % "1.1.0" % "provided" exclude("io.netty", "netty-all"),
+    "org.apache.spark" %% "spark-core" % "1.2.0" % "provided" exclude("io.netty", "netty-all"),
     // Force netty version.  This avoids some Spark netty dependency problem.
     "io.netty" % "netty" % "3.6.6.Final"
   )


### PR DESCRIPTION
typesafe config and spray are upgraded to the latest as required to work
with the akka version provided in spark 1.2 (akka 2.3.4).

Testing done:
Successfully ran jobs on mesos 0.21.0.

Issue #30