### PR TITLE
Add jvmopts to increase default travis-ci memory and support hive contex...

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,6 @@
+-XX:MaxPermSize=512m
+-Xms1g
+-Xmx3g
+-Xss2m
+-XX:+CMSClassUnloadingEnabled
+-XX:+UseConcMarkSweepGC

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See [Troubleshooting Tips](doc/troubleshooting.md).
 ## Features
 
 - *"Spark as a Service"*: Simple REST interface for all aspects of job, context management
-- Support for Spark SQL Contexts/jobs and custom job contexts!  See [Contexts](doc/contexts.md).
+- Support for Spark SQL and Hive Contexts/jobs and custom job contexts!  See [Contexts](doc/contexts.md).
 - Supports sub-second low-latency jobs via long-running job contexts
 - Start and stop job contexts for RDD sharing and low-latency jobs; change resources on restart
 - Kill running jobs via stop context

--- a/job-server-api/src/spark.jobserver/SparkJob.scala
+++ b/job-server-api/src/spark.jobserver/SparkJob.scala
@@ -3,6 +3,7 @@ package spark.jobserver
 import com.typesafe.config.Config
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.hive.HiveContext
 
 sealed trait SparkJobValidation {
   // NOTE(harish): We tried using lazy eval here by passing in a function
@@ -50,4 +51,8 @@ trait SparkJob extends SparkJobBase {
 
 trait SparkSqlJob extends SparkJobBase {
   type C = SQLContext
+}
+
+trait SparkHiveJob extends SparkJobBase {
+  type C = HiveContext
 }

--- a/job-server-tests/src/spark.jobserver/HiveTestJob.scala
+++ b/job-server-tests/src/spark.jobserver/HiveTestJob.scala
@@ -1,0 +1,51 @@
+package spark.jobserver
+
+import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.spark._
+import org.apache.spark.sql.hive.HiveContext
+
+/**
+ * A test job that accepts a HiveContext, as opposed to the regular SparkContext.
+ * Initializes some dummy data into a table, reads it back out, and returns a count
+ * (Will create Hive metastore at job-server/metastore_db if Hive isn't configured)
+ */
+object HiveLoaderJob extends SparkHiveJob {
+  // The following data is stored at ./test_addresses.txt
+  // val addresses = Seq(
+  //   Address("Bob", "Charles", "101 A St.", "San Jose"),
+  //   Address("Sandy", "Charles", "10200 Ranch Rd.", "Purple City"),
+  //   Address("Randy", "Charles", "101 A St.", "San Jose")
+  // )
+
+  val tableCreate = "CREATE TABLE `default.test_addresses`"
+  val tableArgs = "(`firstName` String,`lastName` String, `address` String, `city` String)"
+  val tableRowFormat = "ROW FORMAT DELIMITED FIELDS TERMINATED BY '\001'"
+  val tableColFormat = "COLLECTION ITEMS TERMINATED BY '\002'"
+  val tableMapFormat = "MAP KEYS TERMINATED BY '\003' STORED"
+  val tableAs = "AS TextFile"
+
+  //Will fail with a 'SemanticException : Invalid path' if this file is not there
+  val loadPath:String = "'test/spark.jobserver/hive_test_job_addresses.txt'"
+
+  def validate(hive: HiveContext, config: Config): SparkJobValidation = SparkJobValid
+
+  def runJob(hive: HiveContext, config: Config): Any = {
+    hive.sql("DROP TABLE if exists `default.test_addresses`")
+    hive.sql(s"$tableCreate $tableArgs $tableRowFormat $tableColFormat $tableMapFormat $tableAs")
+    hive.sql(s"LOAD DATA LOCAL INPATH $loadPath OVERWRITE INTO TABLE `default.test_addresses`")
+
+    val addrRdd = hive.sql("SELECT * FROM `default.test_addresses`")
+    addrRdd.count()
+  }
+}
+
+/**
+ * This job simply runs the Hive SQL in the config.
+ */
+object HiveTestJob extends SparkHiveJob {
+  def validate(hive: HiveContext, config: Config): SparkJobValidation = SparkJobValid
+
+  def runJob(hive: HiveContext, config: Config): Any = {
+    hive.sql(config.getString("sql")).collect()
+  }
+}

--- a/job-server/src/spark.jobserver/context/HiveContextFactory.scala
+++ b/job-server/src/spark.jobserver/context/HiveContextFactory.scala
@@ -1,0 +1,21 @@
+package spark.jobserver.context
+
+import com.typesafe.config.Config
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.hive.HiveContext
+import spark.jobserver.{ContextLike, SparkHiveJob, SparkJobBase}
+import spark.jobserver.util.SparkJobUtils
+
+class HiveContextFactory extends SparkContextFactory {
+  import SparkJobUtils._
+
+  type C = HiveContext with ContextLike
+
+  def makeContext(config: Config, contextConfig: Config, contextName: String): C = {
+    val conf = configToSparkConf(config, contextConfig, contextName)
+    new HiveContext(new SparkContext(conf)) with ContextLike {
+      def isValidJob(job: SparkJobBase): Boolean = job.isInstanceOf[SparkHiveJob]
+      def stop() { this.sparkContext.stop() }
+    }
+  }
+}

--- a/job-server/test/spark.jobserver/HiveJobSpec.scala
+++ b/job-server/test/spark.jobserver/HiveJobSpec.scala
@@ -1,0 +1,53 @@
+package spark.jobserver
+
+import com.typesafe.config.ConfigFactory
+import org.apache.spark.sql.catalyst.expressions.Row
+import scala.collection.mutable
+import spark.jobserver.io.JobDAO
+import spark.jobserver.context.HiveContextFactory
+
+object HiveJobSpec extends JobSpecConfig {
+  override val contextFactory = classOf[HiveContextFactory].getName
+}
+
+class HiveJobSpec extends JobSpecBase(HiveJobSpec.getNewSystem) {
+  import scala.concurrent.duration._
+  import CommonMessages._
+  import JobManagerSpec.MaxJobsPerContext
+
+  val classPrefix = "spark.jobserver."
+  private val hiveLoaderClass = classPrefix + "HiveLoaderJob"
+  private val hiveQueryClass = classPrefix + "HiveTestJob"
+
+  val emptyConfig = ConfigFactory.parseString("spark.master = bar")
+  val queryConfig = ConfigFactory.parseString(
+                      """sql = "SELECT firstName, lastName FROM `default.test_addresses` WHERE city = 'San Jose'" """)
+
+  before {
+    dao = new InMemoryDAO
+    manager =
+      system.actorOf(JobManagerActor.props(dao, "test", HiveJobSpec.config, false))
+  }
+
+  describe("Spark Hive Jobs") {
+    it("should be able to create a Hive table, then query it using separate Hive-SQL jobs") {
+      manager ! JobManagerActor.Initialize
+      expectMsgClass(classOf[JobManagerActor.Initialized])
+
+      uploadTestJar()
+      manager ! JobManagerActor.StartJob("demo", hiveLoaderClass, emptyConfig, syncEvents ++ errorEvents)
+      expectMsgPF(120 seconds, "Did not get JobResult") {
+        case JobResult(_, result: Long) => result should equal (3L)
+      }
+      expectNoMsg()
+
+      manager ! JobManagerActor.StartJob("demo", hiveQueryClass, queryConfig, syncEvents ++ errorEvents)
+      expectMsgPF(6 seconds, "Did not get JobResult") {
+        case JobResult(_, result: Array[Row]) =>
+          result should have length (2)
+          result(0)(0) should equal ("Bob")
+      }
+      expectNoMsg()
+    }
+  }
+}

--- a/job-server/test/spark.jobserver/hive_test_job_addresses.txt
+++ b/job-server/test/spark.jobserver/hive_test_job_addresses.txt
@@ -1,0 +1,3 @@
+BobCharles101 A St.San Jose
+SandyCharles10200 Ranch Rd.Purple City
+RandyCharles101 A St.San Jose

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,6 +33,8 @@ object Dependencies {
                                             "io.netty", "netty-all") excludeAll(excludeQQ),
     "org.apache.spark" %% "spark-sql" % sparkVersion % "provided" exclude(
                                             "io.netty", "netty-all") excludeAll(excludeQQ),
+    "org.apache.spark" %% "spark-hive" % sparkVersion % "provided" exclude(
+                                            "io.netty", "netty-all") excludeAll(excludeQQ),
     // Force netty version.  This avoids some Spark netty dependency problem.
     "io.netty" % "netty-all" % "4.0.23.Final"
   )


### PR DESCRIPTION
This is from PR #90 from @ajmerlob 

This seems to fix the issue of builds failing in Travis CI by adding extra memory via a `.jvmopts` file in the project's root. 

(+3 squashed commits)
Squashed commits:
[fdad632] added Hive test and dummy data flatfile
[a735656] added HiveContextFactory, Hive dependencies and SparkHiveJob trait
[13e0134] added Hive support to README