### PR TITLE
Updated Spark version

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Spark Job Server is now included in Datastax Enterprise 4.8!
 - [Linkfluence](http://www.linkfluence.com)
 - [Smartsct](http://www.smartsct.com)
 - [Datadog] (https://www.datadoghq.com/)
+- [Planalytics](http://www.planalytics.com)
 
 ## Features
 
@@ -108,7 +109,7 @@ Spark Job Server is now included in Datastax Enterprise 4.8!
 | 0.6.0       | 1.4.1         |
 | 0.6.1       | 1.5.2         |
 | 0.6.2       | 1.6.1         |
-| master      | 1.6.1         |
+| master      | 1.6.2         |
 
 For release notes, look in the `notes/` directory.  They should also be up on [notes.implicit.ly](http://notes.implicit.ly/search/spark-jobserver).
 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -7,7 +7,7 @@ object Versions {
   lazy val akka = "2.3.15"
   lazy val spray = "1.3.3"
   lazy val sprayJson = "1.3.2"
-  lazy val spark = "1.6.1"
+  lazy val spark = "1.6.2"
   lazy val mesos = "0.25.0-0.2.70.ubuntu1404"
   lazy val netty =  "4.0.29.Final"
   lazy val slick = "3.1.1"


### PR DESCRIPTION
Updated Spark version to 1.6.2.

Since this is a minor update, it should be backward compatible. Since we've been using the 1.6.x branch for sometime, this should just fix bugs in Spark.