### PR TITLE
self-reference is now of supertype SparkJobBase

### DIFF
--- a/job-server-api/src/spark.jobserver/NamedObjectSupport.scala
+++ b/job-server-api/src/spark.jobserver/NamedObjectSupport.scala
@@ -138,7 +138,7 @@ trait NamedObjects {
   def getNames(): Iterable[String]
 }
 
-trait NamedObjectSupport { self: SparkJob =>
+trait NamedObjectSupport { self: SparkJobBase =>
 
   // Note: the JobManagerActor sets the correct NamedObjects instance here before before running our job.
   val namedObjectsPrivate: AtomicReference[NamedObjects] =


### PR DESCRIPTION
See #456  
The change was simple. Just exchange for the supertype of SparkJob and SparkSqlJob which is SparkJobBase.

I tested it locally and it seems to work.