### PR TITLE
Improve Quick Start Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,13 @@ For release notes, look in the `notes/` directory.  They should also be up on [l
 
 ## Quick start / development mode
 
-You need to have [SBT](http://www.scala-sbt.org/release/docs/Getting-Started/Setup.html) installed.
+First clone the repository and check out the v0.4.1 version by running:
+
+    git clone https://github.com/spark-jobserver/spark-jobserver.git
+    cd spark-jobserver
+    git checkout tags/v0.4.1
+
+You need to have [SBT](http://www.scala-sbt.org/release/docs/Getting-Started/Setup.html) installed. Start the SBT shell by running the `sbt` command from within the `spark-jobserver` directory.
 
 From SBT shell, simply type "reStart".  This uses a default configuration file.  An optional argument is a
 path to an alternative config file.  You can also specify JVM parameters after "---".  Including all the


### PR DESCRIPTION
I faced some issues when getting started that could have been avoided if a note about version tag checkout had been in the README, so I thought I'd add it. My issue was that the command `curl --data-binary @job-server-tests/target/job-server-tests-0.4.1.jar localhost:8090/jars/test` was failing with

    Warning: Couldn't read data from file 
    Warning: "job-server-tests/target/job-server-tests-0.4.1.jar", this makes an 
    Warning: empty POST.

I had to change it to `curl --data-binary @job-server-tests/target/job-server-tests-0.4.2-SNAPSHOT.jar localhost:8090/jars/test`. Then I realized I should be using v0.4.1 in the first place.