### PR TITLE
Update Dependencies to use scala-library 2.10.5

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,7 +40,7 @@ object Dependencies {
   )
 
   lazy val scalaLib = if (scala.util.Properties.versionString.split(" ")(1).startsWith("2.10"))
-      Seq("org.scala-lang" % "scala-library" % "2.10.3")
+      Seq("org.scala-lang" % "scala-library" % "2.10.5")
     else Seq()
 
   lazy val sparkExtraDeps = Seq(


### PR DESCRIPTION
Spark-1.6.0 uses Scala 2.10.5
https://github.com/apache/spark/blob/branch-1.6/pom.xml#L166
Dependencies should be in sync with Spark