### PR TITLE
Change "mem-per-node" to "memory-per-node"

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ real clusters and most jobs this may be too slow.
 
 Another way of running this job is in a pre-created context.  Start a new context:
 
-    curl -d "" 'localhost:8090/contexts/test-context?num-cpu-cores=4&mem-per-node=512m'
+    curl -d "" 'localhost:8090/contexts/test-context?num-cpu-cores=4&memory-per-node=512m'
     OK⏎
 
 You can verify that the context has been created:

--- a/job-server/src/spark.jobserver/WebApi.scala
+++ b/job-server/src/spark.jobserver/WebApi.scala
@@ -106,7 +106,7 @@ class WebApi(system: ActorSystem, config: Config, port: Int,
          *    All options are merged into the defaults in spark.context-settings
          *
          * @optional @param num-cpu-cores Int - Number of cores the context will use
-         * @optional @param mem-per-node String - -Xmx style string (512m, 1g, etc) for max memory per node
+         * @optional @param memory-per-node String - -Xmx style string (512m, 1g, etc) for max memory per node
          * @return the string "OK", or error if context exists or could not be initialized
          */
         path(Segment) { (contextName) =>


### PR DESCRIPTION
"mem-per-node" is not valid, because in the config, using "memory-per-node". For example, using  "memory-per-node" in SparkJobUtils.scala, not "mem-per-node".