### PR TITLE
Add Scala version to docker tag

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -145,7 +145,7 @@ object JobServerBuild extends Build {
     imageNames in docker := Seq(
       sbtdocker.ImageName(namespace = Some("velvia"),
                           repository = "spark-jobserver",
-                          tag = Some(s"${version.value}.mesos-${mesosVersion.split('-')(0)}.spark-$sparkVersion"))
+                          tag = Some(s"${version.value}.mesos-${mesosVersion.split('-')(0)}.spark-$sparkVersion.scala-${scalaBinaryVersion.value}"))
     )
   )
 


### PR DESCRIPTION
Re: #517 - Add Scala version to docker tag in order to build images for Scala 2.10 and Scala 2.11.
