### PR TITLE
NamedObjects: cache with references to named objects must be a singleton

### DIFF
--- a/job-server-extras/src/spark.jobserver/NamedObjectsTestJob.scala
+++ b/job-server-extras/src/spark.jobserver/NamedObjectsTestJob.scala
@@ -1,0 +1,54 @@
+package spark.jobserver
+
+import com.typesafe.config.Config
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{ SQLContext, Row, DataFrame }
+
+/**
+ * A test job that accepts a SQLContext, as opposed to the regular SparkContext.
+ * Just initializes some dummy data into a table.
+ */
+class NamedObjectsTestJob extends SparkJob with NamedObjectSupport {
+  import NamedObjectsTestJobConfig._
+  implicit def rddPersister: NamedObjectPersister[NamedRDD[Row]] = new RDDPersister[Row]
+  implicit def dataFramePersister: NamedObjectPersister[NamedDataFrame] = new DataFramePersister
+
+  def validate(sql: SparkContext, config: Config): SparkJobValidation = SparkJobValid
+
+  private def rows(sc: SparkContext): RDD[Row] = {
+    sc.parallelize(List(Row(1, true), Row(2, false), Row(55, true)))
+  }
+
+  def runJob(sc: SparkContext, config: Config): Array[String] = {
+    if (config.hasPath(CREATE_DF) && config.getBoolean(CREATE_DF)) {
+      val sqlContext = new SQLContext(sc)
+      val struct = StructType(
+        StructField("i", IntegerType, true) ::
+          StructField("b", BooleanType, false) :: Nil)
+      val df = sqlContext.createDataFrame(rows(sc), struct)
+      namedObjects.update("df1", NamedDataFrame(df, true, StorageLevel.MEMORY_AND_DISK))
+    }
+    if (config.hasPath(CREATE_RDD) && config.getBoolean(CREATE_RDD)) {
+      namedObjects.update("rdd1", NamedRDD(rows(sc), true, StorageLevel.MEMORY_ONLY))
+    }
+
+    if (config.hasPath(DELETE)) {
+      val iter = config.getStringList(DELETE).iterator
+      while (iter.hasNext) {
+        namedObjects.forget(iter.next)
+      }
+    }
+
+    namedObjects.getNames().toArray
+  }
+}
+
+object NamedObjectsTestJobConfig {
+  val CREATE_DF = "createDF"
+  val CREATE_RDD = "createRDD"
+  val DELETE = "delete"
+}
+

--- a/job-server-extras/test/spark.jobserver/NamedObjectsJobSpec.scala
+++ b/job-server-extras/test/spark.jobserver/NamedObjectsJobSpec.scala
@@ -10,42 +10,50 @@ import collection.JavaConversions._
 
 class NamedObjectsJobSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
 
-  private val emptyConfig = ConfigFactory.parseString("spark.jobserver.named-object-creation-timeout = 60 s")
+  //private val emptyConfig = ConfigFactory.parseString("spark.jobserver.named-object-creation-timeout = 60 s")
 
   before {
     dao = new InMemoryDAO
     daoActor = system.actorOf(JobDAOActor.props(dao))
     manager = system.actorOf(JobManagerActor.props(JobManagerSpec.getContextConfig(adhoc = false)))
     supervisor = TestProbe().ref
+
+    manager ! JobManagerActor.Initialize(daoActor, None)
+    
+    expectMsgClass(classOf[JobManagerActor.Initialized])
+
+    uploadTestJar()
+
   }
 
   val jobName = "spark.jobserver.NamedObjectsTestJob"
 
