### PR TITLE
Revert regression caused by e57bc0ab8bd4b40d3b986841a0349e59c7a15f39

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -68,7 +68,7 @@ object JobServerBuild extends Build {
   lazy val jobServerExtras = Project(id = "job-server-extras",
                                      base = file("job-server-extras"),
                                      settings = commonSettings ++ jobServerExtrasSettings
-                                    ).dependsOn(jobServerApi, jobServer % "test->test")
+                                    ).dependsOn(jobServerApi, jobServer % "compile->compile; test->test")
                                     .disablePlugins(SbtScalariform)
 
 


### PR DESCRIPTION
Make `job-server-extras/assembly` package job-server classes too

Issue reported by @bjoernlohrmann on gitter channel