### PR TITLE
SPARK_CONF_HOME to SPARK_CONF_DIR

### DIFF
--- a/bin/server_start.sh
+++ b/bin/server_start.sh
@@ -42,12 +42,12 @@ if [ -z "$SPARK_HOME" ]; then
   exit 1
 fi
 
-if [ -z "$SPARK_CONF_HOME" ]; then
-  SPARK_CONF_HOME=$SPARK_HOME/conf
+if [ -z "$SPARK_CONF_DIR" ]; then
+  SPARK_CONF_DIR=$SPARK_HOME/conf
 fi
 
 # Pull in other env vars in spark config, such as MESOS_NATIVE_LIBRARY
-. $SPARK_CONF_HOME/spark-env.sh
+. $SPARK_CONF_DIR/spark-env.sh
 
 if [ -f "$PIDFILE" ] && kill -0 $(cat "$PIDFILE"); then
    echo 'Job server is already running'

--- a/job-server/config/local.sh.template
+++ b/job-server/config/local.sh.template
@@ -11,6 +11,6 @@ INSTALL_DIR=/home/spark/job-server
 LOG_DIR=/var/log/job-server
 PIDFILE=spark-jobserver.pid
 SPARK_HOME=/home/spark/spark-0.8.0
-SPARK_CONF_HOME=$SPARK_HOME/conf
+SPARK_CONF_DIR=$SPARK_HOME/conf
 # Only needed for Mesos deploys
 SPARK_EXECUTOR_URI=/home/spark/spark-0.8.0.tar.gz


### PR DESCRIPTION
In Spark we normally use SPARK_CONF_DIR to represent Spark's config directory. Maybe changing the name here is better.