### PR TITLE
fix for flaky-tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,8 @@ database created with necessary rights granted to user.
       }
     }
 
+    flyway.locations="db/postgresql/migration"
+
 It is also important that any dependent jars are to be added to Job Server class path.
 
 ### Chef
@@ -606,7 +608,9 @@ User impersonation for an already Kerberos authenticated user is supported via `
 
   POST /contexts/my-new-context?spark.proxy.user=<user-to-impersonate>
   
-However, whenever the flag `shiro.use-as-proxy-user` is set to `on` (and authentication is `on`) then this parameter is ignored and the name of the authenticated is *always* used as the value of the `spark.proxy.user` parameter when creating contexts. 
+However, whenever the flag `shiro.use-as-proxy-user` is set to `on` (and authentication is `on`) then this parameter 
+is ignored and the name of the authenticated user is *always* used as the value of the `spark.proxy.user` 
+parameter when creating contexts. 
 
 To pass settings directly to the sparkConf that do not use the "spark." prefix "as-is", use the "passthrough" section.
 

--- a/job-server-extras/src/spark.jobserver/NamedObjectsTestJob.scala
+++ b/job-server-extras/src/spark.jobserver/NamedObjectsTestJob.scala
@@ -8,8 +8,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.{ SQLContext, Row, DataFrame }
 
 /**
- * A test job that accepts a SQLContext, as opposed to the regular SparkContext.
- * Just initializes some dummy data into a table.
+ * A test job for named objects
  */
 class NamedObjectsTestJob extends SparkJob with NamedObjectSupport {
   import NamedObjectsTestJobConfig._
@@ -48,6 +47,8 @@ class NamedObjectsTestJob extends SparkJob with NamedObjectSupport {
       }
     }
 
+    //sleep just a bit to allow other threads in
+    Thread.sleep(1)
     namedObjects.getNames().toArray
   }
 }

--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -57,6 +57,7 @@ spark {
 
       # DB connection pool settings
       dbcp {
+        enabled = false
         maxactive = 20
         maxidle = 10
         initialsize = 10

--- a/job-server/src/spark.jobserver/JobManagerActor.scala
+++ b/job-server/src/spark.jobserver/JobManagerActor.scala
@@ -338,9 +338,9 @@ class JobManagerActor(contextConfig: Config) extends InstrumentedActor {
       case _ =>
         // Make sure to decrement the count of running jobs when a job finishes, in both success and failure
         // cases.
+        currentRunningJobs.getAndDecrement()
         resultActor ! Unsubscribe(jobId, subscriber)
         statusActor ! Unsubscribe(jobId, subscriber)
-        currentRunningJobs.getAndDecrement()
         postEachJob()
     }(executionContext)
   }

--- a/job-server/src/spark.jobserver/auth/SJSAuthenticator.scala
+++ b/job-server/src/spark.jobserver/auth/SJSAuthenticator.scala
@@ -1,11 +1,5 @@
 package spark.jobserver.auth
 
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext
-import spray.routing.directives.AuthMagnet
-import spray.routing.authentication.UserPass
-import spray.routing.authentication.BasicAuth
-
 import spray.routing.authentication._
 import spray.routing.directives.AuthMagnet
 

--- a/job-server/src/test/resources/local.test.jobsqldao_dbcp.conf
+++ b/job-server/src/test/resources/local.test.jobsqldao_dbcp.conf
@@ -7,14 +7,14 @@ spark.jobserver {
     rootdir = /tmp/spark-job-server-test/sqldao/data
     # https://coderwall.com/p/a2vnxg
     jdbc {
-      url = "jdbc:h2:mem:jobserver-test;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1"
+      url = "jdbc:h2:mem:jobserver-test-dbcp;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1"
       user = ""
       password = ""
     }
 
     # DB connection pool settings
     dbcp {
-      enabled = false
+      enabled = true
       maxactive = 20
       maxidle = 10
       initialsize = 10

--- a/job-server/test/spark.jobserver/JobManagerActorSpec.scala
+++ b/job-server/test/spark.jobserver/JobManagerActorSpec.scala
@@ -14,6 +14,10 @@ class JobManagerActorSpec extends JobManagerSpec {
     supervisor = TestProbe().ref
   }
 
+  after {
+    ooyala.common.akka.AkkaTestUtils.shutdownAndWait(manager)
+  }
+  
   describe("starting jobs") {
     it("jobs should be able to cache RDDs and retrieve them through getPersistentRDDs") {
       manager ! JobManagerActor.Initialize(daoActor, None)

--- a/job-server/test/spark.jobserver/JobSpecBase.scala
+++ b/job-server/test/spark.jobserver/JobSpecBase.scala
@@ -65,12 +65,9 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
   var supervisor: ActorRef = _
   def extrasJar: java.io.File
 
-  after {
-    ooyala.common.akka.AkkaTestUtils.shutdownAndWait(manager)
-  }
-
   override def afterAll() {
-    ooyala.common.akka.AkkaTestUtils.shutdownAndWait(system)
+    ooyala.common.akka.AkkaTestUtils.shutdownAndWait(manager)
+    TestKit.shutdownActorSystem(system)
   }
 
   protected def uploadJar(dao: JobDAO, jarFilePath: String, appName: String) {

--- a/job-server/test/spark.jobserver/io/JobSqlDAOSpec.scala
+++ b/job-server/test/spark.jobserver/io/JobSqlDAOSpec.scala
@@ -7,8 +7,12 @@ import spark.jobserver.TestJarFinder
 import com.google.common.io.Files
 import java.io.File
 
-class JobSqlDAOSpec extends TestJarFinder with FunSpecLike with Matchers with BeforeAndAfter {
-  private val config = ConfigFactory.load("local.test.jobsqldao.conf")
+abstract class JobSqlDAOSpecBase {
+  def config : Config
+}
+
+class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLike with Matchers with BeforeAndAfter {
+  override def config: Config = ConfigFactory.load("local.test.jobsqldao.conf")
 
   var dao: JobSqlDAO = _
 
@@ -260,4 +264,8 @@ class JobSqlDAOSpec extends TestJarFinder with FunSpecLike with Matchers with Be
       jobs4.last.error.get.getMessage should equal (throwable.getMessage)
     }
   }
+}
+
+class JobSqlDAODBCPSpec extends JobSqlDAOSpec {
+  override def config: Config = ConfigFactory.load("local.test.jobsqldao_dbcp.conf")
 }


### PR DESCRIPTION
@noorul @hntd187 I just set up this branch to address the flacky test.

The latest failure on master is caused by too few job slots: 
java.lang.AssertionError: assertion failed: expected class spark.jobserver.CommonMessages$JobResult, found class spark.jobserver.CommonMessages$NoJobSlotsAvailable

I think that can be easily fixed. 

The other issues reported by @hntd187 are:
The tests in spark.jobserver.auth.WebApiWithAuthenticationSpec fail sometimes for no obvious reason. Given how they are written it seems really strange they fail, but one is ignored and the other 2 are not. Could we make a decision on whether or not these tests should remain or set to ignore for the time being? They seem to cover a rather edge case situation. 