### PR TITLE
Fix issue #229: Always use limit while reading from DB

### DIFF
--- a/job-server-extras/test/spark.jobserver/StreamingJobSpec.scala
+++ b/job-server-extras/test/spark.jobserver/StreamingJobSpec.scala
@@ -46,7 +46,7 @@ class StreamingJobSpec extends JobSpecBase(StreamingJobSpec.getNewSystem) {
         }
       }
       Thread sleep 1000
-      dao.getJobInfos.get(jobId).get match  {
+      dao.getJobInfo(jobId).get match  {
         case JobInfo(_, _, _, _, _, None, _) => {  }
         case e => fail("Unexpected JobInfo" + e)
       }

--- a/job-server/src/spark.jobserver/io/JobDAO.scala
+++ b/job-server/src/spark.jobserver/io/JobDAO.scala
@@ -55,11 +55,18 @@ trait JobDAO {
   def saveJobInfo(jobInfo: JobInfo)
 
   /**
+   * Return job info for a specific job id.
+   *
+   * @return
+   */
+  def getJobInfo(jobId: String): Option[JobInfo]
+
+  /**
    * Return all job ids to their job info.
    *
    * @return
    */
-  def getJobInfos: Map[String, JobInfo]
+  def getJobInfos(limit: Int): Seq[JobInfo]
 
   /**
    * Persist a job configuration along with provided jobId.

--- a/job-server/src/spark.jobserver/io/JobFileDAO.scala
+++ b/job-server/src/spark.jobserver/io/JobFileDAO.scala
@@ -168,7 +168,10 @@ class JobFileDAO(config: Config) extends JobDAO {
     Some(new DateTime(in.readLong)),
     readError(in))
 
-  override def getJobInfos: Map[String, JobInfo] = jobs.toMap
+  override def getJobInfo(jobId: String): Option[JobInfo] = jobs.get(jobId)
+
+  override def getJobInfos(limit: Int): Seq[JobInfo] =
+    jobs.values.toSeq.sortBy(- _.startTime.getMillis).take(limit)
 
   override def saveJobConfig(jobId: String, jobConfig: Config) {
     writeJobConfig(jobConfigsOutputStream, jobId, jobConfig)

--- a/job-server/src/spark.jobserver/io/JobSqlDAO.scala
+++ b/job-server/src/spark.jobserver/io/JobSqlDAO.scala
@@ -278,7 +278,7 @@ class JobSqlDAO(config: Config) extends JobDAO {
     }
   }
 
-  override def getJobInfos: Map[String, JobInfo] = {
+  override def getJobInfos(limit: Int): Seq[JobInfo] = {
     db withSession {
       implicit sessions =>
 
@@ -288,17 +288,43 @@ class JobSqlDAO(config: Config) extends JobDAO {
           j <- jobs if j.jarId === jar.jarId
         } yield
           (j.jobId, j.contextName, jar.appName, jar.uploadTime, j.classPath, j.startTime, j.endTime, j.error)
-
+        val sortQuery = joinQuery.sortBy(_._6.desc)
+        val limitQuery = sortQuery.take(limit)
         // Transform the each row of the table into a map of JobInfo values
+        limitQuery.list.map {
+          case (id, context, app, upload, classpath, start, end, err) =>
+            JobInfo(id,
+              context,
+              JarInfo(app, convertDateSqlToJoda(upload)),
+              classpath,
+              convertDateSqlToJoda(start),
+              end.map(convertDateSqlToJoda(_)),
+              err.map(new Throwable(_)))
+        }.toSeq
+    }
+  }
+
+  override def getJobInfo(jobId: String): Option[JobInfo] = {
+    db withSession {
+      implicit sessions =>
+
+        // Join the JARS and JOBS tables without unnecessary columns
+        val joinQuery = for {
+          jar <- jars
+          j <- jobs if j.jarId === jar.jarId && j.jobId === jobId
+        } yield
+          (j.jobId, j.contextName, jar.appName, jar.uploadTime, j.classPath, j.startTime,
+            j.endTime, j.error)
+        logger.info("Query: " + joinQuery.selectStatement)
         joinQuery.list.map { case (id, context, app, upload, classpath, start, end, err) =>
-          id -> JobInfo(id,
+          JobInfo(id,
             context,
             JarInfo(app, convertDateSqlToJoda(upload)),
             classpath,
             convertDateSqlToJoda(start),
             end.map(convertDateSqlToJoda(_)),
             err.map(new Throwable(_)))
-        }.toMap
+        }.headOption
     }
   }
 }

--- a/job-server/test/spark.jobserver/InMemoryDAO.scala
+++ b/job-server/test/spark.jobserver/InMemoryDAO.scala
@@ -41,7 +41,9 @@ class InMemoryDAO extends JobDAO {
 
   def saveJobInfo(jobInfo: JobInfo) { jobInfos(jobInfo.jobId) = jobInfo }
 
-  def getJobInfos(): Map[String, JobInfo] = jobInfos.toMap
+  def getJobInfos(limit: Int): Seq[JobInfo] = jobInfos.values.toSeq.sortBy(_.startTime.toString()).take(limit)
+
+  def getJobInfo(jobId: String): Option[JobInfo] = jobInfos.get(jobId)
 
   val jobConfigs = mutable.HashMap.empty[String, Config]
 

--- a/job-server/test/spark.jobserver/io/JobSqlDAOSpec.scala
+++ b/job-server/test/spark.jobserver/io/JobSqlDAOSpec.scala
@@ -205,12 +205,13 @@ class JobSqlDAOSpec extends TestJarFinder with FunSpecLike with Matchers with Be
       dao = null
       dao = new JobSqlDAO(config)
 
-      // Get all jobInfos
+      // Get jobInfos
       val jobs = dao.getJobInfos(2)
+      val jobIds = jobs map { _.jobId }
 
       // test
-      // jobs should equal (Seq(jobId, jobId2))
-      // jobs.values.toSeq should equal (Seq(expectedJobInfo, expectedJobInfo2))
+      jobIds should equal (Seq(jobId, jobId2))
+      jobs should equal (Seq(expectedJobInfo, expectedJobInfo2))
     }
 
     it("saving a JobInfo with the same jobId should update the JOBS table") {

--- a/job-server/test/spark.jobserver/io/JobSqlDAOSpec.scala
+++ b/job-server/test/spark.jobserver/io/JobSqlDAOSpec.scala
@@ -166,31 +166,30 @@ class JobSqlDAOSpec extends TestJarFinder with FunSpecLike with Matchers with Be
   }
 
   describe("Basic saveJobInfo() and getJobInfos() tests") {
-    it("should provide an empty map on getJobInfos() for an empty JOBS table") {
-      (Map.empty[String, JobInfo]) should equal (dao.getJobInfos)
+    it("should provide an empty Seq on getJobInfos() for an empty JOBS table") {
+      (Seq.empty[JobInfo]) should equal (dao.getJobInfos(1))
     }
 
     it("should save a new JobInfo and get the same JobInfo") {
       // save JobInfo
       dao.saveJobInfo(jobInfoNoEndNoErr)
 
-      // get all JobInfos
-      val jobs = dao.getJobInfos
+      // get some JobInfos
+      val jobs = dao.getJobInfos(10)
 
       // test
-      jobs.keySet should equal (Set(jobId))
-      jobs(jobId) should equal (expectedJobInfo)
+      jobs.head.jobId should equal (jobId)
+      jobs.head should equal (expectedJobInfo)
     }
 
     it("should be able to get previously saved JobInfo") {
       // jobInfo saved in prior test
 
       // get jobInfos
-      val jobs = dao.getJobInfos
+      val jobInfo = dao.getJobInfo(jobId).get
 
       // test
-      jobs.keySet should equal (Set(jobId))
-      jobs(jobId) should equal (expectedJobInfo)
+      jobInfo should equal (expectedJobInfo)
     }
 
     it("Save another new jobInfo, bring down DB, bring up DB, should JobInfos from DB") {
@@ -207,11 +206,11 @@ class JobSqlDAOSpec extends TestJarFinder with FunSpecLike with Matchers with Be
       dao = new JobSqlDAO(config)
 
       // Get all jobInfos
-      val jobs = dao.getJobInfos
+      val jobs = dao.getJobInfos(2)
 
       // test
-      jobs.keySet should equal (Set(jobId, jobId2))
-      jobs.values.toSeq should equal (Seq(expectedJobInfo, expectedJobInfo2))
+      // jobs should equal (Seq(jobId, jobId2))
+      // jobs.values.toSeq should equal (Seq(expectedJobInfo, expectedJobInfo2))
     }
 
     it("saving a JobInfo with the same jobId should update the JOBS table") {
@@ -224,40 +223,40 @@ class JobSqlDAOSpec extends TestJarFinder with FunSpecLike with Matchers with Be
       info.uploadTime should equal (jarInfo.uploadTime)
 
       // Get all jobInfos
-      val jobs: Map[String, JobInfo] = dao.getJobInfos
+      val jobs: Seq[JobInfo] = dao.getJobInfos(2)
 
       // First Test
       jobs.size should equal (2)
-      jobs(exJobId) should equal (expectedJobInfo)
+      jobs.head should equal (expectedJobInfo)
 
       // Second Test
       // Cannot compare JobInfos directly if error is a Some(Throwable) because
       // Throwable uses referential equality
       dao.saveJobInfo(jobInfoNoEndSomeErr)
-      val jobs2 = dao.getJobInfos
+      val jobs2 = dao.getJobInfos(2)
       jobs2.size should equal (2)
-      jobs2(exJobId).endTime should equal (None)
-      jobs2(exJobId).error.isDefined should equal (true)
-      intercept[Throwable] { jobs2(exJobId).error.map(throw _) }
-      jobs2(exJobId).error.get.getMessage should equal (throwable.getMessage)
+      jobs2.head.endTime should equal (None)
+      jobs2.head.error.isDefined should equal (true)
+      intercept[Throwable] { jobs2.head.error.map(throw _) }
+      jobs2.head.error.get.getMessage should equal (throwable.getMessage)
 
       // Third Test
       dao.saveJobInfo(jobInfoSomeEndNoErr)
-      val jobs3 = dao.getJobInfos
+      val jobs3 = dao.getJobInfos(2)
       jobs3.size should equal (2)
-      jobs3(exJobId).error.isDefined should equal (false)
-      jobs3(exJobId) should equal (expectedSomeEndNoErr)
+      jobs3.head.error.isDefined should equal (false)
+      jobs3.head should equal (expectedSomeEndNoErr)
 
       // Fourth Test
       // Cannot compare JobInfos directly if error is a Some(Throwable) because
       // Throwable uses referential equality
       dao.saveJobInfo(jobInfoSomeEndSomeErr)
-      val jobs4 = dao.getJobInfos
+      val jobs4 = dao.getJobInfos(2)
       jobs4.size should equal (2)
-      jobs4(exJobId).endTime should equal (expectedSomeEndSomeErr.endTime)
-      jobs4(exJobId).error.isDefined should equal (true)
-      intercept[Throwable] { jobs4(exJobId).error.map(throw _) }
-      jobs4(exJobId).error.get.getMessage should equal (throwable.getMessage)
+      jobs4.head.endTime should equal (expectedSomeEndSomeErr.endTime)
+      jobs4.head.error.isDefined should equal (true)
+      intercept[Throwable] { jobs4.head.error.map(throw _) }
+      jobs4.head.error.get.getMessage should equal (throwable.getMessage)
     }
   }
 }


### PR DESCRIPTION
Earlier we were fetching all DB records into memory and then running limit query in memory. For a bigger production system this is causing issues as the records grow beyond certain number. This patch does  the following

1. Modifies the signature of getJobInfos() to take limit parameter so that we always fetch certain number of records from DB.
2. Add new API getJobInfo() to retrieve a information about a specific Job Id. Earlier we were performing a lookup in memory.
3. Adjust tests accordingly.