+  private def getCreateConfig(createDF: Boolean, createRDD: Boolean) : Config = {
+    ConfigFactory.parseString("spark.jobserver.named-object-creation-timeout = 60 s, " + 
+        NamedObjectsTestJobConfig.CREATE_DF + " = " + createDF + ", " +
+        NamedObjectsTestJobConfig.CREATE_RDD + " = " + createRDD)
+  }
+  
+  private def getDeleteConfig(names: List[String]) : Config = {
+    ConfigFactory.parseString("spark.jobserver.named-object-creation-timeout = 60 s, " + 
+        NamedObjectsTestJobConfig.DELETE+" = [" + names.mkString(", ") + "]")
+  }
+  
   describe("NamedObjects (RDD)") {
     it("should survive from one job to another one") {
 
-      manager ! JobManagerActor.Initialize(daoActor, None)
-      expectMsgClass(classOf[JobManagerActor.Initialized])
-
-      uploadTestJar()
-      manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.CREATE_DF, ConfigValueFactory.fromAnyRef(false))
-        .withValue(NamedObjectsTestJobConfig.CREATE_RDD, ConfigValueFactory.fromAnyRef(true)),
-        errorEvents ++ syncEvents)
+      manager ! JobManagerActor.StartJob("demo", jobName, getCreateConfig(false, true), errorEvents ++ syncEvents)
       val JobResult(_, names: Array[String]) = expectMsgClass(classOf[JobResult])
       names should contain("rdd1")
 
-      manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.CREATE_DF, ConfigValueFactory.fromAnyRef(false))
-        .withValue(NamedObjectsTestJobConfig.CREATE_RDD, ConfigValueFactory.fromAnyRef(false)),
-        errorEvents ++ syncEvents)
+      manager ! JobManagerActor.StartJob("demo", jobName, getCreateConfig(false, false), errorEvents ++ syncEvents)
       val JobResult(_, names2: Array[String]) = expectMsgClass(classOf[JobResult])
 
       names2 should contain("rdd1")
       names2 should not contain("df1")
 
       //clean-up
-      manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.DELETE, ConfigValueFactory.fromIterable(List("rdd1")))
-        .withValue(NamedObjectsTestJobConfig.CREATE_RDD, ConfigValueFactory.fromAnyRef(false)),
-        errorEvents ++ syncEvents)
+      manager ! JobManagerActor.StartJob("demo", jobName, getDeleteConfig(List("rdd1")), errorEvents ++ syncEvents)
       val JobResult(_, names3: Array[String]) = expectMsgClass(classOf[JobResult])
 
       names3 should not contain("rdd1")
@@ -55,57 +63,39 @@ class NamedObjectsJobSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
 
   describe("NamedObjects (DataFrame)") {
     it("should survive from one job to another one") {
-      manager ! JobManagerActor.Initialize(daoActor, None)
-      expectMsgClass(classOf[JobManagerActor.Initialized])
 
-      uploadTestJar()
-      manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.CREATE_DF, ConfigValueFactory.fromAnyRef(true))
-        .withValue(NamedObjectsTestJobConfig.CREATE_RDD, ConfigValueFactory.fromAnyRef(false)),
-        errorEvents ++ syncEvents)
+      manager ! JobManagerActor.StartJob("demo", jobName, getCreateConfig(true, false), errorEvents ++ syncEvents)
       val JobResult(_, names: Array[String]) = expectMsgClass(classOf[JobResult])
 
       names should contain("df1")
 
-      manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.CREATE_DF, ConfigValueFactory.fromAnyRef(false))
-        .withValue(NamedObjectsTestJobConfig.CREATE_RDD, ConfigValueFactory.fromAnyRef(false)),
-        errorEvents ++ syncEvents)
+      manager ! JobManagerActor.StartJob("demo", jobName, getCreateConfig(false, false), errorEvents ++ syncEvents)
       val JobResult(_, names2: Array[String]) = expectMsgClass(classOf[JobResult])
 
       names2 should equal(names)
       
       //clean-up
