### PR TITLE
Fix manager_start not found during docker deployment

### DIFF
--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -205,5 +205,5 @@ shiro {
 }
 
 deploy {
-  manager-start-cmd = "./manager_start.sh"
+  manager-start-cmd = "./app/manager_start.sh"
 }


### PR DESCRIPTION
Fixes #477