### PR TITLE
Fix regression caused by PR-270

### DIFF
--- a/job-server/src/spark.jobserver/JobInfoActor.scala
+++ b/job-server/src/spark.jobserver/JobInfoActor.scala
@@ -35,7 +35,9 @@ class JobInfoActor(jobDao: JobDAO, contextSupervisor: ActorRef) extends Instrume
       sender ! jobDao.getJobInfos(limit.get)
 
     case GetJobStatus(jobId) =>
-      sender ! jobDao.getJobInfo(jobId).get
+      val jobInfo = jobDao.getJobInfo(jobId)
+      val resp = if (!jobInfo.isDefined) NoSuchJobId else jobInfo.get
+      sender ! resp
 
     case GetJobResult(jobId) =>
       breakable {

--- a/job-server/src/spark.jobserver/WebApi.scala
+++ b/job-server/src/spark.jobserver/WebApi.scala
@@ -371,6 +371,8 @@ class WebApi(system: ActorSystem,
                 ctx.complete(Map(StatusKey -> "KILLED"))
               case JobInfo(_, _, _, _, _, _, Some(ex)) =>
                 ctx.complete(Map(StatusKey -> "ERROR", "ERROR" -> formatException(ex)))
+              case JobInfo(_, _, _, _, _, Some(e), None) =>
+                notFound(ctx, "No running job with ID " + jobId.toString)
             }
           }
         } ~


### PR DESCRIPTION
After PR-270 DELETE API for following scenarios stopped working.
      DELETE /jobs/non-existing-job-id
      DELETE /jobs/finished-job-id stopped working.