### PR TITLE
Improve the SparkJob API to remove code duplication

### DIFF
--- a/job-server-api/src/spark.jobserver/SparkJob.scala
+++ b/job-server-api/src/spark.jobserver/SparkJob.scala
@@ -2,44 +2,34 @@ package spark.jobserver
 
 import com.typesafe.config.Config
 import org.apache.spark.SparkContext
-
-sealed trait SparkJobValidation {
-  // NOTE(harish): We tried using lazy eval here by passing in a function
-  // instead, which worked fine with tests but when run with the job-server
-  // it would just hang and timeout. This is something worth investigating
-  def &&(sparkValidation: SparkJobValidation): SparkJobValidation = this match {
-    case SparkJobValid =>  sparkValidation
-    case x => x
-  }
-}
-case object SparkJobValid extends SparkJobValidation
-case class SparkJobInvalid(reason: String) extends SparkJobValidation
+import scalaz._
 
 /**
  *  This trait is the main API for Spark jobs submitted to the Job Server.
  */
 trait SparkJobBase {
   type C
+  type Tmp
 
   /**
    * This is the entry point for a Spark Job Server to execute Spark jobs.
    * This function should create or reuse RDDs and return the result at the end, which the
    * Job Server will cache or display.
    * @param sc a SparkContext or similar for the job.  May be reused across jobs.
-   * @param jobConfig the Typesafe Config object passed into the job request
+   * @param jobConfig the object returned by validate
    * @return the job result
    */
-  def runJob(sc: C, jobConfig: Config): Any
+  def runJob(sc: C, jobConfig: Tmp): Any
 
   /**
    * This method is called by the job server to allow jobs to validate their input and reject
-   * invalid job requests.  If SparkJobInvalid is returned, then the job server returns 400
+   * invalid job requests. If a Failure is returned, then the job server returns 400
    * to the user.
    * NOTE: this method should return very quickly.  If it responds slowly then the job server may time out
    * trying to start this job.
-   * @return either SparkJobValid or SparkJobInvalid
+   * @return Failure or Success, where Success is passed to runJob
    */
-  def validate(sc: C, config: Config): SparkJobValidation
+  def validate(sc: C, config: Config): Validation[String, Tmp]
 }
 
 

