### PR TITLE
Make dbcp optional

### DIFF
--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -57,6 +57,7 @@ spark {
 
       # DB connection pool settings
       dbcp {
+        enabled = false
         maxactive = 20
         maxidle = 10
         initialsize = 10

--- a/job-server/src/test/resources/local.test.jobsqldao_dbcp.conf
+++ b/job-server/src/test/resources/local.test.jobsqldao_dbcp.conf
@@ -7,14 +7,14 @@ spark.jobserver {
     rootdir = /tmp/spark-job-server-test/sqldao/data
     # https://coderwall.com/p/a2vnxg
     jdbc {
-      url = "jdbc:h2:mem:jobserver-test;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1"
+      url = "jdbc:h2:mem:jobserver-test-dbcp;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1"
       user = ""
       password = ""
     }
 
     # DB connection pool settings
     dbcp {
-      enabled = false
+      enabled = true
       maxactive = 20
       maxidle = 10
       initialsize = 10

--- a/job-server/test/spark.jobserver/io/JobSqlDAOSpec.scala
+++ b/job-server/test/spark.jobserver/io/JobSqlDAOSpec.scala
@@ -7,8 +7,12 @@ import spark.jobserver.TestJarFinder
 import com.google.common.io.Files
 import java.io.File
 
-class JobSqlDAOSpec extends TestJarFinder with FunSpecLike with Matchers with BeforeAndAfter {
-  var config = ConfigFactory.load("local.test.jobsqldao.conf")
+abstract class JobSqlDAOSpecBase {
+  def config : Config
+}
+
+class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLike with Matchers with BeforeAndAfter {
+  override def config: Config = ConfigFactory.load("local.test.jobsqldao.conf")
 
   var dao: JobSqlDAO = _
 
@@ -263,5 +267,5 @@ class JobSqlDAOSpec extends TestJarFinder with FunSpecLike with Matchers with Be
 }
 
 class JobSqlDAODBCPSpec extends JobSqlDAOSpec {
-  config = ConfigFactory.load("local.test.jobsqldao_dbcp.conf")
+  override def config: Config = ConfigFactory.load("local.test.jobsqldao.conf")
 }

--- a/job-server/test/spark.jobserver/io/JobSqlDAOSpec.scala
+++ b/job-server/test/spark.jobserver/io/JobSqlDAOSpec.scala
@@ -267,5 +267,5 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
 }
 
 class JobSqlDAODBCPSpec extends JobSqlDAOSpec {
-  override def config: Config = ConfigFactory.load("local.test.jobsqldao.conf")
+  override def config: Config = ConfigFactory.load("local.test.jobsqldao_dbcp.conf")
 }

--- a/job-server/test/spark.jobserver/io/JobSqlDAOSpec.scala
+++ b/job-server/test/spark.jobserver/io/JobSqlDAOSpec.scala
@@ -8,7 +8,7 @@ import com.google.common.io.Files
 import java.io.File
 
 class JobSqlDAOSpec extends TestJarFinder with FunSpecLike with Matchers with BeforeAndAfter {
-  private val config = ConfigFactory.load("local.test.jobsqldao.conf")
+  var config = ConfigFactory.load("local.test.jobsqldao.conf")
 
   var dao: JobSqlDAO = _
 
@@ -260,4 +260,8 @@ class JobSqlDAOSpec extends TestJarFinder with FunSpecLike with Matchers with Be
       jobs4.last.error.get.getMessage should equal (throwable.getMessage)
     }
   }
+}
+
+class JobSqlDAODBCPSpec extends JobSqlDAOSpec {
+  config = ConfigFactory.load("local.test.jobsqldao_dbcp.conf")
 }


### PR DESCRIPTION
Allow user to enable/disable DBCP. By default it is not required as it
is only useful when there is huge number of database connections
involved. Also in some scenarios like when pgpool is running in front of
PostgreSQL DBCP is creating issues. There is no need for client side
pool in such cases.