### PR TITLE
Upgrade to Spark 1.5.1 and sbt-scoverage 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Spark Job Server is now included in Datastax Enterprise 4.8!
 | 0.5.1       | 1.3.0         |
 | 0.5.2       | 1.3.1         |
 | 0.6.0       | 1.4.1         |
-| master      | 1.5.0         |
+| master      | 1.5.1         |
 
 For release notes, look in the `notes/` directory.  They should also be up on [ls.implicit.ly](http://ls.implicit.ly/spark-jobserver/spark-jobserver).
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,7 +28,7 @@ object Dependencies {
     yammerDeps
   ) ++ yodaDeps
 
-  val sparkVersion = sys.env.getOrElse("SPARK_VERSION", "1.5.0")
+  val sparkVersion = sys.env.getOrElse("SPARK_VERSION", "1.5.1")
   lazy val sparkDeps = Seq(
     "org.apache.spark" %% "spark-core" % sparkVersion % "provided" excludeAll(excludeNettyIo, excludeQQ),
     // Force netty version.  This avoids some Spark netty dependency problem.
@@ -66,7 +66,7 @@ object Dependencies {
   lazy val securityDeps = Seq(
      "org.apache.shiro" % "shiro-core" % "1.2.4"
   )
-		
+
   lazy val serverDeps = apiDeps ++ yodaDeps
   lazy val apiDeps = sparkDeps :+ typeSafeConfigDeps
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,7 +10,7 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.6.0")
 
 resolvers += Classpaths.sbtPluginReleases
 
-addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.0.4")
+addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.2.0")
 
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.2.1")
 


### PR DESCRIPTION
The latter due to another user discovered dependency issue.

This should help resolve the spark-streaming dependency issue and help the builds pass.