### PR TITLE
Issue #536: Web API returns status "KILLED" for jobs cancelled by user.

### DIFF
--- a/job-server/src/spark.jobserver/CommonMessages.scala
+++ b/job-server/src/spark.jobserver/CommonMessages.scala
@@ -15,7 +15,7 @@ object CommonMessages {
   case class JobFinished(jobId: String, endTime: DateTime) extends StatusMessage
   case class JobValidationFailed(jobId: String, endTime: DateTime, err: Throwable) extends StatusMessage
   case class JobErroredOut(jobId: String, endTime: DateTime, err: Throwable) extends StatusMessage
-  case class JobKilled(jobId: String, endTime: DateTime) extends StatusMessage
+  case class JobKilled(jobId: String, endTime: DateTime, err: Throwable) extends StatusMessage
 
   /**
    * NOTE: For Subscribe, make sure to use `classOf[]` to get the Class for the case classes above.

--- a/job-server/src/spark.jobserver/JobManagerActor.scala
+++ b/job-server/src/spark.jobserver/JobManagerActor.scala
@@ -158,7 +158,7 @@ class JobManagerActor(contextConfig: Config) extends InstrumentedActor {
 
     case KillJob(jobId: String) => {
       jobContext.sparkContext.cancelJobGroup(jobId)
-      statusActor ! JobKilled(jobId, DateTime.now())
+      statusActor ! JobKilled(jobId, DateTime.now(), new Exception("killed"))
     }
 
     case SparkContextStatus => {

--- a/job-server/src/spark.jobserver/JobStatusActor.scala
+++ b/job-server/src/spark.jobserver/JobStatusActor.scala
@@ -100,7 +100,7 @@ class JobStatusActor(jobDao: ActorRef) extends InstrumentedActor with YammerMetr
     case msg: JobKilled =>
       processStatus(msg, "killed", remove = true) {
         case (info, msg) =>
-          info.copy(endTime = Some(msg.endTime))
+          info.copy(endTime = Some(msg.endTime), error = Some(msg.err))
       }
   }
 

--- a/job-server/src/spark.jobserver/WebApi.scala
+++ b/job-server/src/spark.jobserver/WebApi.scala
@@ -87,12 +87,17 @@ object WebApi {
     }
 
   def getJobReport(jobInfo: JobInfo, jobStarted: Boolean = false): Map[String, Any] = {
-    val statusMap = if (jobStarted) Map(StatusKey -> "STARTED") else (jobInfo match {
+    val statusMap = if (jobStarted) Map(StatusKey -> "STARTED") else jobInfo match {
         case JobInfo(_, _, _, _, _, None, _) => Map(StatusKey -> "RUNNING")
-        case JobInfo(_, _, _, _, _, _, Some(ex)) => Map(StatusKey -> "ERROR",
-          ResultKey -> formatException(ex))
+        case JobInfo(_, _, _, _, _, _, Some(ex)) =>
+          ex.getMessage match {
+            case "killed" =>
+              Map(StatusKey -> "KILLED", ResultKey -> formatException(ex))
+            case _ =>
+              Map(StatusKey -> "ERROR", ResultKey -> formatException(ex))
+          }
         case JobInfo(_, _, _, _, _, Some(e), None) => Map(StatusKey -> "FINISHED")
-    })
+    }
     Map("jobId" -> jobInfo.jobId,
       "startTime" -> jobInfo.startTime.toString(),
       "classPath" -> jobInfo.classPath,


### PR DESCRIPTION
The goal of this PR is to fix: https://github.com/spark-jobserver/spark-jobserver/issues/536

`DELETE` requests from the web API will save an exception with the message `killed` in the job model. The API will return status `KILLED` for this class of exceptions.

The code to accomplish this is clumsy and works with the fact that the API attributes an exception in the Job model as an indication of failure. If this code, after I add tests, is acceptable to the project maintainers, I'd be ok with merging it.

However - I think a better long-term refactor is to add a column to the Job model with the status explicitly set, instead of assuming success or failure from other columns: https://github.com/spark-jobserver/spark-jobserver/blob/master/job-server/src/spark.jobserver/WebApi.scala#L93

Either way, if this PR is accepted, I'll create a follow on one to update the UI with a new table section for `KILLED` jobs.

Thanks for your feedback.