### PR TITLE
Add kill-process-tree.sh to server_deploy.sh

### DIFF
--- a/bin/server_deploy.sh
+++ b/bin/server_deploy.sh
@@ -41,6 +41,7 @@ fi
 FILES="job-server-extras/target/scala-$majorVersion/spark-job-server.jar
        bin/server_start.sh
        bin/server_stop.sh
+       bin/kill-process-tree.sh
        $CONFIG_DIR/$ENV.conf
        config/log4j-server.properties"
 


### PR DESCRIPTION
The server_deploy.sh script didn't copy up the kill-process-tree.sh script so server_stop.sh failed.