### PR TITLE
Fix for Issue #507: Fix DELETE /data/<filename> issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Also see [Chinese docs / 中文](doc/chinese/job-server.md).
   - [Contexts](#contexts)
   - [Jobs](#jobs)
   - [Data](#data)
+    - [Data API Example](#data-api-example)
   - [Context configuration](#context-configuration)
   - [Other configuration settings](#other-configuration-settings)
   - [Job Result Serialization](#job-result-serialization)
@@ -595,6 +596,26 @@ just the same as with any other server-local file. A job could therefore add thi
 it to worker nodes via the SparkContext.addFile command.        
 For files that are larger than a few hundred MB, it is recommended to manually upload these files to the server or
 to directly add them to your HDFS.
+
+#### Data API Example
+
+    $ curl -d "Test data file api" http://localhost:8090/data/test_data_file_upload.txt
+    {
+      "result": {
+        "filename": "/tmp/spark-jobserver/upload/test_data_file_upload.txt-2016-07-04T09_09_57.928+05_30.dat"
+      }
+    }
+
+    $ curl http://localhost:8090/data
+    ["/tmp/spark-jobserver/upload/test_data_file_upload.txt-2016-07-04T09_09_57.928+05_30.dat"]
+
+    $ curl -X DELETE http://localhost:8090/data/%2Ftmp%2Fspark-jobserver%2Fupload%2Ftest_data_file_upload.txt-2016-07-04T09_09_57.928%2B05_30.dat
+    OK
+
+    $ curl http://localhost:8090/data
+    []
+
+Note: Both POST and DELETE requests takes URI encoded file names.
 
 ### Context configuration
 

--- a/job-server/src/spark.jobserver/routes/DataRoutes.scala
+++ b/job-server/src/spark.jobserver/routes/DataRoutes.scala
@@ -40,7 +40,7 @@ trait DataRoutes extends HttpService {
       // DELETE /data/filename delete the given file
       delete {
         path(Segment) { filename =>
-          val future = dataManager ? DeleteData(URLDecoder.decode(filename, "UTF-8"))
+          val future = dataManager ? DeleteData(filename)
           respondWithMediaType(MediaTypes.`application/json`) { ctx =>
             future.map {
               case Deleted => ctx.complete(StatusCodes.OK)

--- a/job-server/test/spark.jobserver/WebApiSpec.scala
+++ b/job-server/test/spark.jobserver/WebApiSpec.scala
@@ -93,8 +93,8 @@ with ScalatestRouteTest with HttpService {
       case StoreJar("badjar", _) => sender ! InvalidJar
       case StoreJar(_, _)        => sender ! JarStored
 
-      case DataManagerActor.StoreData("/tmp/fileToRemove", _) => sender ! DataManagerActor.Stored("/tmp/fileToRemove-time-stamp")
       case DataManagerActor.StoreData("errorfileToRemove", _) => sender ! DataManagerActor.Error
+      case DataManagerActor.StoreData(filename, _) => sender ! DataManagerActor.Stored(filename + "-time-stamp")        
       case DataManagerActor.ListData => sender ! Set("demo1", "demo2")
       case DataManagerActor.DeleteData("/tmp/fileToRemove") => sender ! DataManagerActor.Deleted
       case DataManagerActor.DeleteData("errorfileToRemove") => sender ! DataManagerActor.Error


### PR DESCRIPTION
Currently data file delete api expects encoded URI. Enhance it to use
the path as such. This would help the user not to encode path.

Added examples