### PR TITLE
Store initial job jars on startup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ See [Troubleshooting Tips](doc/troubleshooting.md) as well as [Yarn tips](doc/ya
 - Frontline Solvers
 - Aruba Networks
 - [Zed Worldwide](http://www.zed.com)
+- [Azavea](http://azavea.com)
 
 ## Features
 
@@ -85,7 +86,7 @@ Then go ahead and start the job server using the instructions above.
 
 Let's upload the jar:
 
-    curl --data-binary @job-server-tests/target/job-server-tests-$VER.jar localhost:8090/jars/test
+    curl --data-binary @job-server-tests/target/scala-2.10/job-server-tests-$VER.jar localhost:8090/jars/test
     OK⏎
 
 #### Ad-hoc Mode - Single, Unrelated Jobs (Transient Context)

--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -19,7 +19,7 @@ spark {
 
     # To load up job jars on startup, place them here,
     # with the app name as the key and the path to the jar as the value
-    # job-jar-uris {
+    # job-jar-paths {
     #   test = ../job-server-tests/target/scala-2.10/job-server-tests_2.10-0.5.3-SNAPSHOT.jar
     # }
 

--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -17,6 +17,12 @@ spark {
       rootdir = /tmp/spark-jobserver/filedao/data
     }
 
+    # To load up job jars on startup, place them here,
+    # with the app name as the key and the path to the jar as the value
+    # job-jar-uris {
+    #   test = ../job-server-tests/target/scala-2.10/job-server-tests_2.10-0.5.3-SNAPSHOT.jar
+    # }
+
     sqldao {
       # Slick database driver, full classpath
       slick-driver = scala.slick.driver.H2Driver

--- a/job-server/src/spark.jobserver/JarManager.scala
+++ b/job-server/src/spark.jobserver/JarManager.scala
@@ -5,9 +5,12 @@ import spark.jobserver.io.JobDAO
 import spark.jobserver.util.JarUtils
 import org.joda.time.DateTime
 
+import java.nio.file.{Files, Paths}
+
 // Messages to JarManager actor
 case class StoreJar(appName: String, jarBytes: Array[Byte])
 case object ListJars
+case class StoreInitialJars(initialJars: Map[String, String])
 
 // Responses
 case object InvalidJar
@@ -18,16 +21,42 @@ case object JarStored
  * load a class from a jar as a new one is replacing it, so using an actor to serialize requests is perfect.
  */
 class JarManager(jobDao: JobDAO) extends InstrumentedActor {
+  private def saveJar(appName: String, jarBytes: Array[Byte]): Unit = {
+    val uploadTime = DateTime.now()
+    jobDao.saveJar(appName, uploadTime, jarBytes)
+  }
+
   override def wrappedReceive: Receive = {
     case ListJars => sender ! createJarsList()
+
+    case StoreInitialJars(initialJars) =>
+      val success =
+        initialJars.foldLeft(true) { (success, pair) =>
+          success && {
+            val (appName, jarPath) = pair
+            try {
+              val jarBytes = Files.readAllBytes(Paths.get(jarPath))
+              logger.info("Storing jar for app {}, {} bytes", appName, jarBytes.size)
+              JarUtils.validateJarBytes(jarBytes) && {
+                saveJar(appName, jarBytes)
+                true
+              }
+            } catch {
+              case e: Exception =>
+                  logger.error(e.getMessage)
+                  false
+            }
+          }
+        }
+
+      sender ! (if(success) { JarStored } else { InvalidJar })
 
     case StoreJar(appName, jarBytes) =>
       logger.info("Storing jar for app {}, {} bytes", appName, jarBytes.size)
       if (!JarUtils.validateJarBytes(jarBytes)) {
         sender ! InvalidJar
       } else {
-        val uploadTime = DateTime.now()
-        jobDao.saveJar(appName, uploadTime, jarBytes)
+        saveJar(appName, jarBytes)
         sender ! JarStored
       }
   }

--- a/job-server/src/spark.jobserver/JobServer.scala
+++ b/job-server/src/spark.jobserver/JobServer.scala
@@ -76,8 +76,9 @@ object JobServer {
   }
 
   private def storeInitialJars(config: Config, jarManager: ActorRef): Unit = {
-    if(config.hasPath("spark.jobserver.job-jar-uris")) {
-      val initialJarsConfig = config.getConfig("spark.jobserver.job-jar-uris").root
+    val initialJarPathsKey = "spark.jobserver.job-jar-paths"
+    if(config.hasPath(initialJarPathsKey)) {
+      val initialJarsConfig = config.getConfig(initialJarPathsKey).root
 
       logger.info("Adding initial job jars: {}", initialJarsConfig.render())
 

--- a/job-server/src/spark.jobserver/JobServer.scala
+++ b/job-server/src/spark.jobserver/JobServer.scala
@@ -1,11 +1,17 @@
 package spark.jobserver
 
-import akka.actor.ActorSystem
+import akka.actor.{ActorSystem, ActorRef}
 import akka.actor.Props
+import akka.pattern.ask
+
 import com.typesafe.config.{Config, ConfigFactory}
 import java.io.File
 import spark.jobserver.io.JobDAO
 import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.duration._
 
 /**
  * The Spark Job Server is a web service that allows users to submit and run Spark jobs, check status,
@@ -55,6 +61,9 @@ object JobServer {
         "context-supervisor")
       val jobInfo = system.actorOf(Props(classOf[JobInfoActor], jobDAO, supervisor), "job-info")
 
+      // Add initial job JARs, if specified in configuration.
+      storeInitialJars(config, jarManager)
+
       // Create initial contexts
       supervisor ! ContextSupervisor.AddContextsFromConfig
       new WebApi(system, config, port, jarManager, supervisor, jobInfo).start()
@@ -64,6 +73,44 @@ object JobServer {
         sys.exit(1)
     }
 
+  }
+
+  private def storeInitialJars(config: Config, jarManager: ActorRef): Unit = {
+    if(config.hasPath("spark.jobserver.job-jar-uris")) {
+      val initialJarsConfig = config.getConfig("spark.jobserver.job-jar-uris").root
+
+      logger.info("Adding initial job jars: {}", initialJarsConfig.render())
+
+      val initialJars =
+        initialJarsConfig
+          .asScala
+          .map { case (key, value) => (key, value.unwrapped.toString) }
+          .toMap
+
+      // Ensure that the jars exist
+      for(jarPath <- initialJars.values) {
+        val f = new java.io.File(jarPath)
+        if(!f.exists) {
+          val msg =
+            if(f.isAbsolute) {
+              s"Inital Jar File $jarPath does not exist"
+            } else {
+              s"Inital Jar File $jarPath (${f.getAbsolutePath}) does not exist"
+            }
+
+          throw new java.io.IOException(msg)
+        }
+      }
+
+      val contextTimeout = util.SparkJobUtils.getContextTimeout(config)
+      val future =
+        (jarManager ? StoreInitialJars(initialJars))(contextTimeout.seconds)
+
+      Await.result(future, contextTimeout.seconds) match {
+        case InvalidJar => sys.error("Could not store initial job jars.")
+        case _ =>
+      }
+    }
   }
 
   def main(args: Array[String]) {


### PR DESCRIPTION
This PR allows the user to supply a `spark.jobserver.job-jar-uris` configuration object that will cause SJS to store jars at the given URIs for the given application names. It behaves as if the first thing you do when SJS starts is post jars to the `localhost:8090/jars/appName` endpoint with a set of local jars.

The idea comes from @hectcastro.