### PR TITLE
When submit a job, if sparkcontext not alive, send ContextStopped message to LocalContextSupervisorActor to do the sc clean up job.

### DIFF
--- a/job-server/src/spark.jobserver/LocalContextSupervisorActor.scala
+++ b/job-server/src/spark.jobserver/LocalContextSupervisorActor.scala
@@ -130,13 +130,11 @@ class LocalContextSupervisorActor(dao: JobDAO) extends InstrumentedActor {
       if (contexts contains name) {
         val future = (contexts(name) ? SparkContextStatus) (contextTimeout.seconds)
         Await.result(future, contextTimeout.seconds) match {
-          case SparkContextAlive => {
-            sender ! (contexts(name), resultActors(name))
-          }
-          case SparkContextDead => {
+          case SparkContextAlive => sender ! (contexts(name), resultActors(name))
+          case SparkContextDead =>
+            logger.info("SparkContext {} is dead", name)
             self ! StopContext(name)
             sender ! NoSuchContext
-          }
         }
       } else {
         sender ! NoSuchContext


### PR DESCRIPTION
When submit a job, if sparkcontext not alive (e.g. yarn application -kill $appId), the context meta is still exist in jobserver. So when I want to recreate a context, the jobserver tell me the context is existed.

So I make this PR, When submit a job, if sparkcontext not alive, send ContextStopped message to LocalContextSupervisorActor to do the sc clean up job.