### PR TITLE
Make Streaming Context more configurable & Fix Tests

### DIFF
--- a/doc/contexts.md
+++ b/doc/contexts.md
@@ -39,3 +39,10 @@ This can be done easily by extending the `SparkContextFactory` trait, like `SQLC
 ## Jars
 
 If you wish to use the `SQLContext` or `HiveContext`, be sure to pull down the job-server-extras package.
+
+# StreamingContext
+job-server-extras provides a context to run Spark Streaming jobs, there are a couple of configurations you can change in job-server's .conf file
+streaming.batch_interval: the streaming batch in millis
+streaming.stopGracefully: if true, stops gracefully by waiting for the processing of all received data to be completed 
+streaming.stopSparkContext: if true, stops the SparkContext with the StreamingContext. The underlying SparkContext will be stopped regardless of whether the StreamingContext has been started.
+

--- a/job-server-extras/src/spark.jobserver/context/StreamingContextFactory.scala
+++ b/job-server-extras/src/spark.jobserver/context/StreamingContextFactory.scala
@@ -15,7 +15,7 @@ class StreamingContextFactory extends SparkContextFactory {
       def isValidJob(job: SparkJobBase): Boolean = job.isInstanceOf[SparkStramingJob]
       def stop() {
         //Gracefully stops the spark context
-        stop(stopSparkContext = false, stopGracefully = true)
+        stop(stopSparkContext = true, stopGracefully = false)
       }
     }
   }

--- a/job-server-extras/src/spark.jobserver/context/StreamingContextFactory.scala
+++ b/job-server-extras/src/spark.jobserver/context/StreamingContextFactory.scala
@@ -15,7 +15,7 @@ class StreamingContextFactory extends SparkContextFactory {
       def isValidJob(job: SparkJobBase): Boolean = job.isInstanceOf[SparkStramingJob]
       def stop() {
         //Gracefully stops the spark context
-        stop(stopSparkContext = true, stopGracefully = true)
+        stop(stopSparkContext = false, stopGracefully = true)
       }
     }
   }

--- a/job-server-extras/src/spark.jobserver/context/StreamingContextFactory.scala
+++ b/job-server-extras/src/spark.jobserver/context/StreamingContextFactory.scala
@@ -2,8 +2,8 @@ package spark.jobserver.context
 
 import com.typesafe.config.Config
 import org.apache.spark.SparkConf
-import org.apache.spark.streaming.{Seconds, StreamingContext}
-import spark.jobserver.{SparkStramingJob, ContextLike, SparkJobBase}
+import org.apache.spark.streaming.{Milliseconds, StreamingContext}
+import spark.jobserver.{ContextLike, SparkJobBase, SparkStramingJob}
 
 class StreamingContextFactory extends SparkContextFactory {
 
@@ -11,11 +11,13 @@ class StreamingContextFactory extends SparkContextFactory {
 
   def makeContext(sparkConf: SparkConf, config: Config,  contextName: String): C = {
     val interval = config.getInt("streaming.batch_interval")
-    new StreamingContext(sparkConf, Seconds(interval)) with ContextLike {
+    val stopGracefully = config.getBoolean("streaming.stopGracefully")
+    val stopSparkContext = config.getBoolean("streaming.stopSparkContext")
+    new StreamingContext(sparkConf, Milliseconds(interval)) with ContextLike {
       def isValidJob(job: SparkJobBase): Boolean = job.isInstanceOf[SparkStramingJob]
       def stop() {
         //Gracefully stops the spark context
-        stop(stopSparkContext = true, stopGracefully = false)
+        stop(stopSparkContext, stopGracefully)
       }
     }
   }

--- a/job-server-extras/test/spark.jobserver/StreamingJobSpec.scala
+++ b/job-server-extras/test/spark.jobserver/StreamingJobSpec.scala
@@ -24,6 +24,7 @@ class StreamingJobSpec extends JobSpecBase(StreamingJobSpec.getNewSystem) {
   val configMap = Map("streaming.batch_interval" -> Integer.valueOf(3))
 
   val emptyConfig = ConfigFactory.parseMap(configMap.asJava)
+  var jobId = ""
 
   before {
     dao = new InMemoryDAO
@@ -38,18 +39,17 @@ class StreamingJobSpec extends JobSpecBase(StreamingJobSpec.getNewSystem) {
       uploadTestJar()
       manager ! JobManagerActor.StartJob("demo", streamingJob, emptyConfig, asyncEvents ++ errorEvents)
 
-      val jobId = expectMsgPF(6 seconds, "Did not start JobResult") {
+      jobId = expectMsgPF(6 seconds, "Did not start StreamingTestJob, expecting JobStarted") {
         case JobStarted(jobid, _, _) => {
           jobid should not be null
           jobid
         }
       }
-      Thread sleep 6000
+      Thread sleep 3000
       dao.getJobInfos.get(jobId).get match  {
         case JobInfo(_, _, _, _, _, None, _) => {  }
         case e => fail("Unexpected JobInfo" + e)
       }
-
     }
   }
 }

--- a/job-server-extras/test/spark.jobserver/StreamingJobSpec.scala
+++ b/job-server-extras/test/spark.jobserver/StreamingJobSpec.scala
@@ -45,7 +45,7 @@ class StreamingJobSpec extends JobSpecBase(StreamingJobSpec.getNewSystem) {
           jobid
         }
       }
-      Thread sleep 3000
+      Thread sleep 1000
       dao.getJobInfos.get(jobId).get match  {
         case JobInfo(_, _, _, _, _, None, _) => {  }
         case e => fail("Unexpected JobInfo" + e)

--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -54,8 +54,13 @@ spark {
     # Determines the type of jobs that can run in a SparkContext
     context-factory = spark.jobserver.context.DefaultSparkContextFactory
 
-    # Default batch interval for Spark Streaming contexts
-    streaming.batch_interval = 10
+    # Default batch interval for Spark Streaming contexts in milliseconds
+    streaming.batch_interval = 1000
+    # if true, stops gracefully by waiting for the processing of all received data to be completed
+    streaming.stopGracefully = true
+    # if true, stops the SparkContext with the StreamingContext. The underlying SparkContext will be
+    # stopped regardless of whether the StreamingContext has been started.
+    streaming.stopSparkContext = true
 
     # uris of jars to be loaded into the classpath for this context. Uris is a string list, or a string separated by commas ','
     # dependent-jar-uris = ["file:///some/path/present/in/each/mesos/slave/somepackage.jar"]

--- a/job-server/test/spark.jobserver/JobSpecBase.scala
+++ b/job-server/test/spark.jobserver/JobSpecBase.scala
@@ -38,7 +38,9 @@ trait JobSpecConfig {
   lazy val contextConfig = {
     val ConfigMap = Map(
       "context-factory" -> contextFactory,
-      "streaming.batch_interval" -> new Integer(10)
+      "streaming.batch_interval" -> new Integer(40),
+      "streaming.stopGracefully" -> false,
+      "streaming.stopSparkContext" -> true
     )
     ConfigFactory.parseMap(ConfigMap.asJava).withFallback(ConfigFactory.defaultOverrides())
   }


### PR DESCRIPTION
This Thread.sleep should be replaced with some proper status message whenever we have that feature.
Something that would indicate that a streaming batch has been processed