### PR TITLE
Fix typo in SparkStreamingJob

### DIFF
--- a/job-server-extras/src/spark.jobserver/SparkStreamingJob.scala
+++ b/job-server-extras/src/spark.jobserver/SparkStreamingJob.scala
@@ -7,6 +7,6 @@ import org.apache.spark.streaming.StreamingContext
  * these jobs are usually long running jobs and there's (yet) no way in Spark
  * Job Server to query the status of these jobs.
  */
-trait SparkStramingJob extends SparkJobBase {
+trait SparkStreamingJob extends SparkJobBase {
   type C = StreamingContext
 }

--- a/job-server-extras/src/spark.jobserver/StreamingTestJob.scala
+++ b/job-server-extras/src/spark.jobserver/StreamingTestJob.scala
@@ -8,7 +8,7 @@ import org.apache.spark.streaming.StreamingContext
 import scala.collection.mutable
 
 @VisibleForTesting
-object StreamingTestJob extends SparkStramingJob {
+object StreamingTestJob extends SparkStreamingJob {
   def validate(ssc: StreamingContext, config: Config): SparkJobValidation = SparkJobValid
 
 

--- a/job-server-extras/src/spark.jobserver/context/StreamingContextFactory.scala
+++ b/job-server-extras/src/spark.jobserver/context/StreamingContextFactory.scala
@@ -3,7 +3,7 @@ package spark.jobserver.context
 import com.typesafe.config.Config
 import org.apache.spark.SparkConf
 import org.apache.spark.streaming.{Milliseconds, StreamingContext}
-import spark.jobserver.{ContextLike, SparkJobBase, SparkStramingJob}
+import spark.jobserver.{ContextLike, SparkJobBase, SparkStreamingJob}
 
 class StreamingContextFactory extends SparkContextFactory {
 
@@ -14,7 +14,7 @@ class StreamingContextFactory extends SparkContextFactory {
     val stopGracefully = config.getBoolean("streaming.stopGracefully")
     val stopSparkContext = config.getBoolean("streaming.stopSparkContext")
     new StreamingContext(sparkConf, Milliseconds(interval)) with ContextLike {
-      def isValidJob(job: SparkJobBase): Boolean = job.isInstanceOf[SparkStramingJob]
+      def isValidJob(job: SparkJobBase): Boolean = job.isInstanceOf[SparkStreamingJob]
       def stop() {
         //Gracefully stops the spark context
         stop(stopSparkContext, stopGracefully)


### PR DESCRIPTION
This would break the code of anyone using SparkStramingJob... so should we break that or I can add another trait called SparkStramingJob that extends SparkStreamingJob, and mark it as deprecated and we can delete that one on another release.