### PR TITLE
fix: Serialize empty maps.

### DIFF
--- a/akka-app/src/ooyala.common.akka/web/JsonUtils.scala
+++ b/akka-app/src/ooyala.common.akka/web/JsonUtils.scala
@@ -20,6 +20,7 @@ object JsonUtils {
       case f: Float => JsNumber(f.toDouble)
       case s: String => JsString(s)
       case x: Seq[_] => seqFormat[Any].write(x)
+      case m: Map[_, _] if m.isEmpty => JsObject(Map[String, JsValue]())
       // Get the type of map keys from the first key, translate the rest the same way
       case m: Map[_, _] => m.keys.head match {
         case sym: Symbol =>

--- a/akka-app/test/ooyala.common.akka/web/JsonUtilsSpec.scala
+++ b/akka-app/test/ooyala.common.akka/web/JsonUtilsSpec.scala
@@ -28,6 +28,24 @@ class JsonUtilsSpec extends FunSpec with Matchers {
       JsonUtils.listFromJson(json) should equal (batch)
     }
 
+    it("should serialize first-level empty maps to JSON") {
+      val expected = """{"a":1,"b":{}}"""
+      import JsonUtils._
+      Map("a" -> 1, "b" -> Map.empty).toJson.compactPrint should equal (expected)
+    }
+
+    it("should serialize second-level empty maps to JSON") {
+      val expected = """{"a":1,"b":{"a1":1,"b1":{}}}"""
+      import JsonUtils._
+      Map("a" -> 1, "b" -> Map("a1" -> 1, "b1" -> Map.empty)).toJson.compactPrint should equal (expected)
+    }
+
+    it("should serialize third-level empty maps to JSON") {
+      val expected = """{"a":1,"b":{"a1":1,"b1":{"a2":1,"b2":{}}}}"""
+      import JsonUtils._
+      Map("a" -> 1, "b" -> Map("a1" -> 1, "b1" -> Map("a2" -> 1, "b2" -> Map.empty))).toJson.compactPrint should equal (expected)
+    }
+
     it("should serialize some other types") {
       val expected1 = """{"1":[1,2,3]}"""
       import JsonUtils._

--- a/akka-app/test/ooyala.common.akka/web/JsonUtilsSpec.scala
+++ b/akka-app/test/ooyala.common.akka/web/JsonUtilsSpec.scala
@@ -28,6 +28,12 @@ class JsonUtilsSpec extends FunSpec with Matchers {
       JsonUtils.listFromJson(json) should equal (batch)
     }
 
+    it("should serialize an empty map to JSON") {
+      val expected = """{}"""
+      import JsonUtils._
+      Map[String, Any]().toJson.compactPrint should equal (expected)
+    }
+
     it("should serialize first-level empty maps to JSON") {
       val expected = """{"a":1,"b":{}}"""
       import JsonUtils._


### PR DESCRIPTION
Use a pattern guard to filter cases where a map is empty. Empty maps
cause an exception without the guard in place.

This patch was inspired by 434337e in the ooyala master branch.