### PR TITLE
Docker image improvements and parameterized Mesos version.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,6 +28,8 @@ object Dependencies {
     yammerDeps
   ) ++ yodaDeps
 
+  val mesosVersion = sys.env.getOrElse("MESOS_VERSION", "0.25.0-0.2.70.ubuntu1404")
+
   val sparkVersion = sys.env.getOrElse("SPARK_VERSION", "1.5.1")
   lazy val sparkDeps = Seq(
     "org.apache.spark" %% "spark-core" % sparkVersion % "provided" excludeAll(excludeNettyIo, excludeQQ),


### PR DESCRIPTION
This changes the base docker image from ottoops/mesos-java7 to java:7-jre, this alone reduces the image size by about half, ~785MB from ~1.54GB.

If there is a strong preference towards the OracleJDK, we can merge in the [oracle-java7-installer](https://github.com/OttoOps/docker-containers/blob/master/mesos-java7/Dockerfile#L6).

The Mesos library is now installed from apt and configurable via the MESOS_VERSION environment variable.

The docker tag now contains the version for Mesos and Spark, example: 0.6.1-SNAPSHOT.mesos-0.25.0.spark-1.5.1. This should let users discern the correct tag to pull based on their environment.
