### PR TITLE
Revert "Fix manager_start not found during docker deployment"

### DIFF
--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -205,5 +205,5 @@ shiro {
 }
 
 deploy {
-  manager-start-cmd = "./app/manager_start.sh"
+  manager-start-cmd = "./manager_start.sh"
 }


### PR DESCRIPTION
This reverts commit 33735ad1a810985b82c65eae3de3f27b77bdb607.