### PR TITLE
Fix bug - invalid error w no user/pass

### DIFF
--- a/job-server/src/spark.jobserver/auth/SJSAuthenticator.scala
+++ b/job-server/src/spark.jobserver/auth/SJSAuthenticator.scala
@@ -33,7 +33,7 @@ trait SJSAuthenticator {
     def validate(userPass: Option[UserPass]): Future[Option[AuthInfo]] = {
       //if (!currentUser.isAuthenticated()) {
       Future {
-        explicitValidation(userPass.get, logger)
+        explicitValidation(userPass getOrElse UserPass("",""), logger)
       }
     }
 


### PR DESCRIPTION
Fixes a bug that causes java.util.NoSuchElementException: None.get error when operation attempted with auth enabled and no user name / password supplied. This bug in turn seemed to stop the UI working the auth enabled.

I'm not much of a scala expert so there may be a better way to do it but this worked in all my testing.