### PR TITLE
Cleanup /jobs/jobId APIs

### DIFF
--- a/job-server/src/spark.jobserver/JobInfoActor.scala
+++ b/job-server/src/spark.jobserver/JobInfoActor.scala
@@ -13,6 +13,7 @@ object JobInfoActor {
   // Requests
   case class GetJobStatuses(limit: Option[Int])
   case class GetJobConfig(jobId: String)
+  case class GetJobStatus(jobId: String)
   case class StoreJobConfig(jobId: String, jobConfig: Config)
 
   // Responses
@@ -32,6 +33,9 @@ class JobInfoActor(jobDao: JobDAO, contextSupervisor: ActorRef) extends Instrume
   override def wrappedReceive: Receive = {
     case GetJobStatuses(limit) =>
       sender ! jobDao.getJobInfos(limit.get)
+
+    case GetJobStatus(jobId) =>
+      sender ! jobDao.getJobInfo(jobId).get
 
     case GetJobResult(jobId) =>
       breakable {

--- a/job-server/test/spark.jobserver/WebApiMainRoutesSpec.scala
+++ b/job-server/test/spark.jobserver/WebApiMainRoutesSpec.scala
@@ -19,6 +19,16 @@ class WebApiMainRoutesSpec extends WebApiSpec {
   import spray.json.DefaultJsonProtocol._
   import ooyala.common.akka.web.JsonUtils._
 
+  val getJobStatusInfoMap = {
+    Map(
+      "jobId" -> "foo-1",
+      "startTime" -> "2013-05-29T00:00:00.000Z",
+      "classPath" -> "com.abc.meme",
+      "context"  -> "context",
+      "duration" -> "300.0 secs",
+      StatusKey -> "FINISHED")
+  }
+
   describe("jars routes") {
     it("should list all jars") {
       Get("/jars") ~> sealRoute(routes) ~> check {
@@ -87,7 +97,6 @@ class WebApiMainRoutesSpec extends WebApiSpec {
           sealRoute(routes) ~> check {
         status should be (OK)
         responseAs[Map[String, Any]] should be (Map(
-          StatusKey -> "OK",
           ResultKey -> Map(masterConfKey->"overriden", bindConfKey -> bindConfVal, "foo.baz" -> "booboo", "shiro.authentication" -> "off")
         ))
       }
@@ -109,7 +118,6 @@ class WebApiMainRoutesSpec extends WebApiSpec {
         sealRoute(routes) ~> check {
         status should be (OK)
         responseAs[Map[String, Any]] should be (Map(
-          StatusKey -> "OK",
           ResultKey -> Map(masterConfKey->masterConfVal, bindConfKey -> bindConfVal, "foo.baz" -> "booboo", "shiro.authentication" -> "off")
         ))
       }
@@ -121,7 +129,6 @@ class WebApiMainRoutesSpec extends WebApiSpec {
         sealRoute(routes) ~> check {
         status should be (OK)
         responseAs[Map[String, Any]] should be (Map(
-          StatusKey -> "OK",
           ResultKey -> Map(masterConfKey->masterConfVal, bindConfKey -> bindConfVal, "foo.baz" -> "booboo", "shiro.authentication" -> "off")
         ))
       }
@@ -141,7 +148,12 @@ class WebApiMainRoutesSpec extends WebApiSpec {
       Get("/jobs/foobar") ~> sealRoute(routes) ~> check {
         status should be (OK)
         responseAs[Map[String, String]] should be (Map(
-          StatusKey -> "OK",
+          "jobId" -> "foo-1",
+          "startTime" -> "2013-05-29T00:00:00.000Z",
+          "classPath" -> "com.abc.meme",
+          "context"  -> "context",
+          "duration" -> "Job not done yet",
+          StatusKey -> "RUNNING",
           ResultKey -> "foobar!!!"
         ))
       }
@@ -217,17 +229,14 @@ class WebApiMainRoutesSpec extends WebApiSpec {
     it("should be able to serialize nested Seq's and Map's within Map's to JSON") {
       Get("/jobs/_mapseq") ~> sealRoute(routes) ~> check {
         status should be (OK)
-        responseAs[Map[String, Any]] should be (Map(
-          StatusKey -> "OK",
-          ResultKey -> Map("first" -> Seq(1, 2, Seq("a", "b")))
-      ))
+        responseAs[Map[String, Any]] should be (
+          getJobStatusInfoMap ++ Map(ResultKey -> Map("first" -> Seq(1, 2, Seq("a", "b")))))
       }
 
       Get("/jobs/_mapmap") ~> sealRoute(routes) ~> check {
         status should be (OK)
-        responseAs[Map[String, Any]] should be (Map(
-          StatusKey -> "OK",
-          ResultKey -> Map("second" -> Map("K" -> Map("one" -> 1)))
+        responseAs[Map[String, Any]] should be (
+          getJobStatusInfoMap ++ Map(ResultKey -> Map("second" -> Map("K" -> Map("one" -> 1)))
         ))
       }
     }
@@ -236,8 +245,7 @@ class WebApiMainRoutesSpec extends WebApiSpec {
       Get("/jobs/_seq") ~> sealRoute(routes) ~> check {
         status should be (OK)
         responseAs[Map[String, Any]] should be (
-          Map( StatusKey -> "OK",
-            ResultKey -> Seq(1, 2, Map("3" -> "three"))
+          getJobStatusInfoMap ++ Map(ResultKey -> Seq(1, 2, Map("3" -> "three"))
           )
         )
       }
@@ -247,7 +255,7 @@ class WebApiMainRoutesSpec extends WebApiSpec {
       Get("/jobs/_num") ~> sealRoute(routes) ~> check {
         status should be (OK)
         responseAs[Map[String, Any]] should be (
-          Map(StatusKey -> "OK", ResultKey -> 5000)
+          getJobStatusInfoMap ++ Map(ResultKey -> 5000)
         )
       }
     }
@@ -256,7 +264,7 @@ class WebApiMainRoutesSpec extends WebApiSpec {
       Get("/jobs/_unk") ~> sealRoute(routes) ~> check {
         status should be (OK)
         responseAs[Map[String, Any]] should be (
-          Map(StatusKey -> "OK", ResultKey -> Seq(1,  "101"))
+          getJobStatusInfoMap ++ Map(ResultKey -> Seq(1,  "101"))
         )
       }
     }

--- a/job-server/test/spark.jobserver/auth/WebApiWithAuthenticationSpec.scala
+++ b/job-server/test/spark.jobserver/auth/WebApiWithAuthenticationSpec.scala
@@ -74,11 +74,16 @@ class WebApiWithAuthenticationSpec extends FunSpec with Matchers with BeforeAndA
   private val authorization = new Authorization(new BasicHttpCredentials("presidentskroob", "12345"))
   private val authorizationInvalidPassword = new Authorization(new BasicHttpCredentials("presidentskroob", "xxx"))
   private val authorizationUnknownUser = new Authorization(new BasicHttpCredentials("whoami", "xxx"))
+  private val dt = DateTime.parse("2013-05-29T00Z")
+  private val jobInfo = JobInfo("foo-1", "context", JarInfo("demo", dt), "com.abc.meme", dt, None, None)
+  private val ResultKey = "result"
 
   class DummyActor extends Actor {
     import CommonMessages._
+    import JobInfoActor._
     def receive = {
       case ListJars                       => sender ! Map()
+      case GetJobStatus(id)               => sender ! jobInfo
       case GetJobResult(id)               => sender ! JobResult(id, id + "!!!")
       case ContextSupervisor.ListContexts => sender ! Seq("context1", "context2")
     }


### PR DESCRIPTION
As of now /jobs/jobId returns status and result which is very minimal.
Since we lack an API which returns more information like the /jobs API
returns as a list, amend /jobs/jobId to return extra information.

This commit makes job status uniform across /jobs and /jobs/jobId. We no
longer have "OK" status instead it will be the same as "FINISHED"

Now GET /jobs/jobId takes different route instead of the current one.

User => WebAPI => GetJobStatus => WebAPI => GetJobResult => WebAPI => User

And DELETE /jobs/jobId takes

User => WebAPI => GetJobStatus => WebAPI => User