-      manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.DELETE, 
-          ConfigValueFactory.fromIterable(List("df1"))),
-        errorEvents ++ syncEvents)
+      manager ! JobManagerActor.StartJob("demo", jobName, getDeleteConfig(List("df1")), errorEvents ++ syncEvents)
       val JobResult(_, names3: Array[String]) = expectMsgClass(classOf[JobResult])
     }
   }
 
   describe("NamedObjects (DataFrame + RDD)") {
     it("should survive from one job to another one") {
-      manager ! JobManagerActor.Initialize(daoActor, None)
-      expectMsgClass(classOf[JobManagerActor.Initialized])
 
-      uploadTestJar()
-      manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.CREATE_DF, ConfigValueFactory.fromAnyRef(true))
-        .withValue(NamedObjectsTestJobConfig.CREATE_RDD, ConfigValueFactory.fromAnyRef(true)),
-        errorEvents ++ syncEvents)
+      manager ! JobManagerActor.StartJob("demo", jobName, getCreateConfig(true, true), errorEvents ++ syncEvents)
       val JobResult(_, names: Array[String]) = expectMsgClass(classOf[JobResult])
       
       names should contain("rdd1")
       names should contain("df1")
 
-      manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.CREATE_DF, ConfigValueFactory.fromAnyRef(false))
-        .withValue(NamedObjectsTestJobConfig.CREATE_RDD, ConfigValueFactory.fromAnyRef(false)),
-        errorEvents ++ syncEvents)
+      manager ! JobManagerActor.StartJob("demo", jobName, getCreateConfig(false, false), errorEvents ++ syncEvents)
       val JobResult(_, names2: Array[String]) = expectMsgClass(classOf[JobResult])
 
       names2 should equal(names)
       
       //clean-up
-      manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.DELETE,
-          ConfigValueFactory.fromIterable(List("rdd1", "df1"))),
-        errorEvents ++ syncEvents)
+      manager ! JobManagerActor.StartJob("demo", jobName, getDeleteConfig(List("rdd1", "df1")), errorEvents ++ syncEvents)
       val JobResult(_, names3: Array[String]) = expectMsgClass(classOf[JobResult])
     }
   }

--- a/job-server-extras/test/spark.jobserver/NamedObjectsJobSpec.scala
+++ b/job-server-extras/test/spark.jobserver/NamedObjectsJobSpec.scala
@@ -43,7 +43,7 @@ class NamedObjectsJobSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
       names2 should not contain("df1")
 
       //clean-up
-      manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.DELETE, ConfigValueFactory.fromIterable(names.toList))
+      manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.DELETE, ConfigValueFactory.fromIterable(List("rdd1")))
         .withValue(NamedObjectsTestJobConfig.CREATE_RDD, ConfigValueFactory.fromAnyRef(false)),
         errorEvents ++ syncEvents)
       val JobResult(_, names3: Array[String]) = expectMsgClass(classOf[JobResult])
@@ -74,8 +74,8 @@ class NamedObjectsJobSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
       names2 should equal(names)
       
       //clean-up
-      manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.DELETE, ConfigValueFactory.fromIterable(names.toList))
-        .withValue(NamedObjectsTestJobConfig.CREATE_RDD, ConfigValueFactory.fromAnyRef(false)),
+      manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.DELETE, 
+          ConfigValueFactory.fromIterable(List("df1"))),
         errorEvents ++ syncEvents)
       val JobResult(_, names3: Array[String]) = expectMsgClass(classOf[JobResult])
     }
@@ -91,7 +91,9 @@ class NamedObjectsJobSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
         .withValue(NamedObjectsTestJobConfig.CREATE_RDD, ConfigValueFactory.fromAnyRef(true)),
         errorEvents ++ syncEvents)
       val JobResult(_, names: Array[String]) = expectMsgClass(classOf[JobResult])
-      names should equal(Array("rdd1", "df1"))
+      
+      names should contain("rdd1")
+      names should contain("df1")
 
       manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.CREATE_DF, ConfigValueFactory.fromAnyRef(false))
         .withValue(NamedObjectsTestJobConfig.CREATE_RDD, ConfigValueFactory.fromAnyRef(false)),
