### PR TITLE
Remove unnecessary logging of SQL query

### DIFF
--- a/job-server/src/spark.jobserver/io/JobSqlDAO.scala
+++ b/job-server/src/spark.jobserver/io/JobSqlDAO.scala
@@ -315,7 +315,6 @@ class JobSqlDAO(config: Config) extends JobDAO {
         } yield
           (j.jobId, j.contextName, jar.appName, jar.uploadTime, j.classPath, j.startTime,
             j.endTime, j.error)
-        logger.info("Query: " + joinQuery.selectStatement)
         joinQuery.list.map { case (id, context, app, upload, classpath, start, end, err) =>
           JobInfo(id,
             context,


### PR DESCRIPTION
This was actually done for debugging. This could pollute the log.