### PR TITLE
Allow larger job results to be returned by default

### DIFF
--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -29,6 +29,12 @@ Then simply restart the job server.
 
 Note that the idle-timeout must be higher than request-timeout, or Spray and the job server won't start.
 
+## Timeout getting large job results
+
+If your job returns a large job result, it may exceed Akka's maximum network message frame size, in which case the result is dropped and you may get a network timeout.  Change the following configuration, which defaults to 10 MB:
+
+    akka.remote.netty.tcp.maximum-frame-size = 100 MiB
+
 ## AskTimeout when starting job server or contexts
 
 If you are loading large jars or dependent jars, either at startup or when creating a large context, the database such as H2 may take a really long time to write those bytes to disk.  You need to adjust the context timeout setting:

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -31,7 +31,7 @@ Note that the idle-timeout must be higher than request-timeout, or Spray and the
 
 ## Timeout getting large job results
 
-If your job returns a large job result, it may exceed Akka's maximum network message frame size, in which case the result is dropped and you may get a network timeout.  Change the following configuration, which defaults to 10 MB:
+If your job returns a large job result, it may exceed Akka's maximum network message frame size, in which case the result is dropped and you may get a network timeout.  Change the following configuration, which defaults to 10 MiB:
 
     akka.remote.netty.tcp.maximum-frame-size = 100 MiB
 

--- a/job-server/config/local.conf.template
+++ b/job-server/config/local.conf.template
@@ -57,3 +57,10 @@ spark {
 
 # Note that you can use this file to define settings not only for job server,
 # but for your Spark jobs as well.  Spark job configuration merges with this configuration file as defaults.
+
+akka {
+  remote.netty.tcp {
+    # This controls the maximum message size, including job results, that can be sent
+    # maximum-frame-size = 10 MiB
+  }
+}

--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -149,7 +149,8 @@ akka {
       port = 0
       send-buffer-size = 512000b
       receive-buffer-size = 512000b
-      maximum-frame-size = 256000b
+      # This controls the maximum message size, including job results, that can be sent
+      maximum-frame-size = 10 MiB
     }
   }
 

--- a/job-server/test/spark.jobserver/auth/WebApiWithAuthenticationSpec.scala
+++ b/job-server/test/spark.jobserver/auth/WebApiWithAuthenticationSpec.scala
@@ -52,7 +52,9 @@ class WebApiWithAuthenticationSpec extends FunSpec with Matchers with BeforeAndA
   private val dummyActor = system.actorOf(Props(classOf[DummyActor], this))
 
   private def routesWithTimeout(authTimeout: String): Route = {
-    val api = new WebApi(system, config.withValue("shiro.authentication-timeout", ConfigValueFactory.fromAnyRef(authTimeout)), dummyPort, dummyActor, dummyActor, dummyActor, dummyActor) {
+    val testConfig = config.withValue("shiro.authentication-timeout",
+                                      ConfigValueFactory.fromAnyRef(authTimeout))
+    val api = new WebApi(system, testConfig, dummyPort, dummyActor, dummyActor, dummyActor, dummyActor) {
       override def initSecurityManager() {
 
         val ini = {


### PR DESCRIPTION
See #147 for more details.  Basically this allows larger job results to be returned by default.  It is a short term solution;  the longer term solution would be to chunk and pre-serialize the result.   pre-serializing might be a good solution for storing results in a database anyhow.