@@ -99,6 +101,12 @@ class NamedObjectsJobSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
       val JobResult(_, names2: Array[String]) = expectMsgClass(classOf[JobResult])
 
       names2 should equal(names)
+      
+      //clean-up
+      manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.DELETE,
+          ConfigValueFactory.fromIterable(List("rdd1", "df1"))),
+        errorEvents ++ syncEvents)
+      val JobResult(_, names3: Array[String]) = expectMsgClass(classOf[JobResult])
     }
   }
 

--- a/job-server-extras/test/spark.jobserver/NamedObjectsJobSpec.scala
+++ b/job-server-extras/test/spark.jobserver/NamedObjectsJobSpec.scala
@@ -32,14 +32,15 @@ class NamedObjectsJobSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
         .withValue(NamedObjectsTestJobConfig.CREATE_RDD, ConfigValueFactory.fromAnyRef(true)),
         errorEvents ++ syncEvents)
       val JobResult(_, names: Array[String]) = expectMsgClass(classOf[JobResult])
-      names should equal(Array("rdd1"))
+      names should contain("rdd1")
 
       manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.CREATE_DF, ConfigValueFactory.fromAnyRef(false))
         .withValue(NamedObjectsTestJobConfig.CREATE_RDD, ConfigValueFactory.fromAnyRef(false)),
         errorEvents ++ syncEvents)
       val JobResult(_, names2: Array[String]) = expectMsgClass(classOf[JobResult])
 
-      names2 should equal(names)
+      names2 should contain("rdd1")
+      names2 should not contain("df1")
 
       //clean-up
       manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.DELETE, ConfigValueFactory.fromIterable(names.toList))
@@ -47,7 +48,8 @@ class NamedObjectsJobSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
         errorEvents ++ syncEvents)
       val JobResult(_, names3: Array[String]) = expectMsgClass(classOf[JobResult])
 
-      names3.size should equal(0)
+      names3 should not contain("rdd1")
+      names3 should not contain("df1")
     }
   }
 
@@ -61,7 +63,8 @@ class NamedObjectsJobSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
         .withValue(NamedObjectsTestJobConfig.CREATE_RDD, ConfigValueFactory.fromAnyRef(false)),
         errorEvents ++ syncEvents)
       val JobResult(_, names: Array[String]) = expectMsgClass(classOf[JobResult])
-      names should equal(Array("df1"))
+
+      names should contain("df1")
 
       manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.CREATE_DF, ConfigValueFactory.fromAnyRef(false))
         .withValue(NamedObjectsTestJobConfig.CREATE_RDD, ConfigValueFactory.fromAnyRef(false)),
@@ -69,6 +72,12 @@ class NamedObjectsJobSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
       val JobResult(_, names2: Array[String]) = expectMsgClass(classOf[JobResult])
 
       names2 should equal(names)
+      
+      //clean-up
+      manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.DELETE, ConfigValueFactory.fromIterable(names.toList))
+        .withValue(NamedObjectsTestJobConfig.CREATE_RDD, ConfigValueFactory.fromAnyRef(false)),
+        errorEvents ++ syncEvents)
+      val JobResult(_, names3: Array[String]) = expectMsgClass(classOf[JobResult])
     }
   }
 