--- a/job-server-extras/src/spark.jobserver/KMeansExample.scala
+++ b/job-server-extras/src/spark.jobserver/KMeansExample.scala
@@ -25,9 +25,11 @@ object KMeansExample extends SparkJob with NamedRddSupport {
    * @param config
    * @return Always return SparkJobValid as this example will not do error checking
    */
-  override def validate(sc: SparkContext, config: Config): SparkJobValidation = SparkJobValid
+  override def validate(sc: SparkContext, config: Config): scalaz.Validation[String, Unit] =
+    scalaz.Success(())
+  type Tmp = Unit
 
-  override def runJob(sc: SparkContext, config: Config): (Array[String], Array[String], Long) = {
+  override def runJob(sc: SparkContext, config: Unit): (Array[String], Array[String], Long) = {
     //load the hadoop configuration file, since the job server doesn't seem to do it
     val sqlContext = new SQLContext(sc)
 

--- a/job-server-extras/src/spark.jobserver/StreamingTestJob.scala
+++ b/job-server-extras/src/spark.jobserver/StreamingTestJob.scala
@@ -9,10 +9,12 @@ import scala.collection.mutable
 
 @VisibleForTesting
 object StreamingTestJob extends SparkStreamingJob {
-  def validate(ssc: StreamingContext, config: Config): SparkJobValidation = SparkJobValid
+  type Tmp = Unit
+  def validate(ssc: StreamingContext, config: Config): scalaz.Validation[String, Unit] =
+    scalaz.Success(())
 
 
-  def runJob(ssc: StreamingContext, config: Config): Any = {
+  def runJob(ssc: StreamingContext, config: Unit): Any = {
     val queue = mutable.Queue[RDD[String]]()
     queue += ssc.sparkContext.makeRDD(Seq("123", "test", "test2"))
     val lines = ssc.queueStream(queue)

--- a/job-server-tests/src/main/java/spark.jobserver/JavaHelloWorldJob.java
+++ b/job-server-tests/src/main/java/spark.jobserver/JavaHelloWorldJob.java
@@ -6,7 +6,12 @@ import spark.jobserver.JavaSparkJob;
 
 public class JavaHelloWorldJob extends JavaSparkJob {
   @Override
-  public Object runJob(JavaSparkContext jsc, Config jobConfig) {
+  public Object runJob(JavaSparkContext jsc, Object message) {
+    return(message);
+  }
+
+  @Override
+  public Object parse(JavaSparkContext jsc, Config config) {
     return("Hello World!");
   }
 }

--- a/job-server-tests/src/spark.jobserver/LongPiJob.scala
+++ b/job-server-tests/src/spark.jobserver/LongPiJob.scala
@@ -23,16 +23,17 @@ object LongPiJob extends SparkJob {
   def main(args: Array[String]) {
     val sc = new SparkContext("local[4]", "LongPiJob")
     val config = ConfigFactory.parseString("")
-    val results = runJob(sc, config)
-    println("Result is " + results)
+    validate(sc, config)
+      .map(i => runJob(sc, i))
+      .foreach(results => println(s"Result is $results"))
   }
 
-  override def validate(sc: SparkContext, config: Config): SparkJobValidation = {
-    SparkJobValid
+  type Tmp = Int
+  override def validate(sc: SparkContext, config: Config): scalaz.Validation[String, Int] = {
+    scalaz.Success(Try(config.getInt("stress.test.longpijob.duration")).getOrElse(5))
   }
 
-  override def runJob(sc: SparkContext, config: Config): Any = {
-    val duration = Try(config.getInt("stress.test.longpijob.duration")).getOrElse(5)
+  override def runJob(sc: SparkContext, duration: Int): Any = {
     var hit:Long = 0
     var total:Long = 0
     val start = now

--- a/job-server-tests/src/spark.jobserver/NoOpJob.scala
+++ b/job-server-tests/src/spark.jobserver/NoOpJob.scala
@@ -10,11 +10,14 @@ object NoOpJob extends SparkJob {
   def main(args: Array[String]) {
     val sc = new SparkContext("local[4]", "NoOpJob")
     val config = ConfigFactory.parseString("")
-    val results = runJob(sc, config)
-    println("Result is " + results)
+    validate(sc, config)
+      .map(i => runJob(sc, i))
+      .foreach(results => println(s"Result is $results"))
   }
 
-  def validate(sc: SparkContext, config: Config): SparkJobValidation = SparkJobValid
+  type Tmp = Unit
+  def validate(sc: SparkContext, config: Config): scalaz.Validation[String, Unit] =
+    scalaz.Success(())
 
-  def runJob(sc: SparkContext, config: Config): Any = 1
+  def runJob(sc: SparkContext, config: Unit): Any = 1
 }

--- a/job-server-tests/src/spark.jobserver/SparkTestJobs.scala
+++ b/job-server-tests/src/spark.jobserver/SparkTestJobs.scala
@@ -4,13 +4,14 @@ import com.typesafe.config.Config
 import org.apache.spark._
 import org.apache.spark.rdd.RDD
 
-
 trait SparkTestJob extends SparkJob {
-  def validate(sc: SparkContext, config: Config): SparkJobValidation = SparkJobValid
+  type Tmp = Config
+  override def validate(sc: SparkContext, config: Config): scalaz.Validation[String, Config] =
+    scalaz.Success(config)
 }
 
 class MyErrorJob extends SparkTestJob {
-  def runJob(sc: SparkContext, config: Config): Any = {
+  override def runJob(sc: SparkContext, config: Config): Any = {
     throw new IllegalArgumentException("Foobar")
   }
 }

--- a/job-server-tests/src/spark.jobserver/VeryShortDoubleJob.scala
+++ b/job-server-tests/src/spark.jobserver/VeryShortDoubleJob.scala
@@ -8,20 +8,20 @@ import org.apache.spark._
  * Small data. Double every value in the data.
  */
 object VeryShortDoubleJob extends SparkJob {
-  private val data = Array(1, 2, 3)
-
   def main(args: Array[String]) {
     val sc = new SparkContext("local[4]", "VeryShortDoubleJob")
     val config = ConfigFactory.parseString("")
-    val results = runJob(sc, config)
-    println("Result is " + results)
+    validate(sc, config)
+      .map(i => runJob(sc, i))
+      .foreach(results => println(s"Result is $results"))
   }
 
-  override def validate(sc: SparkContext, config: Config): SparkJobValidation = {
-    SparkJobValid
+  type Tmp = Array[Double]
+  override def validate(sc: SparkContext, config: Config): scalaz.Validation[String, Array[Double]] = {
+    scalaz.Success(Array(1, 2, 3))
   }
 
-  override def runJob(sc: SparkContext, config: Config): Any = {
+  override def runJob(sc: SparkContext, data: Array[Double]): Any = {
     val dd = sc.parallelize(data)
     dd.map( _ * 2 ).collect()
   }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -57,7 +57,9 @@ object JobServerBuild extends Build {
 
   lazy val jobServerApi = Project(id = "job-server-api",
                                   base = file("job-server-api"),
-                                  settings = commonSettings ++ publishSettings)
+                                  settings = commonSettings ++ publishSettings ++ Seq(
+                                    libraryDependencies += scalazDeps
+                                  ))
 
   lazy val jobServerExtras = Project(id = "job-server-extras",
                                      base = file("job-server-extras"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,6 +11,7 @@ object Dependencies {
 
   lazy val typeSafeConfigDeps = "com.typesafe" % "config" % "1.2.1"
   lazy val yammerDeps = "com.yammer.metrics" % "metrics-core" % "2.2.0"
+  lazy val scalazDeps = "org.scalaz" %% "scalaz-core" % "7.1.5"
 
   lazy val yodaDeps = Seq(
     "org.joda" % "joda-convert" % "1.2",


### PR DESCRIPTION
Upsides:
- No code duplication of request parsing
- Forces better coding style, no more validation all over the place

Downsides:
- Breaks API
- `type Tmp = ...` required (can't use generics because of how job classes are loaded)

Things to consider:
- Use `util.Try` instead of `scalaz.Validation`

Bugs:
- somehow the Java API doesn't compile with

```
[error] spark-jobserver/job-server-tests/src/main/java/spark.jobserver/JavaHelloWorldJob.java:7: error: JavaHelloWorldJob is not abstract and does not override abstract method validate(Object,Config) in SparkJobBase
[error] public class JavaHelloWorldJob extends JavaSparkJob {
[error]        ^
```