### PR TITLE
Adds Hook For Custom SparkMasterProvider

### DIFF
--- a/job-server/src/spark.jobserver/util/SparkJobUtils.scala
+++ b/job-server/src/spark.jobserver/util/SparkJobUtils.scala
@@ -25,9 +25,13 @@ object SparkJobUtils {
    */
   def configToSparkConf(config: Config, contextConfig: Config,
                         contextName: String): SparkConf = {
+
+    val sparkMaster = SparkMasterProvider.fromConfig(config).getSparkMaster(config)
+
     val conf = new SparkConf()
-    conf.setMaster(config.getString("spark.master"))
-        .setAppName(contextName)
+    conf
+      .setMaster(sparkMaster)
+      .setAppName(contextName)
 
     for (cores <- Try(contextConfig.getInt("num-cpu-cores"))) {
       conf.set("spark.cores.max", cores.toString)
@@ -43,7 +47,7 @@ object SparkJobUtils {
     conf.set("spark.ui.port", "0")
 
     // Set spark broadcast factory in yarn-client mode
-    if (config.getString("spark.master") == "yarn-client") {
+    if (sparkMaster == "yarn-client") {
       conf.set("spark.broadcast.factory", config.getString("spark.jobserver.yarn-broadcast-factory"))
     }
 

--- a/job-server/src/spark.jobserver/util/SparkMasterProvider.scala
+++ b/job-server/src/spark.jobserver/util/SparkMasterProvider.scala
@@ -30,7 +30,6 @@ object SparkMasterProvider {
 
     try {
       val sparkMasterObjectName = config.getString(SparkMasterProperty)
-      println(s"Using $sparkMasterObjectName to determine Spark Master")
       logger.info(s"Using $sparkMasterObjectName to determine Spark Master")
       val m = ru.runtimeMirror(getClass.getClassLoader)
       val module = m.staticModule(sparkMasterObjectName)

--- a/job-server/src/spark.jobserver/util/SparkMasterProvider.scala
+++ b/job-server/src/spark.jobserver/util/SparkMasterProvider.scala
@@ -1,0 +1,54 @@
+package spark.jobserver.util
+
+import scala.reflect.runtime.{universe => ru}
+import com.typesafe.config.{ConfigException, Config}
+import org.slf4j.LoggerFactory
+
+
+trait SparkMasterProvider {
+
+  /**
+   * Implementing classes will determine what the appropriate SparkMaster is and
+   * return it
+   * @return A Spark Master Address
+   */
+  def getSparkMaster(config: Config): String
+
+}
+
+object SparkMasterProvider {
+  val logger = LoggerFactory.getLogger(getClass)
+  val SparkMasterProperty = "spark.master.provider"
+
+  /**
+   * Will look for an Object with the name provided in the Config file and return it
+   * or the DefaultSparkMasterProvider if no spark.master.provider was specified
+   * @param config SparkJobserver Config
+   * @return A SparkMasterProvider
+   */
+  def fromConfig(config: Config): SparkMasterProvider = {
+
+    try {
+      val sparkMasterObjectName = config.getString(SparkMasterProperty)
+      println(s"Using $sparkMasterObjectName to determine Spark Master")
+      logger.info(s"Using $sparkMasterObjectName to determine Spark Master")
+      val m = ru.runtimeMirror(getClass.getClassLoader)
+      val module = m.staticModule(sparkMasterObjectName)
+      val sparkMasterProviderObject = m.reflectModule(module).instance
+        .asInstanceOf[SparkMasterProvider]
+      sparkMasterProviderObject
+    } catch {
+      case me: ConfigException => DefaultSparkMasterProvider
+      case e: Exception => throw e
+    }
+  }
+}
+
+/**
+ * Default Spark Master Provider always returns "spark.master" from the passed in config
+ */
+object DefaultSparkMasterProvider extends SparkMasterProvider {
+
+  def getSparkMaster(config: Config): String = config.getString("spark.master")
+
+}

--- a/job-server/test/spark.jobserver/util/SparkMasterProviderSpec.scala
+++ b/job-server/test/spark.jobserver/util/SparkMasterProviderSpec.scala
@@ -1,0 +1,57 @@
+package spark.jobserver.util
+
+import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.spark.SparkConf
+import org.scalatest.{Matchers, FunSpec}
+
+class SparkMasterProviderSpec extends FunSpec with Matchers {
+
+  import collection.JavaConverters._
+
+
+  val contextName = "demo"
+
+  def getSparkConf(baseConfig: Config): SparkConf =
+    SparkJobUtils.configToSparkConf(baseConfig, ConfigFactory.empty(), contextName)
+
+  describe("SparkMasterProvider.fromConfig") {
+    it("should be able to dynamically use a class to find the spark.master") {
+
+      val config = ConfigFactory.parseMap(Map(
+        "spark.home" -> "/etc/spark",
+        SparkMasterProvider.SparkMasterProperty -> "spark.jobserver.util.TestProvider"
+      ).asJava)
+
+      val sparkConf = getSparkConf(config)
+      sparkConf.get("spark.master") should equal("TestMaster")
+    }
+
+    it("should be able to use a DefaultSparkMaster Provider if no spark.maser.provider is found") {
+
+      val config = ConfigFactory.parseMap(Map(
+        "spark.home" -> "/etc/spark",
+        "spark.master" -> "NotTestMaster"
+      ).asJava)
+
+      val sparkConf = getSparkConf(config)
+      sparkConf.get("spark.master") should equal("NotTestMaster")
+    }
+
+    it(s"should throw an exception if an invalid class is set as ${SparkMasterProvider.SparkMasterProperty}") {
+      intercept[scala.reflect.internal.MissingRequirementError] {
+        val config = ConfigFactory.parseMap(Map(
+          "spark.home" -> "/etc/spark",
+          "spark.master.provider" -> "not.exists.provider"
+        ).asJava)
+        val sparkConf = getSparkConf(config)
+      }
+    }
+  }
+}
+
+object TestProvider extends SparkMasterProvider {
+  /**
+   * This test class always returns "TestMaster" as the master address
+   */
+  override def getSparkMaster(config: Config): String = "TestMaster"
+}

--- a/job-server/test/spark.jobserver/util/SparkMasterProviderSpec.scala
+++ b/job-server/test/spark.jobserver/util/SparkMasterProviderSpec.scala
@@ -38,7 +38,7 @@ class SparkMasterProviderSpec extends FunSpec with Matchers {
     }
 
     it(s"should throw an exception if an invalid class is set as ${SparkMasterProvider.SparkMasterProperty}") {
-      intercept[scala.reflect.internal.MissingRequirementError] {
+      intercept[Exception] {
         val config = ConfigFactory.parseMap(Map(
           "spark.home" -> "/etc/spark",
           "spark.master.provider" -> "not.exists.provider"


### PR DESCRIPTION
Currently the spark.master address passed into the JobServer is used for
all Contexts launched in the future. If the Spark master changes due to
HA Systems the JobServer can no longer make new Contexts. This patch
adds a hook to a new class via spark.master.provider. With this a user
can implement a custom SparkMasterProvider object which will be invoked
on the creation of new SparkConfs. This allows for a dynamic adjustment
of the spark.master property for newley created contexts.