--- a/job-server-extras/test/spark.jobserver/NamedObjectsJobSpec.scala
+++ b/job-server-extras/test/spark.jobserver/NamedObjectsJobSpec.scala
@@ -1,0 +1,96 @@
+package spark.jobserver
+
+import akka.actor.{ ActorRef, ActorSystem, Props }
+import akka.testkit.{ ImplicitSender, TestKit }
+import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
+import akka.testkit.TestProbe
+import spark.jobserver.CommonMessages.{ JobErroredOut, JobResult }
+import spark.jobserver.io.JobDAOActor
+import collection.JavaConversions._
+
+class NamedObjectsJobSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
+
+  private val emptyConfig = ConfigFactory.parseString("spark.jobserver.named-object-creation-timeout = 60 s")
+
+  before {
+    dao = new InMemoryDAO
+    daoActor = system.actorOf(JobDAOActor.props(dao))
+    manager = system.actorOf(JobManagerActor.props(JobManagerSpec.getContextConfig(adhoc = false)))
+    supervisor = TestProbe().ref
+  }
+
+  val jobName = "spark.jobserver.NamedObjectsTestJob"
+
+  describe("NamedObjects (RDD)") {
+    it("should survive from one job to another one") {
+
+      manager ! JobManagerActor.Initialize(daoActor, None)
+      expectMsgClass(classOf[JobManagerActor.Initialized])
+
+      uploadTestJar()
+      manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.CREATE_DF, ConfigValueFactory.fromAnyRef(false))
+        .withValue(NamedObjectsTestJobConfig.CREATE_RDD, ConfigValueFactory.fromAnyRef(true)),
+        errorEvents ++ syncEvents)
+      val JobResult(_, names: Array[String]) = expectMsgClass(classOf[JobResult])
+      names should equal(Array("rdd1"))
+
+      manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.CREATE_DF, ConfigValueFactory.fromAnyRef(false))
+        .withValue(NamedObjectsTestJobConfig.CREATE_RDD, ConfigValueFactory.fromAnyRef(false)),
+        errorEvents ++ syncEvents)
+      val JobResult(_, names2: Array[String]) = expectMsgClass(classOf[JobResult])
+
+      names2 should equal(names)
+
+      //clean-up
+      manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.DELETE, ConfigValueFactory.fromIterable(names.toList))
+        .withValue(NamedObjectsTestJobConfig.CREATE_RDD, ConfigValueFactory.fromAnyRef(false)),
+        errorEvents ++ syncEvents)
+      val JobResult(_, names3: Array[String]) = expectMsgClass(classOf[JobResult])
+
+      names3.size should equal(0)
+    }
+  }
+
+  describe("NamedObjects (DataFrame)") {
+    it("should survive from one job to another one") {
+      manager ! JobManagerActor.Initialize(daoActor, None)
+      expectMsgClass(classOf[JobManagerActor.Initialized])
+
+      uploadTestJar()
+      manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.CREATE_DF, ConfigValueFactory.fromAnyRef(true))
+        .withValue(NamedObjectsTestJobConfig.CREATE_RDD, ConfigValueFactory.fromAnyRef(false)),
+        errorEvents ++ syncEvents)
+      val JobResult(_, names: Array[String]) = expectMsgClass(classOf[JobResult])
+      names should equal(Array("df1"))
+
+      manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.CREATE_DF, ConfigValueFactory.fromAnyRef(false))
+        .withValue(NamedObjectsTestJobConfig.CREATE_RDD, ConfigValueFactory.fromAnyRef(false)),
+        errorEvents ++ syncEvents)
+      val JobResult(_, names2: Array[String]) = expectMsgClass(classOf[JobResult])
+
+      names2 should equal(names)
+    }
+  }
+
+  describe("NamedObjects (DataFrame + RDD)") {
+    it("should survive from one job to another one") {
+      manager ! JobManagerActor.Initialize(daoActor, None)
+      expectMsgClass(classOf[JobManagerActor.Initialized])
+
+      uploadTestJar()
+      manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.CREATE_DF, ConfigValueFactory.fromAnyRef(true))
+        .withValue(NamedObjectsTestJobConfig.CREATE_RDD, ConfigValueFactory.fromAnyRef(true)),
+        errorEvents ++ syncEvents)
+      val JobResult(_, names: Array[String]) = expectMsgClass(classOf[JobResult])
+      names should equal(Array("rdd1", "df1"))
+
+      manager ! JobManagerActor.StartJob("demo", jobName, emptyConfig.withValue(NamedObjectsTestJobConfig.CREATE_DF, ConfigValueFactory.fromAnyRef(false))
+        .withValue(NamedObjectsTestJobConfig.CREATE_RDD, ConfigValueFactory.fromAnyRef(false)),
+        errorEvents ++ syncEvents)
+      val JobResult(_, names2: Array[String]) = expectMsgClass(classOf[JobResult])
+
+      names2 should equal(names)
+    }
+  }
+
+}

