### PR TITLE
fix server_stop for spark-submit start-start

### DIFF
--- a/bin/kill-process-tree.sh
+++ b/bin/kill-process-tree.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+if [ "$(which pgrep)" == "" ]; then
+    echo "pgrep is not available" >&2
+    exit 1
+fi
+
+if [ "$#" != "2" ]; then
+    echo "Syntax error, the expected usage is: kill-process-tree <signal> <process_id>" >&2
+    exit 1
+fi
+
+# This simple script allows to kill the whole process tree. The first argument is a signal and the second
+# is the root process
+parent=$2
+signal=$1
+
+# A string which will be populated with descendant processes ids
+pids="$parent"
+
+# Kills the given process if it is running. It also checks whether the given parameter contains process ID
+function kill_if_running() {
+    if [[ "$1" =~ [0-9]+ ]]; then
+        ps -e -o pid= | grep $1 > /dev/null
+        if [ $? -eq 0 ]; then
+            kill "-$signal" "$1"
+            return 0
+        else
+            return 1
+        fi
+    fi
+}
+
+# Populates pids with descendant processes ids
+function get_descendants_pids() {
+    for cpid in $(pgrep -P $1);
+    do
+        pids="$cpid $pids"
+        get_descendants_pids $cpid
+    done
+}
+
+get_descendants_pids $parent
+
+for pid in $pids
+do
+    if [ "$signal" == "" ]; then
+        echo "$pid"
+    else
+        kill_if_running $pid
+        if [ $? -eq 0 ]; then
+            # If the process has been really killed, then wait for 3 seconds before going to the next
+            # process. In most cases, where there is a scripts execution hierarchy with Java process
+            # at the bottom, it is sufficient to kill that Java process and the scripts will just exit
+            # in a natural way
+            echo "Sent $signal to $pid, sleeping for 3 seconds"
+            sleep 3s
+        fi
+    fi
+done

--- a/bin/server_package.sh
+++ b/bin/server_package.sh
@@ -44,6 +44,7 @@ fi
 FILES="job-server-extras/target/scala-$majorVersion/spark-job-server.jar
        bin/server_start.sh
        bin/server_stop.sh
+       bin/kill-process-tree.sh
        $CONFIG_DIR/$ENV.conf
        config/log4j-server.properties"
 

--- a/bin/server_stop.sh
+++ b/bin/server_stop.sh
@@ -3,7 +3,7 @@
 
 get_abs_script_path() {
   pushd . >/dev/null
-  cd $(dirname $0)
+  cd "$(dirname "$0")"
   appdir=$(pwd)
   popd  >/dev/null
 }
@@ -11,7 +11,7 @@ get_abs_script_path() {
 get_abs_script_path
 
 if [ -f "$appdir/settings.sh" ]; then
-  . $appdir/settings.sh
+  . "$appdir/settings.sh"
 else
   echo "Missing $appdir/settings.sh, exiting"
   exit 1
@@ -19,10 +19,14 @@ fi
 
 pidFilePath=$appdir/$PIDFILE
 
-if [ ! -f "$pidFilePath" ] || ! kill -0 $(cat "$pidFilePath"); then
+if [ ! -f "$pidFilePath" ] || ! kill -0 "$(cat "$pidFilePath")"; then
    echo 'Job server not running'
 else
   echo 'Stopping job server...'
-  kill -15 $(cat "$pidFilePath") && rm -f "$pidFilePath"
+  PID="$(cat "$pidFilePath")"
+  "$(dirname "$0")"/kill-process-tree.sh 15 $PID && rm "$pidFilePath"
   echo '...job server stopped'
 fi
+
+
+


### PR DESCRIPTION
This is shamelessly copied from https://github.com/riptano/spark-jobserver and all credit goes to @RussellSpitzer 

It fixes `server_stop.sh` to properly kill `spark-submit` jobs

