### PR TITLE
Bugfix: Custom YARN_CONF_DIR remain unused

### DIFF
--- a/bin/server_start.sh
+++ b/bin/server_start.sh
@@ -89,6 +89,8 @@ fi
 
 # This needs to be exported for standalone mode so drivers can connect to the Spark cluster
 export SPARK_HOME
+export YARN_CONF_DIR
+export HADOOP_CONF_DIR
 
 cmd='$SPARK_HOME/bin/spark-submit --class $MAIN --driver-memory $JOBSERVER_MEMORY
   --conf "spark.executor.extraJavaOptions=$LOGGING_OPTS"

--- a/job-server/config/local.sh.template
+++ b/job-server/config/local.sh.template
@@ -20,4 +20,5 @@ SPARK_EXECUTOR_URI=/home/spark/spark-0.8.0.tar.gz
 # You will need to COPY these files from your cluster to the remote machine
 # Normally these are kept on the cluster in /etc/hadoop/conf
 # YARN_CONF_DIR=/pathToRemoteConf/conf
+# HADOOP_CONF_DIR=/pathToRemoteConf/conf
 SCALA_VERSION=2.10.4 # or 2.11.6


### PR DESCRIPTION
If you change the YARN_CONF_DIR in your env.sh files the parameter was not used by the spark-submit shell because the server_start.sh did not export the parameters.

Effect: The YARN_CONF_DIR of the settings.sh has no effect. The jobserver will always try to connect to localhost(default) in yarn client mode.