### PR TITLE
Build Spark from source in Docker image

### DIFF
--- a/job-server/config/docker.conf
+++ b/job-server/config/docker.conf
@@ -54,7 +54,11 @@ spark {
   }
 
   # This needs to match SPARK_HOME for cluster SparkContexts to be created successfully
-  home = "/usr/local/spark"
+  home = "/spark"
+}
+
+deploy {
+  manager-start-cmd = "app/manager_start.sh"
 }
 
 # Note that you can use this file to define settings not only for job server,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
     yammerDeps
   )
 
-  val javaVersion = sys.env.getOrElse("JAVA_VERSION", "7-jre")
+  val javaVersion = sys.env.getOrElse("JAVA_VERSION", "7-jdk")
 
   val mesosVersion = sys.env.getOrElse("MESOS_VERSION", mesos)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,4 +18,4 @@ addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.3")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
 
-addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.3.0")
+addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.4.0")


### PR DESCRIPTION
This allows to compile for Scala 2.11. To build for Scala 2.11, run `SCALA_VERSION="2.11.8 sbt docker`.

I've already built 0.6.2 images for both Scala versions using this build file:
https://hub.docker.com/r/mariussoutier/spark-jobserver/tags/

The 0.7.0 snapshot has an Akka issue inside Docker which I'm still investigating, but it doesn't seem related to building from source.
