### PR TITLE
Removed confused assignment of execution context.

### DIFF
--- a/job-server/src/spark.jobserver/JobManagerActor.scala
+++ b/job-server/src/spark.jobserver/JobManagerActor.scala
@@ -179,8 +179,6 @@ class JobManagerActor(dao: JobDAO,
                            jobContext: ContextLike,
                            sparkEnv: SparkEnv,
                            rddManagerActor: ActorRef): Future[Any] = {
-    // Use the SparkContext's ActorSystem threadpool for the futures, so we don't corrupt our own
-    implicit val executionContext = sparkEnv.actorSystem
 
     val jobId = jobInfo.jobId
     val constructor = jobJarInfo.constructor


### PR DESCRIPTION
Previously it was intended to use "SparkContext's ActorSystem threadpool for the futures, so we don't corrupt our own"; however the assignment
  implicit val executionContext = sparkEnv.actorSystem
does not serve said purpose. It is removed.