### PR TITLE
Add JobId to response of sync Job execution

### DIFF
--- a/job-server/config/docker.conf
+++ b/job-server/config/docker.conf
@@ -14,7 +14,7 @@ spark {
     port = 8090
     jobdao = spark.jobserver.io.JobSqlDAO
 
-    context-per-jvm = true
+    context-per-jvm = false
 
     sqldao {
       # Directory where default H2 driver stores its data. Only needed for H2.

--- a/job-server/src/spark.jobserver/WebApi.scala
+++ b/job-server/src/spark.jobserver/WebApi.scala
@@ -485,13 +485,15 @@ class WebApi(system: ActorSystem,
                       JobManagerActor.StartJob(appName, classPath, jobConfig, events))(timeout)
                     respondWithMediaType(MediaTypes.`application/json`) { ctx =>
                       future.map {
-                        case JobResult(_, res) =>
+                        case JobResult(jobId, res) =>
                           res match {
                             case s: Stream[_] => sendStreamingResponse(ctx, ResultChunkSize,
                               resultToByteIterator(Map.empty, s.toIterator))
-                            case _ => ctx.complete(resultToTable(res))
+                            case _ => ctx.complete(
+                              Map[String, Any]("jobId" -> jobId) ++ resultToTable(res))
                           }
-                        case JobErroredOut(_, _, ex) => ctx.complete(errMap(ex, "ERROR"))
+                        case JobErroredOut(jobId, _, ex) => ctx.complete(
+                              Map[String, String]("jobId" -> jobId) ++ errMap(ex, "ERROR"))
                         case JobStarted(jobId, context, _) =>
                           jobInfo ! StoreJobConfig(jobId, postedJobConfig)
                           ctx.complete(202, Map[String, Any](

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -123,6 +123,7 @@ object JobServerBuild extends Build {
         copy(artifact, artifactTargetPath)
         copy(baseDirectory(_ / "bin" / "server_start.sh").value, file("app/server_start.sh"))
         copy(baseDirectory(_ / "bin" / "server_stop.sh").value, file("app/server_stop.sh"))
+        copy(baseDirectory(_ / "bin" / "manager_start.sh").value, file("app/manager_start.sh"))
         copy(baseDirectory(_ / "bin" / "setenv.sh").value, file("app/setenv.sh"))
         copy(baseDirectory(_ / "config" / "log4j-stdout.properties").value, file("app/log4j-server.properties"))
         copy(baseDirectory(_ / "config" / "docker.conf").value, file("app/docker.conf"))


### PR DESCRIPTION
It would be nice to have the jobid in the response of sync Job execution. We use a message brooker to start jobs and the jobId would help to identifier.

