### PR TITLE
Update to the latest Joda Time

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
 
   lazy val yodaDeps = Seq(
     "org.joda" % "joda-convert" % "1.2",
-    "joda-time" % "joda-time" % "2.1"
+    "joda-time" % "joda-time" % "2.8.1"
   )
 
   lazy val akkaDeps = Seq(


### PR DESCRIPTION
Attempting to run a job that uses the AWS client raised this exception

```
java.lang.IllegalStateException: Joda-time 2.2 or later version is required, but found version: null
    at com.amazonaws.util.DateUtils.handleException(DateUtils.java:147)
    at com.amazonaws.util.DateUtils.parseRFC822Date(DateUtils.java:195)
    at com.amazonaws.services.s3.internal.ServiceUtils.parseRfc822Date(ServiceUtils.java:78)
    ...
```

Updating the dependency to the latest version of Joda Time avoids the exception and does not break any unit tests.

Some questions related to this change:

1. Is there a better way of handling this conflict? Is there a method by which I can have a job jar with a transitive dependency on a newer version of one of the jars that SJS depends on?

2. Upgrading from 2.1 to 2.8.1 moves through several version. The compatibility section of all the incremental release notes says "Yes" in all cases, but there are some "Yes, except" sections that explain changes in behavior. If the only way to handle the version conflict is to upgrade, is it preferable to only jump from 2.1 to 2.2 rather than the latest stable version?

http://www.joda.org/joda-time/upgradeto220.html
http://www.joda.org/joda-time/upgradeto230.html
http://www.joda.org/joda-time/upgradeto240.html
http://www.joda.org/joda-time/upgradeto250.html
http://www.joda.org/joda-time/upgradeto260.html
http://www.joda.org/joda-time/upgradeto270.html
http://www.joda.org/joda-time/upgradeto280.html
http://www.joda.org/joda-time/upgradeto281.html