### PR TITLE
Add uris of dependence jars when creating context

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,9 @@ the REST API.
 ### Context configuration
 
 A number of context-specific settings can be controlled when creating a context (POST /contexts) or running an
-ad-hoc job (which creates a context on the spot).
+ad-hoc job (which creates a context on the spot).  For example, add urls of dependent jars for a context.
+
+    POST '/contexts/my-new-context?dependent-jar-uris=file:///some/path/of/my-foo-lib.jar'
 
 When creating a context via POST /contexts, the query params are used to override the default configuration in
 spark.context-settings.  For example,

--- a/job-server/config/local.conf.template
+++ b/job-server/config/local.conf.template
@@ -39,8 +39,7 @@ spark {
     # in case spark distribution should be accessed from HDFS (as opposed to being installed on every mesos slave)
     # spark.executor.uri = "hdfs://namenode:8020/apps/spark/spark.tgz"
 
-    # uris of jars to be loaded into the classpath for this context
-    # uris of jars is a string list, or a string separated by commas ','
+    # uris of jars to be loaded into the classpath for this context. Uris is a string list, or a string separated by commas ','
     # dependent-jar-uris = "[file:///some/path/present/in/each/mesos/slave/somepackage.jar]"
 
     # If you wish to pass any settings directly to the sparkConf as-is, add them here in passthrough,

--- a/job-server/config/local.conf.template
+++ b/job-server/config/local.conf.template
@@ -39,8 +39,10 @@ spark {
     # in case spark distribution should be accessed from HDFS (as opposed to being installed on every mesos slave)
     # spark.executor.uri = "hdfs://namenode:8020/apps/spark/spark.tgz"
 
-    # uris of jars to be loaded into the classpath for this context. URIs of jars separated by commas ','
+    # uris of jars to be loaded into the classpath for this context
+    # uris of jars is a string list, or a string separated by commas ','
     # dependent-jar-uris = "file:///some/path/present/in/each/mesos/slave/somepackage.jar"
+    # dependent-jar-uris = "[file:///some/path/present/in/each/mesos/slave/somepackage.jar]"
     # dependent-jar-uris = "file:///some/path/of/my-foo-lib.jar,file:///some/path/of/my-boo-lib.jar"
 
     # If you wish to pass any settings directly to the sparkConf as-is, add them here in passthrough,

--- a/job-server/config/local.conf.template
+++ b/job-server/config/local.conf.template
@@ -39,8 +39,7 @@ spark {
     # in case spark distribution should be accessed from HDFS (as opposed to being installed on every mesos slave)
     # spark.executor.uri = "hdfs://namenode:8020/apps/spark/spark.tgz"
 
-    # uris of jars to be loaded into the classpath for this context
-    # uris of jars separated by commas ','
+    # uris of jars to be loaded into the classpath for this context. Uris of jars separated by commas ','
     # dependent-jar-uris = "file:///some/path/present/in/each/mesos/slave/somepackage.jar"
     # dependent-jar-uris = "file:///some/path/of/my-foo-lib.jar,file:///some/path/of/my-boo-lib.jar"
 

--- a/job-server/config/local.conf.template
+++ b/job-server/config/local.conf.template
@@ -40,8 +40,10 @@ spark {
     # spark.executor.uri = "hdfs://namenode:8020/apps/spark/spark.tgz"
 
     # uris of jars to be loaded into the classpath for this context
-    # dependent-jar-uris = ["file:///some/path/present/in/each/mesos/slave/somepackage.jar"]
-    
+    # uris of jars separated by commas ','
+    # dependent-jar-uris = "file:///some/path/present/in/each/mesos/slave/somepackage.jar"
+    # dependent-jar-uris = "file:///some/path/of/my-foo-lib.jar,file:///some/path/of/my-boo-lib.jar"
+
     # If you wish to pass any settings directly to the sparkConf as-is, add them here in passthrough,
     # such as hadoop connection settings that don't use the "spark." prefix
     passthrough {

--- a/job-server/config/local.conf.template
+++ b/job-server/config/local.conf.template
@@ -41,9 +41,7 @@ spark {
 
     # uris of jars to be loaded into the classpath for this context
     # uris of jars is a string list, or a string separated by commas ','
-    # dependent-jar-uris = "file:///some/path/present/in/each/mesos/slave/somepackage.jar"
     # dependent-jar-uris = "[file:///some/path/present/in/each/mesos/slave/somepackage.jar]"
-    # dependent-jar-uris = "file:///some/path/of/my-foo-lib.jar,file:///some/path/of/my-boo-lib.jar"
 
     # If you wish to pass any settings directly to the sparkConf as-is, add them here in passthrough,
     # such as hadoop connection settings that don't use the "spark." prefix

--- a/job-server/config/local.conf.template
+++ b/job-server/config/local.conf.template
@@ -39,7 +39,7 @@ spark {
     # in case spark distribution should be accessed from HDFS (as opposed to being installed on every mesos slave)
     # spark.executor.uri = "hdfs://namenode:8020/apps/spark/spark.tgz"
 
-    # uris of jars to be loaded into the classpath for this context. Uris of jars separated by commas ','
+    # uris of jars to be loaded into the classpath for this context. URIs of jars separated by commas ','
     # dependent-jar-uris = "file:///some/path/present/in/each/mesos/slave/somepackage.jar"
     # dependent-jar-uris = "file:///some/path/of/my-foo-lib.jar,file:///some/path/of/my-boo-lib.jar"
 

--- a/job-server/src/spark.jobserver/JobManagerActor.scala
+++ b/job-server/src/spark.jobserver/JobManagerActor.scala
@@ -276,5 +276,6 @@ class JobManagerActor(dao: JobDAO,
   // Each one should be an URL (http, ftp, hdfs, local, or file). local URLs are local files
   // present on every node, whereas file:// will be assumed only present on driver node
   private def getSideJars(config: Config): Seq[String] =
-    Try(config.getString("dependent-jar-uris").split(",").toSeq).getOrElse(Nil)
+    Try(config.getStringList("dependent-jar-uris").asScala.toSeq).
+     orElse(Try(config.getString("dependent-jar-uris").split(",").toSeq)).getOrElse(Nil)
 }

--- a/job-server/src/spark.jobserver/JobManagerActor.scala
+++ b/job-server/src/spark.jobserver/JobManagerActor.scala
@@ -40,8 +40,8 @@ object JobManagerActor {
  * {{{
  *  num-cpu-cores = 4         # Total # of CPU cores to allocate across the cluster
  *  memory-per-node = 512m    # -Xmx style memory string for total memory to use for executor on one node
- *  dependent-jar-uris = "local://opt/foo/my-foo-lib.jar"
- *                            # URIs for dependent jars to load for entire context. URIs of jars Separated by ','
+ *  dependent-jar-uris = ["local://opt/foo/my-foo-lib.jar"]
+ *                            # URIs for dependent jars to load for entire context.
  *  max-jobs-per-context = 4  # Max # of jobs to run at the same time
  *  spark.mesos.coarse = true  # per-context, rather than per-job, resource allocation
  *  rdd-ttl = 24 h            # time-to-live for RDDs in a SparkContext.  Don't specify = forever

--- a/job-server/src/spark.jobserver/JobManagerActor.scala
+++ b/job-server/src/spark.jobserver/JobManagerActor.scala
@@ -40,8 +40,8 @@ object JobManagerActor {
  * {{{
  *  num-cpu-cores = 4         # Total # of CPU cores to allocate across the cluster
  *  memory-per-node = 512m    # -Xmx style memory string for total memory to use for executor on one node
- *  dependent-jar-uris = ["local://opt/foo/my-foo-lib.jar"]
- *                            # URIs for dependent jars to load for entire context
+ *  dependent-jar-uris = "local://opt/foo/my-foo-lib.jar"
+ *                            # URIs for dependent jars to load for entire context. URIs of jars Separated by ','
  *  max-jobs-per-context = 4  # Max # of jobs to run at the same time
  *  spark.mesos.coarse = true  # per-context, rather than per-job, resource allocation
  *  rdd-ttl = 24 h            # time-to-live for RDDs in a SparkContext.  Don't specify = forever

--- a/job-server/src/spark.jobserver/JobManagerActor.scala
+++ b/job-server/src/spark.jobserver/JobManagerActor.scala
@@ -41,7 +41,7 @@ object JobManagerActor {
  *  num-cpu-cores = 4         # Total # of CPU cores to allocate across the cluster
  *  memory-per-node = 512m    # -Xmx style memory string for total memory to use for executor on one node
  *  dependent-jar-uris = ["local://opt/foo/my-foo-lib.jar"]
- *                            # URIs for dependent jars to load for entire context.
+ *                            # URIs for dependent jars to load for entire context
  *  max-jobs-per-context = 4  # Max # of jobs to run at the same time
  *  spark.mesos.coarse = true  # per-context, rather than per-job, resource allocation
  *  rdd-ttl = 24 h            # time-to-live for RDDs in a SparkContext.  Don't specify = forever

--- a/job-server/src/spark.jobserver/JobManagerActor.scala
+++ b/job-server/src/spark.jobserver/JobManagerActor.scala
@@ -276,5 +276,5 @@ class JobManagerActor(dao: JobDAO,
   // Each one should be an URL (http, ftp, hdfs, local, or file). local URLs are local files
   // present on every node, whereas file:// will be assumed only present on driver node
   private def getSideJars(config: Config): Seq[String] =
-    Try(config.getStringList("dependent-jar-uris").asScala.toSeq).getOrElse(Nil)
+    Try(config.getString("dependent-jar-uris").split(",").toSeq).getOrElse(Nil)
 }


### PR DESCRIPTION
When creating context, I want to add uris of dependent jars.  And i want to add different jars for different context. If option "dependent-jar-uris" is a list, there is impossible to using "POST /contexts/<name>?dependent-jar-uris=[file:///some/path/of/my-foo-lib.jar]" to create context. So i change the type of "dependent-jar-uris".

For example:
curl -d "" 'localhost:8090/contexts/test-context?dependent-jar-uris=file:///some/path/of/my-foo-lib.jar,file:///some/path/of/my-boo-lib.jar'

In this way, when creating test-context, i pass the dependence jars for this context.