### PR TITLE
Support storing rdds that have a storeLevel already set

### DIFF
--- a/job-server/src/spark.jobserver/JobServerNamedRdds.scala
+++ b/job-server/src/spark.jobserver/JobServerNamedRdds.scala
@@ -88,8 +88,8 @@ class JobServerNamedRdds(val rddManager: ActorRef) extends NamedRdds {
     val rdd = rddGen
     rdd.setName(name)
     rdd.getStorageLevel match {
-      case StorageLevel.NONE => rdd.persist(storageLevel) 
-      case currentLevel => rdd.persist(currentLevel) 
+      case StorageLevel.NONE => rdd.persist(storageLevel)
+      case currentLevel => rdd.persist(currentLevel)
     }
     // TODO: figure out if there is a better way to force the RDD to be computed
     if (forceComputation) rdd.count()

--- a/job-server/src/spark.jobserver/JobServerNamedRdds.scala
+++ b/job-server/src/spark.jobserver/JobServerNamedRdds.scala
@@ -87,11 +87,10 @@ class JobServerNamedRdds(val rddManager: ActorRef) extends NamedRdds {
       "forceComputation implies storageLevel != NONE")
     val rdd = rddGen
     rdd.setName(name)
-    val level = rdd.getStorageLevel match {
-      case StorageLevel.NONE => storageLevel
-      case _ => rdd.getStorageLevel
+    rdd.getStorageLevel match {
+      case StorageLevel.NONE => rdd.persist(storageLevel) 
+      case currentLevel => rdd.persist(currentLevel) 
     }
-    if (level != StorageLevel.NONE) rdd.persist(level)
     // TODO: figure out if there is a better way to force the RDD to be computed
     if (forceComputation) rdd.count()
     rdd

--- a/job-server/src/spark.jobserver/JobServerNamedRdds.scala
+++ b/job-server/src/spark.jobserver/JobServerNamedRdds.scala
@@ -87,7 +87,11 @@ class JobServerNamedRdds(val rddManager: ActorRef) extends NamedRdds {
       "forceComputation implies storageLevel != NONE")
     val rdd = rddGen
     rdd.setName(name)
-    if (storageLevel != StorageLevel.NONE) rdd.persist(storageLevel)
+    val level = rdd.getStorageLevel match {
+      case StorageLevel.NONE => storageLevel
+      case _ => rdd.getStorageLevel
+    }
+    if (level != StorageLevel.NONE) rdd.persist(level)
     // TODO: figure out if there is a better way to force the RDD to be computed
     if (forceComputation) rdd.count()
     rdd

--- a/job-server/test/spark.jobserver/NamedRddsSpec.scala
+++ b/job-server/test/spark.jobserver/NamedRddsSpec.scala
@@ -5,7 +5,7 @@ import akka.testkit.{ImplicitSender, TestKit}
 import org.apache.spark.SparkContext
 import org.apache.spark.storage.StorageLevel
 import org.scalatest.matchers.ShouldMatchers
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpec}
+import org.scalatest.{FunSpec, BeforeAndAfterAll, BeforeAndAfter}
 
 class NamedRddsSpec extends TestKit(ActorSystem("NamedRddsSpec")) with FunSpec
 with ImplicitSender with ShouldMatchers with BeforeAndAfter with BeforeAndAfterAll {

--- a/job-server/test/spark.jobserver/NamedRddsSpec.scala
+++ b/job-server/test/spark.jobserver/NamedRddsSpec.scala
@@ -94,7 +94,7 @@ with ImplicitSender with ShouldMatchers with BeforeAndAfter with BeforeAndAfterA
       namedRdds.get[Int]("rdd") should equal (Some(rdd2))
     }
 
-    it("update() should replace existing RDD even if it was persisted before") {
+    it("update() should update an RDD even if it was persisted before") {
       // The result of some computations (ie: a MatrixFactorizationModel after training ALS) might have been
       // persisted before so they might have a specific storageLevel.
       val rdd1 = sc.parallelize(Seq(1, 2, 3))

--- a/job-server/test/spark.jobserver/NamedRddsSpec.scala
+++ b/job-server/test/spark.jobserver/NamedRddsSpec.scala
@@ -1,10 +1,11 @@
 package spark.jobserver
 
-import akka.actor.{PoisonPill, Props, ActorRef, ActorSystem}
+import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.testkit.{ImplicitSender, TestKit}
 import org.apache.spark.SparkContext
+import org.apache.spark.storage.StorageLevel
 import org.scalatest.matchers.ShouldMatchers
-import org.scalatest.{FunSpec, BeforeAndAfterAll, BeforeAndAfter}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpec}
 
 class NamedRddsSpec extends TestKit(ActorSystem("NamedRddsSpec")) with FunSpec
 with ImplicitSender with ShouldMatchers with BeforeAndAfter with BeforeAndAfterAll {
@@ -91,6 +92,15 @@ with ImplicitSender with ShouldMatchers with BeforeAndAfter with BeforeAndAfterA
       namedRdds.getOrElseCreate("rdd", rdd1) should equal (rdd1)
       namedRdds.update("rdd", rdd2)
       namedRdds.get[Int]("rdd") should equal (Some(rdd2))
+    }
+
+    it("update() should replace existing RDD even if it was persisted before") {
+      // The result of some computations (ie: a MatrixFactorizationModel after training ALS) might have been
+      // persisted before so they might have a specific storageLevel.
+      val rdd1 = sc.parallelize(Seq(1, 2, 3))
+      rdd1.persist(StorageLevel.MEMORY_AND_DISK)
+      namedRdds.update("rdd", rdd1)
+      namedRdds.get[Int]("rdd") should equal (Some(rdd1))
     }
 
     it("should include underlying exception when error occurs") {


### PR DESCRIPTION
The code was trying to override the StorageLevel on the given RDD, but some rdds are cached by spark (ie: the ones in a MatrixFactorization result of ALS.train)