--- a/job-server-extras/test/spark.jobserver/NamedObjectsSpec.scala
+++ b/job-server-extras/test/spark.jobserver/NamedObjectsSpec.scala
@@ -2,7 +2,7 @@ package spark.jobserver
 
 import akka.actor.{ ActorRef, ActorSystem, Props }
 import akka.testkit.{ ImplicitSender, TestKit }
-import org.apache.spark.SparkContext
+import org.apache.spark.{ SparkContext, SparkConf }
 import org.apache.spark.sql.{ SQLContext, Row, DataFrame}
 import org.apache.spark.sql.types._
 import org.apache.spark.rdd.RDD
@@ -16,7 +16,7 @@ import org.scalatest.{ Matchers, FunSpecLike, FunSpec, BeforeAndAfterAll, Before
 class NamedObjectsSpec extends TestKit(ActorSystem("NamedObjectsSpec")) with FunSpecLike
     with ImplicitSender with Matchers with BeforeAndAfter with BeforeAndAfterAll {
   
-  val sc = new SparkContext("local[4]", getClass.getSimpleName)
+  val sc = new SparkContext("local[3]", getClass.getSimpleName, new SparkConf)
   val sqlContext = new SQLContext(sc)
   val namedObjects: NamedObjects = new JobServerNamedObjects(system)
 

--- a/job-server/src/spark.jobserver/JobManagerActor.scala
+++ b/job-server/src/spark.jobserver/JobManagerActor.scala
@@ -95,6 +95,7 @@ class JobManagerActor(contextConfig: Config) extends InstrumentedActor {
   protected var resultActor: ActorRef = _
   private var daoActor: ActorRef = _
 
+  private val jobServerNamedObjects = new JobServerNamedObjects(context.system)
 
   override def postStop() {
     logger.info("Shutting down SparkContext {}", contextName)
@@ -257,7 +258,7 @@ class JobManagerActor(contextConfig: Config) extends InstrumentedActor {
       if (job.isInstanceOf[NamedObjectSupport]) {
         val namedObjects = job.asInstanceOf[NamedObjectSupport].namedObjectsPrivate
         if (namedObjects.get() == null) {
-          namedObjects.compareAndSet(null, new JobServerNamedObjects(context.system))
+          namedObjects.compareAndSet(null, jobServerNamedObjects)
         }
       }
 

--- a/job-server/src/spark.jobserver/JobServerNamedObjects.scala
+++ b/job-server/src/spark.jobserver/JobServerNamedObjects.scala
@@ -18,8 +18,6 @@ import spray.util._
  */
 class JobServerNamedObjects(system: ActorSystem) extends NamedObjects {
 
-  import JobServerNamedObjects._
-
   val logger = LoggerFactory.getLogger(getClass)
 
   implicit val ec: ExecutionContext = system.dispatcher
@@ -31,6 +29,11 @@ class JobServerNamedObjects(system: ActorSystem) extends NamedObjects {
   val defaultTimeout = Timeout(
     config.getDuration("spark.jobserver.named-object-creation-timeout",
       SECONDS), SECONDS)
+
+  // we must store a reference to each NamedObject even though only its ID is used here
+  // this reference prevents the object from being GCed and cleaned by sparks ContextCleaner
+  // or some other GC for other types of objects
+  private val namesToObjects: Cache[NamedObject] = LruCache()
 
   override def getOrElseCreate[O <: NamedObject](name: String, objGen: => O)
                                  (implicit timeout: Timeout = defaultTimeout,
@@ -93,15 +96,5 @@ class JobServerNamedObjects(system: ActorSystem) extends NamedObjects {
       case answer: Iterable[String] @unchecked => answer
     }
   }
-}
 
-/**
- * companion object that hold reference to cache with named object so that we can reference
- * named objects across jobs
- */
-object JobServerNamedObjects {
-  // we must store a reference to each NamedObject even though only its ID is used here
-  // this reference prevents the object from being GCed and cleaned by sparks ContextCleaner
-  // or some other GC for other types of objects
-  val namesToObjects: Cache[NamedObject] = LruCache()
 }

--- a/job-server/test/spark.jobserver/JobWithNamedRddsSpec.scala
+++ b/job-server/test/spark.jobserver/JobWithNamedRddsSpec.scala
@@ -2,7 +2,7 @@ package spark.jobserver
 
 import akka.actor.{ ActorRef, ActorSystem, Props }
 import akka.testkit.{ ImplicitSender, TestKit }
-import org.apache.spark.SparkContext
+import org.apache.spark.{ SparkContext, SparkConf }
 import org.apache.spark.storage.StorageLevel
 import org.scalatest.{ FunSpecLike, FunSpec, BeforeAndAfterAll, BeforeAndAfter }
 import com.typesafe.config.Config
@@ -15,7 +15,7 @@ class JobWithNamedRddsSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
 
   private val emptyConfig = ConfigFactory.parseString("spark.jobserver.named-object-creation-timeout = 60 s")
 
-  val sc = new SparkContext("local[4]", getClass.getSimpleName)
+  val sc = new SparkContext("local[4]", getClass.getSimpleName, new SparkConf)
 
   class TestJob1 extends SparkJob with NamedRddSupport {
     def validate(sc: SparkContext, config: Config): SparkJobValidation = SparkJobValid

--- a/job-server/test/spark.jobserver/LocalContextSupervisorSpec.scala
+++ b/job-server/test/spark.jobserver/LocalContextSupervisorSpec.scala
@@ -20,6 +20,7 @@ object LocalContextSupervisorSpec {
       jobserver.job-result-cache-size = 100
       jobserver.context-creation-timeout = 5 s
       jobserver.yarn-context-creation-timeout = 40 s
+      jobserver.named-object-creation-timeout = 60 s
       contexts {
         olap-demo {
           num-cpu-cores = 4

--- a/job-server/test/spark.jobserver/NamedObjectsRDDsOnlySpec.scala
+++ b/job-server/test/spark.jobserver/NamedObjectsRDDsOnlySpec.scala
@@ -2,7 +2,7 @@ package spark.jobserver
 
 import akka.actor.{ ActorRef, ActorSystem, Props }
 import akka.testkit.{ ImplicitSender, TestKit }
-import org.apache.spark.SparkContext
+import org.apache.spark.{ SparkContext, SparkConf }
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
 import org.scalatest.{ Matchers, FunSpecLike, FunSpec, BeforeAndAfterAll, BeforeAndAfter }
@@ -14,7 +14,7 @@ import org.scalatest.{ Matchers, FunSpecLike, FunSpec, BeforeAndAfterAll, Before
 class NamedObjectsRDDsOnlySpec extends TestKit(ActorSystem("NamedObjectsSpec")) with FunSpecLike
     with ImplicitSender with Matchers with BeforeAndAfter with BeforeAndAfterAll {
   
-  val sc = new SparkContext("local[4]", getClass.getSimpleName)
+  val sc = new SparkContext("local[2]", getClass.getSimpleName, new SparkConf)
   val namedObjects: NamedObjects = new JobServerNamedObjects(system)
 
   implicit def rddPersister[T] = new RDDPersister[T]


### PR DESCRIPTION
Fixes problem that references to named objects were lost inbetween jobs.

Sorry about the delay infixing this !