### PR TITLE
add unitest

### DIFF
--- a/job-server/test/spark.jobserver/LocalContextSupervisorSpec.scala
+++ b/job-server/test/spark.jobserver/LocalContextSupervisorSpec.scala
@@ -118,5 +118,22 @@ class LocalContextSupervisorSpec extends TestKit(LocalContextSupervisorSpec.syst
       supervisor ! AddContext("c1", contextConfig)
       expectMsg(ContextAlreadyExists)
     }
+	
+	it("should list empty contexts if a yarn-client mode context crashed") {
+      import ContextSupervisor._
+      supervisor ! AddContext("c1", contextConfig)
+      expectMsg(ContextInitialized)
+
+      supervisor ! ListContexts
+      expectMsg(Seq("c1"))
+
+      supervisor ! GetContext("c1")
+      val (jmActor,rActor) = expectMsgClass(classOf[Tuple2[ActorRef,ActorRef]])
+      jmActor !  PoisonPill
+      supervisor ! ListContexts
+      //expectMsg(Seq("c1"))
+      expectMsg(Seq.empty[String])
+	}
+	
   }
 }


### PR DESCRIPTION
in yarn-client mode that when sparkcontext crashs the map data struct
should delete item