### PR TITLE
Redirect /dev/null to stdin in server_start.sh

### DIFF
--- a/bin/server_start.sh
+++ b/bin/server_start.sh
@@ -48,7 +48,7 @@ cmd='$SPARK_HOME/bin/spark-submit --class $MAIN --driver-memory $JOBSERVER_MEMOR
   --driver-java-options "$GC_OPTS $JAVA_OPTS $LOGGING_OPTS $CONFIG_OVERRIDES"
   $@ $appdir/spark-job-server.jar $conffile'
 if [ -z "$JOBSERVER_FG" ]; then
-  eval $cmd 2>&1 &
+  eval $cmd > /dev/null 2>&1 < /dev/null &
   echo $! > $PIDFILE
 else
   eval $cmd


### PR DESCRIPTION
Currently server_start.sh hang at the end if run it inside another script via ssh
if we run cmd on background we need to redirect /dev/null to stdin

Redirecting /dev/null to stdin will give an immediate EOF to any read call from that process. This is typically useful to detach a process from a tty (such a process is called a daemon). For example, when starting a background process remotely over ssh, you must redirect stdin to prevent the process waiting for local input.

Another reason to redirect to /dev/null is to prevent an unused file descriptor being created for stdin. This can minimize the total open file handles when you have many long running processes.