### PR TITLE
Update EMR.md to use SCALA_VERSION 2.10.5

### DIFF
--- a/doc/EMR.md
+++ b/doc/EMR.md
@@ -70,7 +70,7 @@ InstanceCount=10,BidPrice=2.99,Name=sparkSlave,InstanceGroupType=CORE,InstanceTy
  SPARK_CONF_DIR=/etc/spark/conf
  HADOOP_CONF_DIR=/etc/hadoop/conf
  YARN_CONF_DIR=/etc/hadoop/conf
- SCALA_VERSION=2.10.4
+ SCALA_VERSION=2.10.5
  ```
 
 6. Create config/emr.conf


### PR DESCRIPTION
Spark-1.6.0 uses Scala 2.10.5
https://github.com/apache/spark/blob/branch-1.6/pom.xml#L166
SJS on EMR should be in sync with Spark