### PR TITLE
flaky-tests:

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,7 +608,9 @@ User impersonation for an already Kerberos authenticated user is supported via `
 
   POST /contexts/my-new-context?spark.proxy.user=<user-to-impersonate>
   
-However, whenever the flag `shiro.use-as-proxy-user` is set to `on` (and authentication is `on`) then this parameter is ignored and the name of the authenticated is *always* used as the value of the `spark.proxy.user` parameter when creating contexts. 
+However, whenever the flag `shiro.use-as-proxy-user` is set to `on` (and authentication is `on`) then this parameter 
+is ignored and the name of the authenticated user is *always* used as the value of the `spark.proxy.user` 
+parameter when creating contexts. 
 
 To pass settings directly to the sparkConf that do not use the "spark." prefix "as-is", use the "passthrough" section.
 

--- a/job-server-extras/src/spark.jobserver/NamedObjectsTestJob.scala
+++ b/job-server-extras/src/spark.jobserver/NamedObjectsTestJob.scala
@@ -8,8 +8,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.{ SQLContext, Row, DataFrame }
 
 /**
- * A test job that accepts a SQLContext, as opposed to the regular SparkContext.
- * Just initializes some dummy data into a table.
+ * A test job for named objects
  */
 class NamedObjectsTestJob extends SparkJob with NamedObjectSupport {
   import NamedObjectsTestJobConfig._
@@ -48,6 +47,8 @@ class NamedObjectsTestJob extends SparkJob with NamedObjectSupport {
       }
     }
 
+    //sleep just a bit to allow other threads in
+    Thread.sleep(1)
     namedObjects.getNames().toArray
   }
 }

--- a/job-server/src/spark.jobserver/JobManagerActor.scala
+++ b/job-server/src/spark.jobserver/JobManagerActor.scala
@@ -338,9 +338,9 @@ class JobManagerActor(contextConfig: Config) extends InstrumentedActor {
       case _ =>
         // Make sure to decrement the count of running jobs when a job finishes, in both success and failure
         // cases.
+        currentRunningJobs.getAndDecrement()
         resultActor ! Unsubscribe(jobId, subscriber)
         statusActor ! Unsubscribe(jobId, subscriber)
-        currentRunningJobs.getAndDecrement()
         postEachJob()
     }(executionContext)
   }

--- a/job-server/src/spark.jobserver/auth/SJSAuthenticator.scala
+++ b/job-server/src/spark.jobserver/auth/SJSAuthenticator.scala
@@ -1,11 +1,5 @@
 package spark.jobserver.auth
 
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext
-import spray.routing.directives.AuthMagnet
-import spray.routing.authentication.UserPass
-import spray.routing.authentication.BasicAuth
-
 import spray.routing.authentication._
 import spray.routing.directives.AuthMagnet
 

--- a/job-server/test/spark.jobserver/JobManagerActorSpec.scala
+++ b/job-server/test/spark.jobserver/JobManagerActorSpec.scala
@@ -14,6 +14,10 @@ class JobManagerActorSpec extends JobManagerSpec {
     supervisor = TestProbe().ref
   }
 
+  after {
+    ooyala.common.akka.AkkaTestUtils.shutdownAndWait(manager)
+  }
+  
   describe("starting jobs") {
     it("jobs should be able to cache RDDs and retrieve them through getPersistentRDDs") {
       manager ! JobManagerActor.Initialize(daoActor, None)

--- a/job-server/test/spark.jobserver/JobSpecBase.scala
+++ b/job-server/test/spark.jobserver/JobSpecBase.scala
@@ -65,12 +65,9 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
   var supervisor: ActorRef = _
   def extrasJar: java.io.File
 
-  after {
-    ooyala.common.akka.AkkaTestUtils.shutdownAndWait(manager)
-  }
-
   override def afterAll() {
-    ooyala.common.akka.AkkaTestUtils.shutdownAndWait(system)
+    ooyala.common.akka.AkkaTestUtils.shutdownAndWait(manager)
+    TestKit.shutdownActorSystem(system)
   }
 
   protected def uploadJar(dao: JobDAO, jarFilePath: String, appName: String) {


### PR DESCRIPTION
Fixes for flaky tests reported by @hntd187 and others. 

1. Timeout test in WebApiWithAuthenticationSpec uses a TimeoutException to ensure that an Exception is always thrown.

2.  NamedObjectsSpec only creates its SparkContext when run and only once.

3. NamedObjectsTestJob sleeps 1 ms so that other threads can do their work and release the job resources.

4. HiveContextFactory in HiveJobSpec needs to stop the SparkContext if it fails to create the Hive context. We might want to add this check to 'spark.jobserver.HiveContextFactory' as well, just in case.

5. JobSpecBaseBase.afterAll uses TestKit.shutdownActorSystem(system) instead of the ooyala version. It also only shuts down the manager in afterAll (as opposed to after each method).
