### PR TITLE
Added support for chunked encoding when job result is a Stream[Byte]

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,7 +621,10 @@ serialized properly:
 - Anything that implements Product (Option, case classes) -- they will be serialized as lists
 - Maps and Seqs may contain nested values of any of the above
 - If a job result is of scala's Stream[Byte] type it will be serialised directly as a chunk encoded stream.
-  This is useful if your job result payload is large and may cause a timeout serialising as objects.
+  This is useful if your job result payload is large and may cause a timeout serialising as objects. Beware, this
+  will not currently work as desired with context-per-jvm=true configuration, since it would require serialising
+  Stream[_] blob between processes. For now use Stream[_] job results in context-per-jvm=false configuration, pending
+  potential future enhancements to support this in context-per-jvm=true mode.
 
 If we encounter a data type that is not supported, then the entire result will be serialized to a string.
 

--- a/README.md
+++ b/README.md
@@ -620,6 +620,8 @@ serialized properly:
 - Array's
 - Anything that implements Product (Option, case classes) -- they will be serialized as lists
 - Maps and Seqs may contain nested values of any of the above
+- If a job result is of scala's Stream[Byte] type it will be serialised directly as a chunk encoded stream.
+  This is useful if your job result payload is large and may cause a timeout serialising as objects.
 
 If we encounter a data type that is not supported, then the entire result will be serialized to a string.
 

--- a/job-server/config/local.conf.template
+++ b/job-server/config/local.conf.template
@@ -22,6 +22,9 @@ spark {
     filedao {
       rootdir = /tmp/spark-job-server/filedao/data
     }
+
+    # When using chunked transfer encoding with scala Stream job results, this is the size of each chunk
+    result-chunk-size = 1m
   }
 
   # predefined Spark contexts

--- a/job-server/src/spark.jobserver/ChunkEncodedStreamingSupport.scala
+++ b/job-server/src/spark.jobserver/ChunkEncodedStreamingSupport.scala
@@ -1,0 +1,18 @@
+package spark.jobserver
+
+import akka.actor.Props
+import spray.routing.{HttpService, RequestContext}
+
+trait ChunkEncodedStreamingSupport {
+  this: HttpService =>
+
+  protected def sendStreamingResponse(ctx: RequestContext,
+                                    chunkSize: Int,
+                                    byteIterator: Iterator[_]): Unit = {
+    actorRefFactory.actorOf {
+      Props {
+        new ChunkEncodingActor(ctx, chunkSize, byteIterator)
+      }
+    }
+  }
+}

--- a/job-server/src/spark.jobserver/ChunkEncodingActor.scala
+++ b/job-server/src/spark.jobserver/ChunkEncodingActor.scala
@@ -1,0 +1,48 @@
+package spark.jobserver
+
+import akka.actor.{Actor, ActorLogging}
+import spark.jobserver.ChunkEncodingActor.Ok
+import spray.can.Http
+import spray.http._
+import spray.routing.RequestContext
+
+object ChunkEncodingActor {
+  // simple case class whose instances we use as send confirmation message for streaming chunks
+  case class Ok(remaining: Iterator[_])
+}
+
+/**
+  * Performs sending back a response in streaming fashion using chunk encoding
+  * @param ctx RequestContext which has the responder to send chunks to
+  * @param chunkSize The size of each chunk
+  * @param byteIterator Iterator of data to stream back (currently only Byte is supported)
+  */
+class ChunkEncodingActor(ctx: RequestContext,
+                         chunkSize: Int,
+                         byteIterator: Iterator[_]) extends Actor with ActorLogging {
+  // we use the successful sending of a chunk as trigger for sending the next chunk
+  ctx.responder ! ChunkedResponseStart(
+    HttpResponse(entity = HttpEntity(MediaTypes.`application/json`,
+      byteIterator.take(chunkSize).map {
+        case c: Byte => c
+      }.toArray))).withAck(Ok(byteIterator))
+
+  def receive: Receive = {
+    case Ok(remaining) =>
+      val arr = remaining.take(chunkSize).map {
+        case c: Byte => c
+      }.toArray
+      if (arr.nonEmpty) {
+        ctx.responder ! MessageChunk(arr).withAck(Ok(remaining))
+      }
+      else {
+        ctx.responder ! ChunkedMessageEnd
+        context.stop(self)
+      }
+    case ev: Http.ConnectionClosed => {
+      log.warning("Stopping response streaming due to {}", ev)
+      context.stop(self)
+    }
+  }
+}
+

--- a/job-server/src/spark.jobserver/JobManagerActor.scala
+++ b/job-server/src/spark.jobserver/JobManagerActor.scala
@@ -285,6 +285,15 @@ class JobManagerActor(contextConfig: Config) extends InstrumentedActor {
     }(executionContext).andThen {
       case Success(result: Any) =>
         statusActor ! JobFinished(jobId, DateTime.now())
+        // TODO: If the result is Stream[_] and this is running with context-per-jvm=true configuration
+        // serializing a Stream[_] blob across process boundaries is not desirable.
+        // In that scenario an enhancement is required here to chunk stream results back.
+        // Something like ChunkedJobResultStart, ChunkJobResultMessage, and ChunkJobResultEnd messages
+        // might be a better way to send results back and then on the other side use chunked encoding
+        // transfer to send the chunks back. Alternatively the stream could be persisted here to HDFS
+        // and the streamed out of InputStream on the other side.
+        // Either way an enhancement would be required here to make Stream[_] responses work
+        // with context-per-jvm=true configuration
         resultActor ! JobResult(jobId, result)
       case Failure(error: Throwable) =>
         // If and only if job validation fails, JobErroredOut message is dropped silently in JobStatusActor.


### PR DESCRIPTION
If a job result is scala Stream[Byte] it is returned in body using chunk encoding