### PR TITLE
uris of jars is a string list, or a string separated by commas ','

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,9 @@ the REST API.
 ### Context configuration
 
 A number of context-specific settings can be controlled when creating a context (POST /contexts) or running an
-ad-hoc job (which creates a context on the spot).
+ad-hoc job (which creates a context on the spot).  For example, add urls of dependent jars for a context.
+
+    POST '/contexts/my-new-context?dependent-jar-uris=file:///some/path/of/my-foo-lib.jar'
 
 When creating a context via POST /contexts, the query params are used to override the default configuration in
 spark.context-settings.  For example,

--- a/job-server/config/local.conf.template
+++ b/job-server/config/local.conf.template
@@ -41,7 +41,6 @@ spark {
 
     # uris of jars to be loaded into the classpath for this context. Uris is a string list, or a string separated by commas ','
     # dependent-jar-uris = ["file:///some/path/present/in/each/mesos/slave/somepackage.jar"]
-    # dependent-jar-uris = "file:///some/path/of/my-foo-lib.jar,file:///some/path/of/my-boo-lib.jar"
     
     # If you wish to pass any settings directly to the sparkConf as-is, add them here in passthrough,
     # such as hadoop connection settings that don't use the "spark." prefix

--- a/job-server/config/local.conf.template
+++ b/job-server/config/local.conf.template
@@ -39,8 +39,9 @@ spark {
     # in case spark distribution should be accessed from HDFS (as opposed to being installed on every mesos slave)
     # spark.executor.uri = "hdfs://namenode:8020/apps/spark/spark.tgz"
 
-    # uris of jars to be loaded into the classpath for this context
+    # uris of jars to be loaded into the classpath for this context. Uris is a string list, or a string separated by commas ','
     # dependent-jar-uris = ["file:///some/path/present/in/each/mesos/slave/somepackage.jar"]
+    # dependent-jar-uris = "file:///some/path/of/my-foo-lib.jar,file:///some/path/of/my-boo-lib.jar"
     
     # If you wish to pass any settings directly to the sparkConf as-is, add them here in passthrough,
     # such as hadoop connection settings that don't use the "spark." prefix

--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -53,6 +53,9 @@ spark {
     # A zero-arg class implementing spark.jobserver.context.SparkContextFactory
     # Determines the type of jobs that can run in a SparkContext
     context-factory = spark.jobserver.context.DefaultSparkContextFactory
+    
+    # uris of jars to be loaded into the classpath for this context. Uris is a string list, or a string separated by commas ','
+    # dependent-jar-uris = ["file:///some/path/present/in/each/mesos/slave/somepackage.jar"]
 
     passthrough {
       spark.driver.allowMultipleContexts = true  # Ignore the Multiple context exception related with SPARK-2243

--- a/job-server/src/spark.jobserver/JobManagerActor.scala
+++ b/job-server/src/spark.jobserver/JobManagerActor.scala
@@ -285,5 +285,6 @@ class JobManagerActor(dao: JobDAO,
   // Each one should be an URL (http, ftp, hdfs, local, or file). local URLs are local files
   // present on every node, whereas file:// will be assumed only present on driver node
   private def getSideJars(config: Config): Seq[String] =
-    Try(config.getStringList("dependent-jar-uris").asScala.toSeq).getOrElse(Nil)
+    Try(config.getStringList("dependent-jar-uris").asScala.toSeq).
+     orElse(Try(config.getString("dependent-jar-uris").split(",").toSeq)).getOrElse(Nil)
 }


### PR DESCRIPTION
When creating context, I want to add uris of dependent jars. And i want to add different jars for different context. If option "dependent-jar-uris" is a list, there is impossible to using "POST /contexts/?dependent-jar-uris=[file:///some/path/of/my-foo-lib.jar]" to create context. So i change the type of "dependent-jar-uris".

For example:
curl -d "" 'localhost:8090/contexts/test-context?dependent-jar-uris=file:///some/path/of/my-foo-lib.jar,file:///some/path/of/my-boo-lib.jar'

In this way, when creating test-context, i pass the dependence jars for this context.

See: https://github.com/spark-jobserver/spark-jobserver/pull/65 