### PR TITLE
Added ability to add to Spark's Hadoop configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,14 @@ To pass settings directly to the sparkConf that do not use the "spark." prefix "
         }
     }
 
+To add to the underlying Hadoop configuration in a Spark context, add the hadoop section to the context settings
+
+    spark.context-settings {
+        hadoop {
+            mapreduce.framework.name = "Foo"
+        }
+    }
+
 For the exact context configuration parameters, see JobManagerActor docs as well as application.conf.
 
 Also see the [yarn doc](doc/yarn.md) for more tips.

--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -127,6 +127,11 @@ spark {
     passthrough {
       spark.driver.allowMultipleContexts = true  # Ignore the Multiple context exception related with SPARK-2243
     }
+
+    #This adds configuration to the underlying Hadoop configuration in the Spark Context
+    #hadoop {
+    #  mapreduce.framework.name = "FooFramework"
+    #}
   }
 }
 

--- a/job-server/src/spark.jobserver/JobManagerActor.scala
+++ b/job-server/src/spark.jobserver/JobManagerActor.scala
@@ -24,7 +24,7 @@ object JobManagerActor {
   case class StartJob(appName: String, classPath: String, config: Config,
                       subscribedEvents: Set[Class[_]])
   case class KillJob(jobId: String)
-  case object ContextConfig
+  case object GetContextConfig
   case object SparkContextStatus
 
   // Results/Data
@@ -164,10 +164,10 @@ class JobManagerActor(contextConfig: Config) extends InstrumentedActor {
         }
       }
     }
-    case ContextConfig => {
-      if (jobContext.sparkContext == null){
+    case GetContextConfig => {
+      if (jobContext.sparkContext == null) {
         sender ! SparkContextDead
-      }else{
+      } else {
         try {
           val conf: SparkConf = jobContext.sparkContext.getConf
           val hadoopConf: Configuration = jobContext.sparkContext.hadoopConfiguration

--- a/job-server/src/spark.jobserver/context/SparkContextFactory.scala
+++ b/job-server/src/spark.jobserver/context/SparkContextFactory.scala
@@ -50,9 +50,11 @@ class DefaultSparkContextFactory extends SparkContextFactory {
   type C = SparkContext with ContextLike
 
   def makeContext(sparkConf: SparkConf, config: Config,  contextName: String): C = {
-    new SparkContext(sparkConf) with ContextLike {
+    val sc = new SparkContext(sparkConf) with ContextLike {
       def sparkContext: SparkContext = this
       def isValidJob(job: SparkJobBase): Boolean = job.isInstanceOf[SparkJob]
     }
+    for ((k, v) <- SparkJobUtils.getHadoopConfig(config)) sc.hadoopConfiguration.set(k, v)
+    sc
   }
 }

--- a/job-server/src/spark.jobserver/util/SparkJobUtils.scala
+++ b/job-server/src/spark.jobserver/util/SparkJobUtils.scala
@@ -74,6 +74,17 @@ object SparkJobUtils {
   }
 
   /**
+    *
+    * @param config the specific context configuration
+    * @return a map of the hadoop configuration values or an empty Map
+    */
+  def getHadoopConfig(config: Config): Map[String, String] = {
+    Try(config.getConfig("hadoop").entrySet().asScala.map { e =>
+      e.getKey -> e.getValue.unwrapped().toString
+    }.toMap).getOrElse(Map())
+  }
+
+  /**
    * Returns the maximum number of jobs that can run at the same time
    */
   def getMaxRunningJobs(config: Config): Int = {

--- a/job-server/test/spark.jobserver/LocalContextSupervisorSpec.scala
+++ b/job-server/test/spark.jobserver/LocalContextSupervisorSpec.scala
@@ -111,7 +111,7 @@ class LocalContextSupervisorSpec extends TestKit(LocalContextSupervisorSpec.syst
       supervisor ! GetContext("c1")
       expectMsgPF(5 seconds, "I can't find that context :'-(") {
         case (contextActor: ActorRef, resultActor: ActorRef) => {
-          contextActor ! ContextConfig
+          contextActor ! GetContextConfig
           val cc = expectMsgClass(classOf[ContextConfig])
           cc.contextName shouldBe "c1"
           cc.contextConfig.get("spark.ui.enabled") shouldBe "false"

--- a/job-server/test/spark.jobserver/LocalContextSupervisorSpec.scala
+++ b/job-server/test/spark.jobserver/LocalContextSupervisorSpec.scala
@@ -1,10 +1,12 @@
 package spark.jobserver
 
 import akka.actor._
-import akka.testkit.{TestKit, ImplicitSender}
+import akka.testkit.{ImplicitSender, TestKit}
 import com.typesafe.config.ConfigFactory
-import spark.jobserver.io.{JobDAOActor, JobDAO}
-import org.scalatest.{Matchers, FunSpecLike, BeforeAndAfterAll, BeforeAndAfter}
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.SparkConf
+import spark.jobserver.io.{JobDAO, JobDAOActor}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
 
 import scala.concurrent.duration._
 
@@ -35,6 +37,9 @@ object LocalContextSupervisorSpec {
         passthrough {
           spark.driver.allowMultipleContexts = true
           spark.ui.enabled = false
+        }
+        hadoop {
+          mapreduce.framework.name = "ayylmao"
         }
       }
     }
@@ -71,6 +76,7 @@ class LocalContextSupervisorSpec extends TestKit(LocalContextSupervisorSpec.syst
   }
 
   import ContextSupervisor._
+  import JobManagerActor._
 
   describe("context management") {
     it("should list empty contexts at startup") {
@@ -97,6 +103,21 @@ class LocalContextSupervisorSpec extends TestKit(LocalContextSupervisorSpec.syst
       supervisor ! GetResultActor("c1")
       val rActor = expectMsgClass(classOf[ActorRef])
       rActor.path.toString should not include ("global")
+    }
+
+    it("should be able to get context configs") {
+      supervisor ! AddContext("c1", contextConfig)
+      expectMsg(ContextInitialized)
+      supervisor ! GetContext("c1")
+      expectMsgPF(5 seconds, "I can't find that context :'-(") {
+        case (contextActor: ActorRef, resultActor: ActorRef) => {
+          contextActor ! ContextConfig
+          val cc = expectMsgClass(classOf[ContextConfig])
+          cc.contextName shouldBe "c1"
+          cc.contextConfig.get("spark.ui.enabled") shouldBe "false"
+          cc.hadoopConfig.get("mapreduce.framework.name") shouldBe "ayylmao"
+        }
+      }
     }
 
     it("should be able to stop contexts already running") {


### PR DESCRIPTION
I wanted to be able to add things to the Spark Hadoop configuration, specifically things like the shuffle manager and ParquetOutputCommitter which require you to set them via the hadoop configuration.

I added the ability to be able to add to the spark context's hadoop configuration. I think I may have to add this to the extras-api stuff too.