### PR TITLE
Remove wrong DatePattern Parameter

### DIFF
--- a/job-server/config/log4j-server.properties
+++ b/job-server/config/log4j-server.properties
@@ -5,7 +5,6 @@ log4j.rootLogger=INFO,LOGFILE
 
 log4j.appender.LOGFILE=org.apache.log4j.RollingFileAppender
 log4j.appender.LOGFILE.File=${LOG_DIR}/spark-job-server.log
-log4j.appender.LOGFILE.DatePattern='.'yyyy-MM-dd
 log4j.appender.LOGFILE.layout=org.apache.log4j.PatternLayout
 # log4j.appender.LOGFILE.layout.ConversionPattern=%d %-5p %c - %m%n
 log4j.appender.LOGFILE.layout.ConversionPattern=[%d] %-5p %.26c [%X{testName}] [%X{akkaSource}] - %m%n


### PR DESCRIPTION
DatePattern is no parameter of the RollingFileAppender and creates a warning when starting the Job-Server

    log4j:WARN No such property [datePattern] in org.apache.log4j.RollingFileAppender.

http://www.tutorialspoint.com/log4j/log4j_logging_files.htm