### PR TITLE
Make create job API to return more information

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,11 +170,12 @@ server will create its own SparkContext, and return a job ID for subsequent quer
 
     curl -d "input.string = a b c a b see" 'localhost:8090/jobs?appName=test&classPath=spark.jobserver.WordCountExample'
     {
+      "duration": "Job not done yet",
+      "classPath": "spark.jobserver.LongPiJob",
+      "startTime": "2016-06-19T16:27:12.196+05:30",
+      "context": "b7ea0eb5-spark.jobserver.WordCountExample",
       "status": "STARTED",
-      "result": {
-        "jobId": "5453779a-f004-45fc-a11d-a39dae0f9bf4",
-        "context": "b7ea0eb5-spark.jobserver.WordCountExample"
-      }
+      "jobId": "5453779a-f004-45fc-a11d-a39dae0f9bf4"
     }⏎
 
 NOTE: If you want to feed in a text file config and POST using curl, you want the `--data-binary` option, otherwise

--- a/job-server-extras/test/spark.jobserver/StreamingJobSpec.scala
+++ b/job-server-extras/test/spark.jobserver/StreamingJobSpec.scala
@@ -41,7 +41,7 @@ class StreamingJobSpec extends JobSpecBase(StreamingJobSpec.getNewSystem) {
       manager ! JobManagerActor.StartJob("demo", streamingJob, emptyConfig, asyncEvents ++ errorEvents)
 
       jobId = expectMsgPF(6 seconds, "Did not start StreamingTestJob, expecting JobStarted") {
-        case JobStarted(jobid, _, _) => {
+        case JobStarted(jobid, _) => {
           jobid should not be null
           jobid
         }

--- a/job-server/src/spark.jobserver/CommonMessages.scala
+++ b/job-server/src/spark.jobserver/CommonMessages.scala
@@ -2,6 +2,7 @@ package spark.jobserver
 
 import akka.actor.ActorRef
 import org.joda.time.DateTime
+import spark.jobserver.io.JobInfo
 
 trait StatusMessage {
   val jobId: String
@@ -10,7 +11,7 @@ trait StatusMessage {
 // Messages that are sent and received by multiple actors.
 object CommonMessages {
   // job status messages
-  case class JobStarted(jobId: String, context: String, startTime: DateTime) extends StatusMessage
+  case class JobStarted(jobId: String, jobInfo: JobInfo) extends StatusMessage
   case class JobFinished(jobId: String, endTime: DateTime) extends StatusMessage
   case class JobValidationFailed(jobId: String, endTime: DateTime, err: Throwable) extends StatusMessage
   case class JobErroredOut(jobId: String, endTime: DateTime, err: Throwable) extends StatusMessage

--- a/job-server/src/spark.jobserver/JobManagerActor.scala
+++ b/job-server/src/spark.jobserver/JobManagerActor.scala
@@ -281,7 +281,7 @@ class JobManagerActor(contextConfig: Config) extends InstrumentedActor {
               statusActor ! JobValidationFailed(jobId, DateTime.now(), err)
               throw err
             case Good(jobData) =>
-              statusActor ! JobStarted(jobId: String, contextName, jobInfo.startTime)
+              statusActor ! JobStarted(jobId: String, jobInfo)
               val sc = jobContext.sparkContext
               sc.setJobGroup(jobId, s"Job group for $jobId and spark context ${sc.applicationId}", true)
               job.runJob(jobC, jobEnv, jobData)

--- a/job-server/src/spark.jobserver/JobStatusActor.scala
+++ b/job-server/src/spark.jobserver/JobStatusActor.scala
@@ -76,7 +76,7 @@ class JobStatusActor(jobDao: ActorRef) extends InstrumentedActor with YammerMetr
     case msg: JobStarted =>
       processStatus(msg, "started") {
         case (info, msg) =>
-          info.copy(startTime = msg.startTime)
+          info.copy(startTime = msg.jobInfo.startTime)
       }
 
     case msg: JobFinished =>

--- a/job-server/src/spark.jobserver/WebApi.scala
+++ b/job-server/src/spark.jobserver/WebApi.scala
@@ -86,7 +86,7 @@ object WebApi {
         "stack" -> t.getStackTrace.map(_.toString).toSeq)
     }
 
-  def getJobReport(jobInfo: JobInfo, jobStarted:Boolean = false): Map[String, Any] = {
+  def getJobReport(jobInfo: JobInfo, jobStarted: Boolean = false): Map[String, Any] = {
     val statusMap = if (jobStarted) Map(StatusKey -> "STARTED") else (jobInfo match {
         case JobInfo(_, _, _, _, _, None, _) => Map(StatusKey -> "RUNNING")
         case JobInfo(_, _, _, _, _, _, Some(ex)) => Map(StatusKey -> "ERROR",

--- a/job-server/test/spark.jobserver/JobManagerSpec.scala
+++ b/job-server/test/spark.jobserver/JobManagerSpec.scala
@@ -227,7 +227,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
       uploadTestJar()
       manager ! JobManagerActor.StartJob("demo", classPrefix + "LongPiJob", stringConfig, allEvents)
       expectMsgPF(5.seconds.dilated, "Did not get JobResult") {
-        case JobStarted(id, _, _) =>
+        case JobStarted(id, _) =>
           manager ! KillJob(id)
           expectMsgClass(classOf[JobKilled])
 

--- a/job-server/test/spark.jobserver/JobStatusActorSpec.scala
+++ b/job-server/test/spark.jobserver/JobStatusActorSpec.scala
@@ -64,7 +64,7 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
     it("should be informed JobStarted until it is unsubscribed") {
       actor ! JobInit(jobInfo)
       actor ! Subscribe(jobId, self, Set(classOf[JobStarted]))
-      val msg = JobStarted(jobId, contextName, DateTime.now)
+      val msg = JobStarted(jobId, jobInfo)
       actor ! msg
       expectMsg(msg)
 
@@ -72,7 +72,7 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
       expectMsg(msg)
 
       actor ! Unsubscribe(jobId, self)
-      actor ! JobStarted(jobId, contextName, DateTime.now)
+      actor ! JobStarted(jobId, jobInfo)
       expectNoMsg()   // shouldn't get it again
 
       actor ! Unsubscribe(jobId, self)
@@ -82,7 +82,7 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
     it("should be ok to subscribe beofore job init") {
       actor ! Subscribe(jobId, self, Set(classOf[JobStarted]))
       actor ! JobInit(jobInfo)
-      val msg = JobStarted(jobId, contextName, DateTime.now)
+      val msg = JobStarted(jobId, jobInfo)
       actor ! msg
       expectMsg(msg)
     }
@@ -100,7 +100,7 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
 
     it("should be informed JobFinished until it is unsubscribed") {
       actor ! JobInit(jobInfo)
-      actor ! JobStarted(jobId, contextName, DateTime.now)
+      actor ! JobStarted(jobId, jobInfo)
       actor ! Subscribe(jobId, self, Set(classOf[JobFinished]))
       val msg = JobFinished(jobId, DateTime.now)
       actor ! msg
@@ -112,7 +112,7 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
 
     it("should be informed JobErroredOut until it is unsubscribed") {
       actor ! JobInit(jobInfo)
-      actor ! JobStarted(jobId, contextName, DateTime.now)
+      actor ! JobStarted(jobId, jobInfo)
       actor ! Subscribe(jobId, self, Set(classOf[JobErroredOut]))
       val msg = JobErroredOut(jobId, DateTime.now, new Throwable)
       actor ! msg
@@ -128,7 +128,7 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
       expectMsg(Seq(jobInfo))
 
       val startTime = DateTime.now
-      actor ! JobStarted(jobId, contextName, startTime)
+      actor ! JobStarted(jobId, jobInfo)
       actor ! GetRunningJobStatus
       expectMsg(Seq(JobInfo(jobId, contextName, jarInfo, classPath, startTime, None, None)))
 
@@ -154,7 +154,7 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
       actor ! JobInit(jobInfo)
 
       val startTime = DateTime.now
-      actor ! JobStarted(jobId, contextName, startTime)
+      actor ! JobStarted(jobId, jobInfo)
 
       val failedTime = DateTime.now
       val err = new Throwable

--- a/job-server/test/spark.jobserver/JobStatusActorSpec.scala
+++ b/job-server/test/spark.jobserver/JobStatusActorSpec.scala
@@ -128,7 +128,7 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
       expectMsg(Seq(jobInfo))
 
       val startTime = DateTime.now
-      actor ! JobStarted(jobId, jobInfo)
+      actor ! JobStarted(jobId, jobInfo.copy(startTime=startTime))
       actor ! GetRunningJobStatus
       expectMsg(Seq(JobInfo(jobId, contextName, jarInfo, classPath, startTime, None, None)))
 

--- a/job-server/test/spark.jobserver/WebApiMainRoutesSpec.scala
+++ b/job-server/test/spark.jobserver/WebApiMainRoutesSpec.scala
@@ -104,10 +104,14 @@ class WebApiMainRoutesSpec extends WebApiSpec {
     it("async route should return 202 if job starts successfully") {
       Post("/jobs?appName=foo&classPath=com.abc.meme&context=one", "") ~> sealRoute(routes) ~> check {
         status should be (Accepted)
-        responseAs[Map[String, Any]] should be (Map(
-          StatusKey -> "STARTED",
-          ResultKey -> Map("jobId" -> "foo", "context" -> "context1")
-        ))
+        responseAs[Map[String, String]] should be (Map(
+          "jobId" -> "foo",
+          "startTime" -> "2013-05-29T00:00:00.000Z",
+          "classPath" -> "com.abc.meme",
+          "context"  -> "context",
+          "duration" -> "Job not done yet",
+          StatusKey -> "STARTED")
+        )
       }
     }
 
@@ -159,10 +163,14 @@ class WebApiMainRoutesSpec extends WebApiSpec {
     it("adhoc job started successfully of async route should return 202") {
       Post("/jobs?appName=foo&classPath=com.abc.meme", "") ~> sealRoute(routes) ~> check {
         status should be (Accepted)
-        responseAs[Map[String, Any]] should be (Map(
-          StatusKey -> "STARTED",
-          ResultKey -> Map("jobId" -> "foo", "context" -> "context1")
-        ))
+        responseAs[Map[String, String]] should be (Map(
+          "jobId" -> "foo",
+          "startTime" -> "2013-05-29T00:00:00.000Z",
+          "classPath" -> "com.abc.meme",
+          "context"  -> "context",
+          "duration" -> "Job not done yet",
+          StatusKey -> "STARTED")
+        )
       }
     }
 

--- a/job-server/test/spark.jobserver/WebApiSpec.scala
+++ b/job-server/test/spark.jobserver/WebApiSpec.scala
@@ -119,16 +119,18 @@ with ScalatestRouteTest with HttpService {
                                                           new IllegalArgumentException("foo")))
       case StartJob("foo", _, config, events)     =>
         statusActor ! Subscribe("foo", sender, events)
-        statusActor ! JobStatusActor.JobInit(JobInfo("foo", "context", null, "", dt, None, None))
-        statusActor ! JobStarted("foo", "context1", dt)
+        val jobInfo = JobInfo("foo", "context", null, "", dt, None, None)
+        statusActor ! JobStatusActor.JobInit(jobInfo)
+        statusActor ! JobStarted(jobInfo.jobId, jobInfo)
         val map = config.entrySet().asScala.map { entry => entry.getKey -> entry.getValue.unwrapped }.toMap
         if (events.contains(classOf[JobResult])) sender ! JobResult("foo", map)
         statusActor ! Unsubscribe("foo", sender)
 
       case StartJob("foo.stream", _, config, events)     =>
         statusActor ! Subscribe("foo.stream", sender, events)
-        statusActor ! JobStatusActor.JobInit(JobInfo("foo.stream", "context", null, "", dt, None, None))
-        statusActor ! JobStarted("foo.stream", "context1", dt)
+        val jobInfo = JobInfo("foo.stream", "context", null, "", dt, None, None)
+        statusActor ! JobStatusActor.JobInit(jobInfo)
+        statusActor ! JobStarted(jobInfo.jobId, jobInfo)
         val result = "\"1, 2, 3, 4, 5, 6\"".getBytes().toStream
         if (events.contains(classOf[JobResult])) sender ! JobResult("foo.stream", result)
         statusActor ! Unsubscribe("foo.stream", sender)

--- a/job-server/test/spark.jobserver/WebApiSpec.scala
+++ b/job-server/test/spark.jobserver/WebApiSpec.scala
@@ -119,7 +119,7 @@ with ScalatestRouteTest with HttpService {
                                                           new IllegalArgumentException("foo")))
       case StartJob("foo", _, config, events)     =>
         statusActor ! Subscribe("foo", sender, events)
-        val jobInfo = JobInfo("foo", "context", null, "", dt, None, None)
+        val jobInfo = JobInfo("foo", "context", null, "com.abc.meme", dt, None, None)
         statusActor ! JobStatusActor.JobInit(jobInfo)
         statusActor ! JobStarted(jobInfo.jobId, jobInfo)
         val map = config.entrySet().asScala.map { entry => entry.getKey -> entry.getValue.unwrapped }.toMap


### PR DESCRIPTION
POST /jobs/ should return as many information as GET /jobs/<jobId>

Also the returned json should not have a result key in the json to make
it consistent.