### PR TITLE
server_start.sh and server_stop.sh should running in any path

### DIFF
--- a/bin/server_start.sh
+++ b/bin/server_start.sh
@@ -49,7 +49,9 @@ fi
 # Pull in other env vars in spark config, such as MESOS_NATIVE_LIBRARY
 . $SPARK_CONF_DIR/spark-env.sh
 
-if [ -f "$PIDFILE" ] && kill -0 $(cat "$PIDFILE"); then
+pidFilePath=$appdir/$PIDFILE
+
+if [ -f "$pidFilePath" ] && kill -0 $(cat "$pidFilePath"); then
    echo 'Job server is already running'
    exit 1
 fi
@@ -78,4 +80,4 @@ export SPARK_HOME
 CLASSPATH="$appdir:$appdir/spark-job-server.jar:$($SPARK_HOME/bin/compute-classpath.sh)"
 
 exec java -cp $CLASSPATH $GC_OPTS $JAVA_OPTS $LOGGING_OPTS $CONFIG_OVERRIDES $MAIN $conffile 2>&1 &
-echo $! > $PIDFILE
+echo $! > $pidFilePath

--- a/bin/server_stop.sh
+++ b/bin/server_stop.sh
@@ -17,10 +17,12 @@ else
   exit 1
 fi
 
-if [ ! -f "$PIDFILE" ] || ! kill -0 $(cat "$PIDFILE"); then
+pidFilePath=$appdir/$PIDFILE
+
+if [ ! -f "$pidFilePath" ] || ! kill -0 $(cat "$pidFilePath"); then
    echo 'Job server not running'
 else
   echo 'Stopping job server...'
-  kill -15 $(cat "$PIDFILE") && rm -f "$PIDFILE"
+  kill -15 $(cat "$pidFilePath") && rm -f "$pidFilePath"
   echo '...job server stopped'
 fi


### PR DESCRIPTION
when running server_start.sh, the $PIDFILE should be created in the path of $appdir. For example, running $appdir/server_start.sh in the current directory (eg,  /home), the PIDFILE  should not created in the path of  /home/. Because there is a issue to find PIDFILE  when running  server_stop.sh. 