### PR TITLE
Update libraryDependencies instructions to use %%

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ In your `build.sbt`, add this to use the job server jar:
 
 	resolvers += "Job Server Bintray" at "https://dl.bintray.com/spark-jobserver/maven"
 
-	libraryDependencies += "spark.jobserver" % "job-server-api" % "0.5.1" % "provided"
+	libraryDependencies += "spark.jobserver" %% "job-server-api" % "0.5.1" % "provided"
 
 If a SQL or Hive job/context is desired, you also want to pull in `job-server-extras`:
 
-    libraryDependencies += "spark.jobserver" % "job-server-extras" % "0.5.1" % "provided"
+    libraryDependencies += "spark.jobserver" %% "job-server-extras" % "0.5.1" % "provided"
 
 For most use cases it's better to have the dependencies be "provided" because you don't want SBT assembly to include the whole job server jar.
 


### PR DESCRIPTION
The current distribution at Bintray (https://dl.bintray.com/spark-jobserver/maven/spark/jobserver/) is partitioned by Scala version, which requires %% instead of % when specifying the library dependency in sbt. Using % causes resolution errors.