### PR TITLE
Remove unnecesary fallback in SparkContextFactory 

### DIFF
--- a/job-server/src/spark.jobserver/context/SparkContextFactory.scala
+++ b/job-server/src/spark.jobserver/context/SparkContextFactory.scala
@@ -34,8 +34,7 @@ trait SparkContextFactory {
    */
   def makeContext(config: Config, contextConfig: Config, contextName: String): C = {
     val sparkConf = configToSparkConf(config, contextConfig, contextName)
-    val contextCfg = contextConfig
-    makeContext(sparkConf, contextCfg, contextName)
+    makeContext(sparkConf, contextConfig, contextName)
   }
 }
 

--- a/job-server/src/spark.jobserver/context/SparkContextFactory.scala
+++ b/job-server/src/spark.jobserver/context/SparkContextFactory.scala
@@ -34,7 +34,7 @@ trait SparkContextFactory {
    */
   def makeContext(config: Config, contextConfig: Config, contextName: String): C = {
     val sparkConf = configToSparkConf(config, contextConfig, contextName)
-    val contextCfg = config.getConfig("spark.context-settings").withFallback(contextConfig)
+    val contextCfg = contextConfig
     makeContext(sparkConf, contextCfg, contextName)
   }
 }

--- a/job-server/test/spark.jobserver/WebApiMainRoutesSpec.scala
+++ b/job-server/test/spark.jobserver/WebApiMainRoutesSpec.scala
@@ -82,13 +82,13 @@ class WebApiMainRoutesSpec extends WebApiSpec {
     }
 
     it("should merge user passed jobConfig with default jobConfig") {
-      val config2 = "foo.baz = booboo"
+      val config2 = "foo.baz = booboo, spark.master=overriden"
       Post("/jobs?appName=foo&classPath=com.abc.meme&context=one&sync=true", config2) ~>
           sealRoute(routes) ~> check {
         status should be (OK)
         responseAs[Map[String, Any]] should be (Map(
           StatusKey -> "OK",
-          ResultKey -> Map(masterConfKey->masterConfVal, bindConfKey -> bindConfVal, "foo.baz" -> "booboo", "shiro.authentication" -> "off")
+          ResultKey -> Map(masterConfKey->"overriden", bindConfKey -> bindConfVal, "foo.baz" -> "booboo", "shiro.authentication" -> "off")
         ))
       }
     }


### PR DESCRIPTION
There was a fallback in SparkContextFactory that made the default config override job config instead of the other way around.
Since LocalContextSupervisorActor and WebApi do the fallback action there's no need to do it again in the context factory.