### PR TITLE
Fix shell problem, change processbuilder to scala style api

### DIFF
--- a/bin/manager_start.sh
+++ b/bin/manager_start.sh
@@ -3,6 +3,14 @@
 # args: <job manager actor name> <cluster address>
 set -e
 
+get_abs_script_path() {
+   pushd . >/dev/null
+   cd $(dirname $0)
+   appdir=$(pwd)
+   popd  >/dev/null
+}
+get_abs_script_path
+
 . $appdir/setenv.sh
 
 GC_OPTS="-XX:+UseConcMarkSweepGC
@@ -20,4 +28,5 @@ cmd='$SPARK_HOME/bin/spark-submit --class $MAIN --driver-memory $JOBSERVER_MEMOR
   --driver-java-options "$GC_OPTS $JAVA_OPTS $LOGGING_OPTS $CONFIG_OVERRIDES"
   $appdir/spark-job-server.jar $1 $2 $conffile'
 
+eval $cmd > /dev/null 2>&1 &
 # exec java -cp $CLASSPATH $GC_OPTS $JAVA_OPTS $LOGGING_OPTS $CONFIG_OVERRIDES $MAIN $1 $2 $conffile 2>&1 &

--- a/bin/server_start.sh
+++ b/bin/server_start.sh
@@ -9,6 +9,15 @@
 #   JOBSERVER_FG    - launches job server in foreground; defaults to forking in background
 set -e
 
+get_abs_script_path() {
+  pushd . >/dev/null
+  cd "$(dirname "$0")"
+  appdir=$(pwd)
+  popd  >/dev/null
+}
+
+get_abs_script_path
+
 . $appdir/setenv.sh
 
 GC_OPTS="-XX:+UseConcMarkSweepGC


### PR DESCRIPTION
We have deployed the feature/context-per-jvm , but found some problem:
* manager_start.sh and server_start.sh start use $appdir without initial
* AkkaClusterSupervisorActor blocked when creating new persist context at process.waitFor api by unread inputstream and outputstream from sub process stdin/stdout/stderr to the main process, so the main thread block and no result return to the POST /context/name request, cause timeout. So I try to add some processIO handler to consume stdin/stderr stream and also redirect manager_start.sh command to /dev/null, I am not quite sure about which really fix the block problem, but finally it works, and scala process api looks better than the native java api.

We have test deploy/create context/run job with the context, all works but restart job-server itself do not cause jobmanager and spark driver jvm process to restart , and the former context disappear but context jvm still running. Need to fix this in the future. 