### PR TITLE
Add web service config

### DIFF
--- a/akka-app/src/ooyala.common.akka/web/WebService.scala
+++ b/akka-app/src/ooyala.common.akka/web/WebService.scala
@@ -1,6 +1,8 @@
 package ooyala.common.akka.web
 
 import akka.actor.ActorSystem
+import com.typesafe.config.Config
+import spray.can.server.ServerSettings
 import spray.routing.{Route, SimpleRoutingApp}
 
 /**
@@ -16,9 +18,9 @@ object WebService extends SimpleRoutingApp {
    * @param host The host string to bind to, defaults to "0.0.0.0"
    * @param port The port number to bind to
    */
-  def start(route: Route, system: ActorSystem,
+  def start(route: Route, system: ActorSystem, config: Config,
             host: String = "0.0.0.0", port: Int = 8080) {
     implicit val actorSystem = system
-    startServer(host, port)(route)
+    startServer(host, port, settings = Some(ServerSettings.fromSubConfig(config)))(route)
   }
 }

--- a/job-server/src/spark.jobserver/WebApi.scala
+++ b/job-server/src/spark.jobserver/WebApi.scala
@@ -51,7 +51,7 @@ class WebApi(system: ActorSystem,
 
   def start() {
     logger.info("Starting browser web service...")
-    WebService.start(myRoutes ~ commonRoutes, system, bindAddress, port)
+    WebService.start(myRoutes ~ commonRoutes, system, config, bindAddress, port)
   }
 
   /**


### PR DESCRIPTION
- passes through application config to the spray web service
- allows job server configuration to be used by spray

This allows the spray instance for the API to be configured using the job server configuration. This will be useful for modifying parsing configuration for tweaking chunk size and max request size. Full docs on spray config can be found here: http://spray.io/documentation/1.2.2/spray-can/configuration/.