### PR TITLE
Small ask timeout bug

### DIFF
--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -60,6 +60,9 @@ spark {
       }
     }
 
+    # The ask pattern timeout for Api
+    short-timeout = 3 s
+
     # Time out for job server to wait while creating contexts
     context-creation-timeout = 15 s
 

--- a/job-server/src/spark.jobserver/WebApi.scala
+++ b/job-server/src/spark.jobserver/WebApi.scala
@@ -106,10 +106,8 @@ class WebApi(system: ActorSystem,
 
   override def actorRefFactory: ActorSystem = system
   implicit val ec: ExecutionContext = system.dispatcher
-  implicit val ShortTimeout = Timeout(
-    Try(config.getDuration("spark.jobserver.short-timeout", TimeUnit.MILLISECONDS)).getOrElse(3000),
-    TimeUnit.MILLISECONDS
-  )
+  implicit val ShortTimeout =
+    Timeout(config.getDuration("spark.jobserver.short-timeout", TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS)
   val DefaultSyncTimeout = Timeout(10 seconds)
   val DefaultJobLimit = 50
   val StatusKey = "status"

--- a/job-server/src/spark.jobserver/WebApi.scala
+++ b/job-server/src/spark.jobserver/WebApi.scala
@@ -1,5 +1,7 @@
 package spark.jobserver
 
+import java.util.concurrent.TimeUnit
+
 import akka.actor.{ ActorSystem, ActorRef }
 import akka.pattern.ask
 import akka.util.Timeout
@@ -104,7 +106,10 @@ class WebApi(system: ActorSystem,
 
   override def actorRefFactory: ActorSystem = system
   implicit val ec: ExecutionContext = system.dispatcher
-  implicit val ShortTimeout = Timeout(3 seconds)
+  implicit val ShortTimeout = Timeout(
+    Try(config.getDuration("spark.jobserver.short-timeout", TimeUnit.MILLISECONDS)).getOrElse(3000),
+    TimeUnit.MILLISECONDS
+  )
   val DefaultSyncTimeout = Timeout(10 seconds)
   val DefaultJobLimit = 50
   val StatusKey = "status"

--- a/job-server/test/spark.jobserver/WebApiMainRoutesSpec.scala
+++ b/job-server/test/spark.jobserver/WebApiMainRoutesSpec.scala
@@ -97,7 +97,13 @@ class WebApiMainRoutesSpec extends WebApiSpec {
           sealRoute(routes) ~> check {
         status should be (OK)
         responseAs[Map[String, Any]] should be (Map(
-          ResultKey -> Map(masterConfKey->"overriden", bindConfKey -> bindConfVal, "foo.baz" -> "booboo", "shiro.authentication" -> "off")
+          ResultKey -> Map(
+            masterConfKey->"overriden",
+            bindConfKey -> bindConfVal,
+            "foo.baz" -> "booboo",
+            "shiro.authentication" -> "off",
+            "spark.jobserver.short-timeout" -> "3 s"
+          )
         ))
       }
     }
@@ -118,7 +124,13 @@ class WebApiMainRoutesSpec extends WebApiSpec {
         sealRoute(routes) ~> check {
         status should be (OK)
         responseAs[Map[String, Any]] should be (Map(
-          ResultKey -> Map(masterConfKey->masterConfVal, bindConfKey -> bindConfVal, "foo.baz" -> "booboo", "shiro.authentication" -> "off")
+          ResultKey -> Map(
+            masterConfKey -> masterConfVal,
+            bindConfKey -> bindConfVal,
+            "foo.baz" -> "booboo",
+            "shiro.authentication" -> "off",
+            "spark.jobserver.short-timeout" -> "3 s"
+          )
         ))
       }
     }
@@ -129,7 +141,13 @@ class WebApiMainRoutesSpec extends WebApiSpec {
         sealRoute(routes) ~> check {
         status should be (OK)
         responseAs[Map[String, Any]] should be (Map(
-          ResultKey -> Map(masterConfKey->masterConfVal, bindConfKey -> bindConfVal, "foo.baz" -> "booboo", "shiro.authentication" -> "off")
+          ResultKey -> Map(
+            masterConfKey -> masterConfVal,
+            bindConfKey -> bindConfVal,
+            "foo.baz" -> "booboo",
+            "shiro.authentication" -> "off",
+            "spark.jobserver.short-timeout" -> "3 s"
+          )
         ))
       }
     }

--- a/job-server/test/spark.jobserver/WebApiSpec.scala
+++ b/job-server/test/spark.jobserver/WebApiSpec.scala
@@ -30,6 +30,7 @@ with ScalatestRouteTest with HttpService {
     spark {
       master = "${masterConfVal}"
       jobserver.bind-address = "${bindConfVal}"
+      jobserver.short-timeout = 3 s
     }
     shiro {
       authentication = off

--- a/job-server/test/spark.jobserver/auth/WebApiWithAuthenticationSpec.scala
+++ b/job-server/test/spark.jobserver/auth/WebApiWithAuthenticationSpec.scala
@@ -38,6 +38,7 @@ class WebApiWithAuthenticationSpec extends FunSpec with Matchers with BeforeAndA
     spark {
       master = "${masterConfVal}"
       jobserver.bind-address = "${bindConfVal}"
+      jobserver.short-timeout = 3 s
     }
     shiro {
       authentication = on


### PR DESCRIPTION
When I try to post a big jar in spark-jobserver, I am getting the error response:
```
{
  "status": "ERROR",
  "result": {
    "message": "Ask timed out on [Actor[akka://JobServer/user/jar-manager#735054989]] after [3000 ms]",
    "errorClass": "akka.pattern.AskTimeoutException",
    "stack": ["akka.pattern.PromiseActorRef$$anonfun$1.apply$mcV$sp(AskSupport.scala:334)", "akka.actor.Scheduler$$anon$7.run(Scheduler.scala:117)", "scala.concurrent.Future$InternalCallbackExecutor$.unbatchedExecute(Future.scala:599)", "scala.concurrent.BatchingExecutor$class.execute(BatchingExecutor.scala:109)", "scala.concurrent.Future$InternalCallbackExecutor$.execute(Future.scala:597)", "akka.actor.LightArrayRevolverScheduler$TaskHolder.executeTask(Scheduler.scala:467)", "akka.actor.LightArrayRevolverScheduler$$anon$8.executeBucket$1(Scheduler.scala:419)", "akka.actor.LightArrayRevolverScheduler$$anon$8.nextTick(Scheduler.scala:423)", "akka.actor.LightArrayRevolverScheduler$$anon$8.run(Scheduler.scala:375)", "java.lang.Thread.run(Thread.java:745)"]
  }
}
```
It has happened because spark-jobserver has 3 seconds ask timeout in WebApi.scala.  It would be better if we can to change timeout, so I make short-timeout parameter in application.conf