### PR TITLE
Fix config collision in spark master provider

### DIFF
--- a/job-server/src/spark.jobserver/util/SparkMasterProvider.scala
+++ b/job-server/src/spark.jobserver/util/SparkMasterProvider.scala
@@ -18,11 +18,11 @@ trait SparkMasterProvider {
 
 object SparkMasterProvider {
   val logger = LoggerFactory.getLogger(getClass)
-  val SparkMasterProperty = "spark.ha.provider"
+  val SparkMasterProperty = "spark.master-provider"
 
   /**
    * Will look for an Object with the name provided in the Config file and return it
-   * or the DefaultSparkMasterProvider if no spark.ha.provider was specified
+   * or the DefaultSparkMasterProvider if no spark.master-provider was specified
    * @param config SparkJobserver Config
    * @return A SparkMasterProvider
    */

--- a/job-server/src/spark.jobserver/util/SparkMasterProvider.scala
+++ b/job-server/src/spark.jobserver/util/SparkMasterProvider.scala
@@ -18,11 +18,11 @@ trait SparkMasterProvider {
 
 object SparkMasterProvider {
   val logger = LoggerFactory.getLogger(getClass)
-  val SparkMasterProperty = "spark.master.provider"
+  val SparkMasterProperty = "spark.ha.provider"
 
   /**
    * Will look for an Object with the name provided in the Config file and return it
-   * or the DefaultSparkMasterProvider if no spark.master.provider was specified
+   * or the DefaultSparkMasterProvider if no spark.ha.provider was specified
    * @param config SparkJobserver Config
    * @return A SparkMasterProvider
    */

--- a/job-server/test/spark.jobserver/util/SparkMasterProviderSpec.scala
+++ b/job-server/test/spark.jobserver/util/SparkMasterProviderSpec.scala
@@ -41,7 +41,7 @@ class SparkMasterProviderSpec extends FunSpec with Matchers {
       intercept[Exception] {
         val config = ConfigFactory.parseMap(Map(
           "spark.home" -> "/etc/spark",
-          "spark.master.provider" -> "not.exists.provider"
+          "spark.ha.provider" -> "not.exists.provider"
         ).asJava)
         val sparkConf = getSparkConf(config)
       }

--- a/job-server/test/spark.jobserver/util/SparkMasterProviderSpec.scala
+++ b/job-server/test/spark.jobserver/util/SparkMasterProviderSpec.scala
@@ -41,7 +41,7 @@ class SparkMasterProviderSpec extends FunSpec with Matchers {
       intercept[Exception] {
         val config = ConfigFactory.parseMap(Map(
           "spark.home" -> "/etc/spark",
-          "spark.ha.provider" -> "not.exists.provider"
+          "spark.master-provider" -> "not.exists.provider"
         ).asJava)
         val sparkConf = getSparkConf(config)
       }


### PR DESCRIPTION
Currently spark master provider configuration property is
spark.master.provider, which is colliding with spark.master which is
used for spark master URL.