### PR TITLE
Previously, the OK responses returned a string equal to OK that did n…

### DIFF
--- a/job-server/test/spark.jobserver/JobServerSprayProtocol.scala
+++ b/job-server/test/spark.jobserver/JobServerSprayProtocol.scala
@@ -1,0 +1,17 @@
+package spark.jobserver
+
+import spray.json.DefaultJsonProtocol
+import spray.json._
+
+/**
+  * Created by alexsilva on 8/20/16.
+  */
+case class JobServerResponse(status: String, result: String) {
+  def isSuccess:Boolean = status == "SUCCESS"
+}
+
+object JobServerSprayProtocol extends DefaultJsonProtocol {
+  implicit val jobServerResponseFormat: RootJsonFormat[JobServerResponse] = jsonFormat2(JobServerResponse)
+
+}
+


### PR DESCRIPTION
Previously, the OK responses returned a string equal to 'OK' that did not comply to the application/json content-type.  This was causing any client libraries to break.  What I did was a simple (possible temporary) fix which modified all complete(StatusCodes.OK) in the WebApi class to return complete(StatusCodes.OK,Map(statusKey,resultKey).  This way, the 200 responses will comply with the JSON content type.