### PR TITLE
Update Joda Time dependency to version 2.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
 
   lazy val yodaDeps = Seq(
     "org.joda" % "joda-convert" % "1.2",
-    "joda-time" % "joda-time" % "2.1"
+    "joda-time" % "joda-time" % "2.2"
   )
 
   lazy val akkaDeps = Seq(


### PR DESCRIPTION
Attempting to run a job that uses the AWS client raised this exception

```
java.lang.IllegalStateException: Joda-time 2.2 or later version is required, but found version: null
    at com.amazonaws.util.DateUtils.handleException(DateUtils.java:147)
    at com.amazonaws.util.DateUtils.parseRFC822Date(DateUtils.java:195)
    at com.amazonaws.services.s3.internal.ServiceUtils.parseRfc822Date(ServiceUtils.java:78)
    ...
```

Updating the dependency to Joda Time 2.2 avoids the exception and does not break any unit tests.

Compatibility notes from http://www.joda.org/joda-time/upgradeto220.html

```
Compatibility with 2.1
----------------------
Build system - No
 - Ant build removed. Build only on Maven now.

Binary compatible - Yes

Source compatible - Yes

Serialization compatible - Yes

Data compatible - Yes, except
 - DateTimeZone data updated to version 2012j

Semantic compatible - Yes, except
 - DateTimeFormatter.parseInto() retains the year if only month parsed (as it did in v1.x)
 - If a formatter cannot print or parse, it will now throw an exception instead of ignoring it
 - Format pattern "z" now has limited parsing abilities
```