### PR TITLE
POST /contexts/<contextName> takes typesafe config payload

### DIFF
--- a/job-server/src/spark.jobserver/WebApi.scala
+++ b/job-server/src/spark.jobserver/WebApi.scala
@@ -7,7 +7,7 @@ import javax.net.ssl.SSLContext
 import akka.actor.{ActorRef, ActorSystem}
 import akka.pattern.ask
 import akka.util.Timeout
-import com.typesafe.config.{Config, ConfigException, ConfigFactory, ConfigRenderOptions, ConfigValueFactory}
+import com.typesafe.config.{Config, ConfigException, ConfigFactory, ConfigValueFactory, ConfigRenderOptions}
 import ooyala.common.akka.web.JsonUtils.AnyJsonFormat
 import ooyala.common.akka.web.{CommonRoutes, WebService}
 import org.apache.shiro.SecurityUtils
@@ -227,7 +227,6 @@ class WebApi(system: ActorSystem,
    *    DELETE /data/<filename>       - deletes given file, no-op if file does not exist
    *    POST /data/<filename-prefix>  - upload a new data file, using the given prefix,
    *                                      a time stamp is appended to ensure uniqueness
-   *
    * @author TimMaltGermany
    */
   def dataRoutes: Route = pathPrefix("data") {

--- a/job-server/test/spark.jobserver/WebApiMainRoutesSpec.scala
+++ b/job-server/test/spark.jobserver/WebApiMainRoutesSpec.scala
@@ -1,6 +1,9 @@
 package spark.jobserver
 
 import com.typesafe.config.ConfigFactory
+import spark.jobserver.JobInfoActor.GetJobStatuses
+import spark.jobserver.JobManagerActor.{ContextConfig, GetContextConfig}
+import spark.jobserver.io.JobInfo
 import spray.http.StatusCodes._
 import spark.jobserver.util.SparkJobUtils
 
@@ -350,6 +353,18 @@ class WebApiMainRoutesSpec extends WebApiSpec {
         status should be (OK)
       }
       Post("/contexts/meme?num-cpu-cores=3&coarse-mesos-mode=true") ~> sealRoute(routes) ~> check {
+        status should be (OK)
+      }
+    }
+
+    it("should setup a new context with the correct configurations.") {
+      val config =
+        """spark.context-settings {
+          |  test = 1
+          |  override_me = 3
+          |}
+        """.stripMargin
+      Post("/contexts/custom-ctx?num-cpu-cores=2&override_me=2", config) ~> sealRoute(routes) ~> check {
         status should be (OK)
       }
     }

--- a/job-server/test/spark.jobserver/WebApiMainRoutesSpec.scala
+++ b/job-server/test/spark.jobserver/WebApiMainRoutesSpec.scala
@@ -1,9 +1,6 @@
 package spark.jobserver
 
 import com.typesafe.config.ConfigFactory
-import spark.jobserver.JobInfoActor.GetJobStatuses
-import spark.jobserver.JobManagerActor.{ContextConfig, GetContextConfig}
-import spark.jobserver.io.JobInfo
 import spray.http.StatusCodes._
 import spark.jobserver.util.SparkJobUtils
 

--- a/job-server/test/spark.jobserver/WebApiSpec.scala
+++ b/job-server/test/spark.jobserver/WebApiSpec.scala
@@ -103,6 +103,13 @@ with ScalatestRouteTest with HttpService {
       case StopContext("none") => sender ! NoSuchContext
       case StopContext(_)      => sender ! ContextStopped
       case AddContext("one", _) => sender ! ContextAlreadyExists
+      case AddContext("custom-ctx", c) =>
+        // see WebApiMainRoutesSpec => "context routes" =>
+        // "should setup a new context with the correct configurations."
+        c.getInt("test") should be(1)
+        c.getInt("num-cpu-cores") should be(2)
+        c.getInt("override_me") should be(3)
+        sender ! ContextInitialized
       case AddContext(_, _)     => sender ! ContextInitialized
 
       case GetContext("no-context") => sender ! NoSuchContext


### PR DESCRIPTION
#### Motivation
I have a lot of spark configs I want to set on my spark context. The only way to do this when creating a context is to supply the configs as URL parameters, but I get a `414: URI Too Long` because there are too many.

#### Solution
Add support for typesafe config in the payload of the `POST /contexts/<contextName>` endpoint. This is the same support for the `POST /jobs` endpoint - the user can supply:
```
spark.context-settings {
  # spark configs
  hadoop {
    # hadoop configs
  }
}