### PR TITLE
Only set spark.executor.uri if env var is set

### DIFF
--- a/bin/setenv.sh
+++ b/bin/setenv.sh
@@ -57,7 +57,10 @@ LOGGING_OPTS="-Dlog4j.configuration=file:$appdir/log4j-server.properties
               -DLOG_DIR=$LOG_DIR"
 
 # For Mesos
-CONFIG_OVERRIDES="-Dspark.executor.uri=$SPARK_EXECUTOR_URI "
+CONFIG_OVERRIDES=""
+if [ -n "$SPARK_EXECUTOR_URI" ]; then
+  CONFIG_OVERRIDES="-Dspark.executor.uri=$SPARK_EXECUTOR_URI "
+fi
 # For Mesos/Marathon, use the passed-in port
 if [ "$PORT" != "" ]; then
   CONFIG_OVERRIDES+="-Dspark.jobserver.port=$PORT "


### PR DESCRIPTION
This fixes a regression that was fixed in #136 and #137, without this, it breaks if you aren't setting `SPARK_EXECUTOR_URI`