### PR TITLE
cassandra support

### DIFF
--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -33,6 +33,14 @@ spark {
       rootdir = /tmp/spark-jobserver/upload
     }
 
+    cassandra {
+      consistency = "ONE"
+      hosts = ["localhost:9042"]
+      user = ""
+      password = ""
+      chunk-size-in-kb = 1024
+    }
+
     # To load up job jars on startup, place them here,
     # with the app name as the key and the path to the jar as the value
     # job-binary-paths {

--- a/job-server/src/main/resources/db/postgresql/migration/V0_7_0/V0_7_0__init_tables.sql
+++ b/job-server/src/main/resources/db/postgresql/migration/V0_7_0/V0_7_0__init_tables.sql
@@ -1,5 +1,5 @@
 CREATE TABLE "JARS" (
-  "JAR_ID"         SERIAL                         NOT NULL PRIMARY KEY,
+  "JAR_ID"          SERIAL                        NOT NULL PRIMARY KEY,
   "APP_NAME"        VARCHAR(255)                  NOT NULL,
   "UPLOAD_TIME"     TIMESTAMP WITHOUT TIME ZONE   NOT NULL,
   "JAR"             BYTEA                         NOT NULL

--- a/job-server/src/spark.jobserver/cassandra/Cassandra.scala
+++ b/job-server/src/spark.jobserver/cassandra/Cassandra.scala
@@ -1,0 +1,76 @@
+package spark.jobserver.cassandra
+
+import com.datastax.driver.core.{BoundStatement, ResultSet, ResultSetFuture}
+import scala.concurrent.{CanAwait, Future, ExecutionContext}
+import scala.util.{Success, Try}
+import scala.concurrent.duration.Duration
+import java.util.concurrent.{TimeUnit, Executor => JExecutor}
+
+
+trait CassandraResultSetOperations {
+
+  private case class ExecutionContextExecutor(executionContext: ExecutionContext) extends JExecutor {
+    def execute(command: Runnable): Unit = { executionContext.execute(command) }
+  }
+
+  protected class RichResultSetFuture(resultSetFuture: ResultSetFuture) extends Future[ResultSet] {
+    @throws(classOf[InterruptedException])
+    @throws(classOf[scala.concurrent.TimeoutException])
+    def ready(atMost: Duration)(implicit permit: CanAwait): this.type = {
+      resultSetFuture.get(atMost.toMillis, TimeUnit.MILLISECONDS)
+      this
+    }
+
+    @throws(classOf[Exception])
+    def result(atMost: Duration)(implicit permit: CanAwait): ResultSet = {
+      resultSetFuture.get(atMost.toMillis, TimeUnit.MILLISECONDS)
+    }
+
+    def onComplete[U](func: (Try[ResultSet]) => U)(implicit executionContext: ExecutionContext): Unit = {
+      if (resultSetFuture.isDone) {
+        func(Success(resultSetFuture.getUninterruptibly))
+      } else {
+        resultSetFuture.addListener(new Runnable {
+          def run() {
+            func(Try(resultSetFuture.get()))
+          }
+        }, ExecutionContextExecutor(executionContext))
+      }
+    }
+
+    def isCompleted: Boolean = resultSetFuture.isDone
+
+    def value: Option[Try[ResultSet]] = if (resultSetFuture.isDone) Some(Try(resultSetFuture.get())) else None
+  }
+
+  implicit def toFuture(resultSetFuture: ResultSetFuture): Future[ResultSet] = {
+    new RichResultSetFuture(resultSetFuture)
+  }
+}
+
+trait Binder[-A] {
+
+  def bind(value: A, boundStatement: BoundStatement): Unit
+
+}
+
+trait BoundStatementOperations {
+
+  implicit class RichBoundStatement[A : Binder](boundStatement: BoundStatement) {
+    val binder = implicitly[Binder[A]]
+
+    def bindFrom(value: A): BoundStatement = {
+      binder.bind(value, boundStatement)
+      boundStatement
+    }
+  }
+
+}
+
+object Cassandra {
+
+  object Resultset extends CassandraResultSetOperations
+
+  object Boundstatement extends BoundStatementOperations
+
+}

--- a/job-server/src/spark.jobserver/io/FileCasher.scala
+++ b/job-server/src/spark.jobserver/io/FileCasher.scala
@@ -1,0 +1,44 @@
+package spark.jobserver.io
+
+import java.io.{BufferedOutputStream, File, FileOutputStream}
+
+import org.joda.time.DateTime
+import org.slf4j.LoggerFactory
+
+trait FileCasher {
+
+  val rootDir: String
+  val rootDirFile: File
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  def initFileDirectory(): Unit = {
+    if (!rootDirFile.exists()) {
+      if (!rootDirFile.mkdirs()) {
+        throw new RuntimeException("Could not create directory " + rootDir)
+      }
+    }
+  }
+
+  def createBinaryName(appName: String, binaryType: BinaryType, uploadTime: DateTime): String = {
+    appName + "-" + uploadTime.toString("yyyyMMdd_hhmmss_SSS") + s".${binaryType.extension}"
+  }
+
+  // Cache the jar file into local file system.
+  protected def cacheBinary(appName: String,
+                          binaryType: BinaryType,
+                          uploadTime: DateTime,
+                          binBytes: Array[Byte]) {
+    val outFile =
+      new File(rootDir, createBinaryName(appName, binaryType, uploadTime))
+    val bos = new BufferedOutputStream(new FileOutputStream(outFile))
+    try {
+      logger.debug("Writing {} bytes to file {}", binBytes.length, outFile.getPath)
+      bos.write(binBytes)
+      bos.flush()
+    } finally {
+      bos.close()
+    }
+  }
+
+}

--- a/job-server/src/spark.jobserver/io/JobCassandraDAO.scala
+++ b/job-server/src/spark.jobserver/io/JobCassandraDAO.scala
@@ -1,0 +1,357 @@
+package spark.jobserver.io
+
+import java.io.File
+import java.net.InetSocketAddress
+import java.nio.ByteBuffer
+import java.util.UUID
+
+import com.datastax.driver.core.querybuilder.{QueryBuilder => QB}
+import com.datastax.driver.core.querybuilder.QueryBuilder._
+import com.datastax.driver.core._
+import com.datastax.driver.core.schemabuilder.SchemaBuilder.Direction
+import com.datastax.driver.core.schemabuilder.{Create, SchemaBuilder}
+import com.typesafe.config.{Config, ConfigFactory, ConfigRenderOptions}
+import org.joda.time.DateTime
+import org.slf4j.LoggerFactory
+
+import scala.collection.convert.WrapAsJava
+import scala.collection.convert.Wrappers.JListWrapper
+import scala.concurrent.Future
+import spark.jobserver.cassandra.Cassandra.Resultset.toFuture
+
+import scala.util.Try
+
+object Metadata {
+  val BinariesTable = "binaries"
+  val BinariesChronologicalTable = "binaries_chronological"
+  val BinaryId = "binary_id"
+  val AppName = "app_name"
+  val BType = "binary_type"
+  val UploadTime = "upload_time"
+  val ChunkIndex = "chunk_index"
+  val Binary = "binary"
+
+  val JobsTable = "jobs"
+  val JobsChronologicalTable = "jobs_chronological"
+  val JobId = "job_id"
+  val ContextName = "context_name"
+  val JobConfig = "job_config"
+  val Classpath = "classpath"
+  val StartTime = "start_time"
+  val StartDate = "start_date"
+  val EndTime = "end_time"
+  val Error = "error"
+
+}
+
+class JobCassandraDAO(config: Config) extends JobDAO with FileCasher {
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+  private val logger = LoggerFactory.getLogger(getClass)
+  val session = setup(config)
+  val chunkSizeInKb = Try(config.getInt("spark.jobserver.cassandra.chunk-size-in-kb")).getOrElse(1024)
+  setupSchema()
+
+
+  // NOTE: below is only needed for H2 drivers
+  val rootDir = config.getString("spark.jobserver.sqldao.rootdir")
+  val rootDirFile = new File(rootDir)
+  logger.info("rootDir is " + rootDirFile.getAbsolutePath)
+  initFileDirectory()
+
+  override def saveBinary(appName: String,
+                          binaryType: BinaryType,
+                          uploadTime: DateTime,
+                          binBytes: Array[Byte]): Unit = {
+    // The order is important. Save the binary file first and then log it into database.
+    cacheBinary(appName, binaryType, uploadTime, binBytes)
+
+    // log it into database
+    val ok = insertBinaryInfo(BinaryInfo(appName, binaryType, uploadTime), binBytes)
+    if (!ok) {
+      logger.error(s"Fail save binary $appName, $uploadTime, content length ${binBytes.length}")
+    }
+  }
+
+
+  import Metadata._
+
+  private def insertBinaryInfo(binInfo: BinaryInfo, binBytes: Array[Byte]): Boolean = {
+    session.executeAsync(insertInto(BinariesChronologicalTable).
+      value(AppName, binInfo.appName).
+      value(BType, binInfo.binaryType.name).
+      value(UploadTime, binInfo.uploadTime.getMillis)
+    ).getUninterruptibly().wasApplied()
+
+    val bytesSize = 1024 * chunkSizeInKb
+    val chunks = binBytes.sliding(bytesSize, bytesSize)
+    try {
+      val replies = chunks.zipWithIndex.map { case (chunk, index) =>
+        session.executeAsync(insertInto(BinariesTable).
+          value(AppName, binInfo.appName).
+          value(BType, binInfo.binaryType.name).
+          value(UploadTime, binInfo.uploadTime.getMillis).
+          value(ChunkIndex, index)
+          value(Binary, ByteBuffer.wrap(chunk))
+        ).getUninterruptibly.wasApplied()
+      }
+      return replies.fold(true)(_ && _)
+    } catch {
+      case e: Throwable =>
+        logger.error(s"Fail save chunk of file $binInfo", e)
+        false
+    }
+  }
+
+  override def getApps: Future[Map[String, (BinaryType, DateTime)]] = {
+
+    implicit def ordering = new Ordering[DateTime] {
+      override def compare(x: DateTime, y: DateTime): Int = java.lang.Long.compare(x.getMillis, y.getMillis)
+    }
+
+    val query = QB.select(AppName, BType, UploadTime).from(BinariesChronologicalTable)
+    session.executeAsync(query).map { rs =>
+      val apps = JListWrapper(rs.all()).map { row =>
+        val appName = row.getString(AppName)
+        val binaryType = BinaryType.fromString(row.getString(BType))
+        val uploadTime = row.getTimestamp(UploadTime)
+        appName -> (binaryType, new DateTime(uploadTime))
+      }
+
+      apps.sortBy { case (app, (binaryType, upload)) => -1 * upload.getMillis }.toMap
+    }
+  }
+
+  override def saveJobConfig(jobId: String, jobConfig: Config): Unit = {
+    session.executeAsync(
+      insertInto(JobsTable).
+        value(JobId, UUID.fromString(jobId)).
+        value(JobConfig, jobConfig.root().render(ConfigRenderOptions.concise()))
+    ).getUninterruptibly
+  }
+
+  override def getJobInfos(limit: Int, status: Option[String] = None): Future[Seq[JobInfo]] = {
+    import Metadata._
+    val query = QB.select(
+      JobId, ContextName, AppName, BType, UploadTime, Classpath, StartTime, EndTime, Error
+    ).from(JobsChronologicalTable).where(QB.eq(StartDate, today())).limit(limit)
+
+    session.executeAsync(query).map { rs =>
+      val allJobs = JListWrapper(rs.all()).map { row =>
+        val endTime = row.getTimestamp(EndTime)
+        val error = row.getString(Error)
+
+        JobInfo(
+          row.getUUID(JobId).toString,
+          row.getString(ContextName),
+          BinaryInfo(
+            row.getString(AppName),
+            BinaryType.fromString(row.getString(BType)),
+            new DateTime(row.getTimestamp(UploadTime))
+          ),
+          row.getString(Classpath),
+          new DateTime(row.getTimestamp(StartTime)),
+          if (endTime != null) Option(new DateTime(endTime)) else None,
+          if (error != null) Option(new Throwable(error)) else None
+        )
+      }
+      status match {
+        // !endTime.isDefined
+        case Some(JobStatus.Running) => allJobs.filter(j => j.endTime.isEmpty && j.error.isEmpty)
+        // endTime.isDefined && error.isDefined
+        case Some(JobStatus.Error) => allJobs.filter(j => j.error.isDefined)
+        // not RUNNING AND NOT ERROR
+        case Some(JobStatus.Finished) => allJobs.filter(j => j.endTime.isDefined && j.error.isEmpty)
+        case _ => allJobs
+      }
+    }
+  }
+
+  override def retrieveBinaryFile(appName: String, binaryType: BinaryType, uploadTime: DateTime): String = {
+    val binaryFile = new File(rootDir, createBinaryName(appName, binaryType, uploadTime))
+    if (!binaryFile.exists()) {
+      fetchAndCacheBinaryFile(appName, binaryType, uploadTime)
+    }
+    binaryFile.getAbsolutePath
+  }
+
+  private def today(): LocalDate = {
+    LocalDate.fromMillisSinceEpoch(DateTime.now.getMillis)
+  }
+
+  // Fetch the binary file from database and cache it into local file system.
+  private def fetchAndCacheBinaryFile(appName: String, binaryType: BinaryType, uploadTime: DateTime) {
+    val binBytes = fetchBinary(appName, binaryType, uploadTime)
+    cacheBinary(appName, binaryType, uploadTime, binBytes)
+  }
+
+  // Fetch the binary from the database
+  private def fetchBinary(appName: String, binaryType: BinaryType, uploadTime: DateTime): Array[Byte] = {
+    val rows = session.executeAsync(QB.select(AppName, BType, UploadTime, ChunkIndex, Binary).
+      from(BinariesTable).
+      where(QB.eq(AppName, appName)).
+      and(QB.eq(BType, binaryType.name)).
+      and(QB.eq(UploadTime, uploadTime.getMillis))
+    ).getUninterruptibly().all()
+
+    val tuples = JListWrapper(rows).toIndexedSeq.map { row =>
+      (row.getInt(ChunkIndex), row.getBytes(Binary).array())
+    }
+    tuples.sortBy(_._1).toMap.values.foldLeft(Array[Byte]()) { _ ++ _ }
+  }
+
+  override def getJobInfo(jobId: String): Future[Option[JobInfo]] = {
+    val query = QB.select(
+      JobId, ContextName, AppName, BType, UploadTime, Classpath, StartTime, EndTime, Error
+    ).from(JobsTable).
+      where(QB.eq(JobId, UUID.fromString(jobId))).
+      limit(1)
+
+    session.executeAsync(query).map { rs =>
+      val row = rs.one()
+      Option(row).map(r =>
+        JobInfo(
+          r.getUUID(Metadata.JobId).toString,
+          r.getString(ContextName),
+          BinaryInfo(
+            r.getString(AppName),
+            BinaryType.fromString(r.getString(BType)),
+            new DateTime(r.getTimestamp(UploadTime))
+          ),
+          r.getString(Classpath),
+          new DateTime(r.getTimestamp(StartTime)),
+          Option(r.getTimestamp(EndTime)).map(new DateTime(_)),
+          Option(r.getString(Error)).map(new Throwable(_))
+        ))
+    }
+  }
+
+  override def saveJobInfo(jobInfo: JobInfo): Unit = {
+    val JobInfo(jobId, contextName, binaryInfo, classPath, startTime, endTime, error) = jobInfo
+    val (_, endOpt, errOpt) = (startTime,
+      endTime.map(e => e),
+      error.map(_.getMessage))
+
+    val localDate: LocalDate = LocalDate.fromMillisSinceEpoch(jobInfo.startTime.getMillis)
+
+    val insert = insertInto(JobsTable).
+      value(JobId, UUID.fromString(jobId)).
+      value(ContextName, contextName).
+      value(AppName, binaryInfo.appName).
+      value(BType, binaryInfo.binaryType.name).
+      value(UploadTime, binaryInfo.uploadTime.getMillis).
+      value(Classpath, classPath).
+      value(StartTime, startTime.getMillis).
+      value(StartDate, localDate)
+
+    endOpt.foreach{e => insert.value(EndTime, e.getMillis)}
+    errOpt.foreach(insert.value(Error, _))
+    session.execute(insert)
+
+    val insert2 = insertInto(JobsChronologicalTable).
+      value(StartDate, localDate).
+      value(StartTime, startTime.getMillis).
+      value(JobId, UUID.fromString(jobId)).
+      value(ContextName, contextName).
+      value(AppName, binaryInfo.appName).
+      value(BType, binaryInfo.binaryType.name).
+      value(UploadTime, binaryInfo.uploadTime.getMillis).
+      value(Classpath, classPath)
+
+    endOpt.foreach{e => insert2.value(EndTime, e.getMillis)}
+    errOpt.foreach(insert2.value(Error, _))
+    session.execute(insert2)
+  }
+
+  override def getJobConfigs: Future[Map[String, Config]] = {
+    val query = QB.select(Metadata.JobId, Metadata.JobConfig).from(Metadata.JobsTable)
+    session.executeAsync(query).map { rs =>
+      JListWrapper(rs.all()).map { row =>
+        val config = Option(row.getString(Metadata.JobConfig)).getOrElse("")
+        (row.getUUID(Metadata.JobId).toString, ConfigFactory.parseString(config))
+      }.toMap
+    }
+  }
+
+  private def setup(config: Config): Session = {
+    val cassandraConfig = config.getConfig("spark.jobserver.cassandra")
+    val hosts = JListWrapper(cassandraConfig.getStringList("hosts"))
+    val username = cassandraConfig.getString("user")
+    val password = cassandraConfig.getString("password")
+    val consistencyLevel = Try(
+      ConsistencyLevel.valueOf(cassandraConfig.getString("consistency"))
+    ).getOrElse(ConsistencyLevel.ONE)
+    val keyspace = "spark_jobserver"
+    val addrs = hosts.map(_.trim()).map(input => {
+      var port: Int = 9042
+      var host: String = input
+      val idx: Int = host.indexOf(":")
+      if (idx != -1) {
+        port = host.substring(idx + 1).toInt
+        host = host.substring(0, idx)
+      }
+      new InetSocketAddress(host, port)
+    })
+    val queryOptions = new QueryOptions().setConsistencyLevel(consistencyLevel)
+    val cluster = Cluster.builder
+      .addContactPointsWithPorts(WrapAsJava.asJavaCollection(addrs))
+      .withQueryOptions(queryOptions)
+      .withCredentials(username, password)
+      .build
+    cluster.getConfiguration.getProtocolOptions.setCompression(ProtocolOptions.Compression.LZ4)
+    cluster.connect(keyspace)
+  }
+
+  private def setupSchema() = {
+    import Metadata._
+
+    val binariesTable: Create = SchemaBuilder.createTable(BinariesTable).ifNotExists.
+      addPartitionKey(AppName, DataType.text).
+      addPartitionKey(BType, DataType.text).
+      addPartitionKey(UploadTime, DataType.timestamp).
+      addClusteringColumn(ChunkIndex, DataType.cint()).
+      addColumn(Binary, DataType.blob)
+
+    session.execute(binariesTable)
+
+    val binariesChronologicalTable: Create = SchemaBuilder.createTable(BinariesChronologicalTable).
+      ifNotExists().
+      addPartitionKey(AppName, DataType.text).
+      addPartitionKey(BType, DataType.text).
+      addColumn(UploadTime, DataType.timestamp())
+
+    session.execute(binariesChronologicalTable)
+
+    val jobsTableStatement = SchemaBuilder.createTable(JobsTable).ifNotExists.
+      addPartitionKey(JobId, DataType.uuid).
+      addColumn(ContextName, DataType.text).
+      addColumn(AppName, DataType.text).
+      addColumn(BType, DataType.text).
+      addColumn(UploadTime, DataType.timestamp).
+      addColumn(JobConfig, DataType.text).
+      addColumn(Classpath, DataType.text).
+      addColumn(StartTime, DataType.timestamp).
+      addColumn(StartDate, DataType.date).
+      addColumn(EndTime, DataType.timestamp).
+      addColumn(Error, DataType.text)
+
+    session.execute(jobsTableStatement)
+
+    val jobsChronologicalView = SchemaBuilder.createTable(JobsChronologicalTable).ifNotExists().
+      addPartitionKey(StartDate, DataType.date).
+      addClusteringColumn(StartTime, DataType.timestamp()).
+      addClusteringColumn(JobId, DataType.uuid()).
+      addColumn(ContextName, DataType.text).
+      addColumn(AppName, DataType.text).
+      addColumn(BType, DataType.text).
+      addColumn(UploadTime, DataType.timestamp).
+      addColumn(JobConfig, DataType.text).
+      addColumn(Classpath, DataType.text).
+      addColumn(EndTime, DataType.timestamp).
+      addColumn(Error, DataType.text).
+      withOptions().clusteringOrder(StartTime, Direction.DESC)
+
+    session.execute(jobsChronologicalView)
+
+  }
+}

--- a/job-server/src/spark.jobserver/io/JobDAO.scala
+++ b/job-server/src/spark.jobserver/io/JobDAO.scala
@@ -49,9 +49,9 @@ case class JobInfo(jobId: String, contextName: String,
                    binaryInfo: BinaryInfo, classPath: String,
                    startTime: DateTime, endTime: Option[DateTime],
                    error: Option[Throwable]) {
-  def jobLengthMillis: Option[Long] = endTime.map { end => new Duration(startTime, end).getMillis() }
+  def jobLengthMillis: Option[Long] = endTime.map { end => new Duration(startTime, end).getMillis }
 
-  def isRunning: Boolean = !endTime.isDefined
+  def isRunning: Boolean = endTime.isEmpty
   def isErroredOut: Boolean = endTime.isDefined && error.isDefined
 }
 
@@ -123,7 +123,7 @@ trait JobDAO {
 
   /**
    * Return all job ids to their job configuration.
-   *
+   * @todo remove. used only in test
    * @return
    */
   def getJobConfigs: Future[Map[String, Config]]

--- a/job-server/src/test/resources/local.test.jobsqldao.conf
+++ b/job-server/src/test/resources/local.test.jobsqldao.conf
@@ -3,6 +3,12 @@
 spark.jobserver {
   jobdao = spark.jobserver.io.JobSqlDAO
 
+  cassandra {
+    hosts = ["localhost:9142"]
+    chunk-size-in-kb = 8
+    user = ""
+    password = ""
+  }
   sqldao {
     rootdir = /tmp/spark-job-server-test/sqldao/data
     # https://coderwall.com/p/a2vnxg

--- a/job-server/test/spark.jobserver/WebApiMainRoutesSpec.scala
+++ b/job-server/test/spark.jobserver/WebApiMainRoutesSpec.scala
@@ -192,6 +192,7 @@ class WebApiMainRoutesSpec extends WebApiSpec {
           sealRoute(routes) ~> check {
         status should be (OK)
         responseAs[Map[String, Any]] should be (Map(
+          JobId -> "foo",
           ResultKey -> Map(
             masterConfKey->"overriden",
             bindConfKey -> bindConfVal,
@@ -223,6 +224,7 @@ class WebApiMainRoutesSpec extends WebApiSpec {
         sealRoute(routes) ~> check {
         status should be (OK)
         responseAs[Map[String, Any]] should be (Map(
+          JobId -> "foo",
           ResultKey -> Map(
             masterConfKey -> masterConfVal,
             bindConfKey -> bindConfVal,
@@ -251,6 +253,7 @@ class WebApiMainRoutesSpec extends WebApiSpec {
         sealRoute(routes) ~> check {
         status should be (OK)
         responseAs[Map[String, Any]] should be (Map(
+          JobId -> "foo",
           ResultKey -> Map(
             masterConfKey -> masterConfVal,
             bindConfKey -> bindConfVal,
@@ -347,7 +350,7 @@ class WebApiMainRoutesSpec extends WebApiSpec {
         status should be (OK)
         val result = responseAs[Map[String, Any]]
         result(StatusKey) should equal(JobStatus.Error)
-        result.keys should equal (Set(StatusKey, ResultKey))
+        result.keys should equal (Set(JobId, StatusKey, ResultKey))
         val exceptionMap = result(ResultKey).asInstanceOf[Map[String, Any]]
         exceptionMap should contain key ("cause")
         exceptionMap should contain key ("causingClass")

--- a/job-server/test/spark.jobserver/WebApiSpec.scala
+++ b/job-server/test/spark.jobserver/WebApiSpec.scala
@@ -51,6 +51,7 @@ with ScalatestRouteTest with HttpService {
   val finishedJobInfo = baseJobInfo.copy(endTime = Some(dt.plusMinutes(5)))
   val errorJobInfo = finishedJobInfo.copy(error =  Some(new Throwable("test-error")))
   val killedJobInfo = finishedJobInfo.copy(error =  Some(JobKilledException(finishedJobInfo.jobId)))
+  val JobId = "jobId"
   val StatusKey = "status"
   val ResultKey = "result"
   class DummyActor extends Actor {

--- a/job-server/test/spark.jobserver/io/JobCassandraDAOSpec.scala
+++ b/job-server/test/spark.jobserver/io/JobCassandraDAOSpec.scala
@@ -1,0 +1,330 @@
+package spark.jobserver.io
+
+import java.io.File
+import java.util.UUID
+
+import com.datastax.driver.core.Cluster
+import com.datastax.driver.core.utils.UUIDs
+import com.google.common.io.Files
+import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper
+import org.joda.time.DateTime
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
+import spark.jobserver.TestJarFinder
+import scala.concurrent.duration._
+import scala.concurrent.Await
+
+class JobCassandraDAOSpec extends TestJarFinder with FunSpecLike with Matchers with BeforeAndAfter
+  with BeforeAndAfterAll {
+
+  private val config = ConfigFactory.load("local.test.jobsqldao.conf")
+
+  var dao: JobCassandraDAO = _
+
+  // *** TEST DATA ***
+  val time: DateTime = new DateTime()
+  val timeout = 5 seconds
+  val throwable: Throwable = new Throwable("test-error")
+  // jar test data
+  val jarInfo: BinaryInfo = genJarInfo(false, false)
+  val jarBytes: Array[Byte] = Files.toByteArray(testJar)
+  var jarFile: File = new File(
+    config.getString("spark.jobserver.sqldao.rootdir"),
+    jarInfo.appName + "-" + jarInfo.uploadTime.toString("yyyyMMdd_hhmmss_SSS") + ".jar"
+  )
+
+  // jobInfo test data; order is important
+  val jobInfoNoEndNoErr:JobInfo = genJobInfo(jarInfo, false, false, false)
+  val expectedJobInfo = jobInfoNoEndNoErr
+  val jobInfoNoEndSomeErr: JobInfo = genJobInfo(jarInfo, false, true, false)
+  val jobInfoSomeEndNoErr: JobInfo = genJobInfo(jarInfo, true, false, false)
+  val jobInfoSomeEndSomeErr: JobInfo = genJobInfo(jarInfo, true, true, false)
+
+  // job config test data
+  val jobId: String = jobInfoNoEndNoErr.jobId
+  val jobConfig: Config = ConfigFactory.parseString("{marco=pollo}")
+  val expectedConfig: Config = ConfigFactory.empty()
+    .withValue("marco", ConfigValueFactory.fromAnyRef("pollo"))
+
+  // Helper functions and closures!!
+  private def genJarInfoClosure = {
+    var appCount: Int = 0
+    var timeCount: Int = 0
+
+    def genTestJarInfo(newAppName: Boolean, newTime: Boolean): BinaryInfo = {
+      appCount = appCount + (if (newAppName) 1 else 0)
+      timeCount = timeCount + (if (newTime) 1 else 0)
+
+      val app = "test-appName" + appCount
+      val upload = if (newTime) time.plusMinutes(timeCount) else time
+
+      BinaryInfo(app, BinaryType.Jar, upload)
+    }
+
+    genTestJarInfo _
+  }
+
+  private def genJobInfoClosure = {
+    var count: Int = 0
+
+    def genTestJobInfo(jarInfo: BinaryInfo, hasEndTime: Boolean, hasError: Boolean, isNew:Boolean):JobInfo ={
+      count = count + (if (isNew) 1 else 0)
+
+      val id: String = UUIDs.random().toString
+      val contextName: String = "test-context"
+      val classPath: String = "test-classpath"
+      val startTime: DateTime = new DateTime()
+
+      val noEndTime: Option[DateTime] = None
+      val someEndTime: Option[DateTime] = Some(startTime.plusSeconds(5)) // Any DateTime Option is fine
+      val noError: Option[Throwable] = None
+      val someError: Option[Throwable] = Some(throwable)
+
+      val endTime: Option[DateTime] = if (hasEndTime) someEndTime else noEndTime
+      val error: Option[Throwable] = if (hasError) someError else noError
+
+      Thread.sleep(2) // hack to guarantee order
+      JobInfo(id, contextName, jarInfo, classPath, startTime, endTime, error)
+    }
+
+    genTestJobInfo _
+  }
+
+  def genJarInfo: (Boolean, Boolean) => BinaryInfo = genJarInfoClosure
+  def genJobInfo: (BinaryInfo, Boolean, Boolean, Boolean) => JobInfo = genJobInfoClosure
+  //**********************************
+  override def beforeAll() {
+    EmbeddedCassandraServerHelper.startEmbeddedCassandra()
+    val session = Cluster.builder.addContactPoint("localhost").withPort(9142).build().connect()
+    session.execute(
+      "CREATE KEYSPACE spark_jobserver " +
+      "WITH replication={'class' : 'SimpleStrategy', 'replication_factor':1};")
+  }
+
+  before {
+    dao = new JobCassandraDAO(config)
+
+    jarFile.delete()
+  }
+
+  describe("save and get the jars") {
+    it("should be able to save one jar and get it back") {
+      // check the pre-condition
+      jarFile.exists() should equal (false)
+
+      // save
+      dao.saveBinary(jarInfo.appName, jarInfo.binaryType, jarInfo.uploadTime, jarBytes)
+
+      // read it back
+      val apps = Await.result(dao.getApps, timeout)
+
+      // test
+      jarFile.exists() should equal (true)
+      apps.keySet should equal (Set(jarInfo.appName))
+      apps(jarInfo.appName)._2 should equal (jarInfo.uploadTime)
+      apps(jarInfo.appName)._1 should be (BinaryType.Jar)
+    }
+
+    it("should be able to retrieve the jar file") {
+      // check the pre-condition
+      jarFile.exists() should equal (false)
+
+      // retrieve the jar file
+      val jarFilePath: String = dao.retrieveBinaryFile(jarInfo.appName, jarInfo.binaryType, jarInfo.uploadTime)
+
+      // test
+      jarFile.exists() should equal (true)
+      jarFilePath should equal (jarFile.getAbsolutePath)
+      val retrieved = new File(jarFilePath)
+      jarFile.length() should equal (retrieved.length())
+    }
+  }
+
+  describe("saveJobConfig() and getJobConfigs() tests") {
+    it("should provide an empty map on getJobConfigs() for an empty CONFIGS table") {
+      val configs = Await.result(dao.getJobConfigs, timeout)
+      (Map.empty[String, Config]) should equal (configs)
+    }
+
+    it("should save and get the same config") {
+      // save job config
+      dao.saveJobConfig(jobId, jobConfig)
+
+      // get all configs
+      val configs = Await.result(dao.getJobConfigs, timeout)
+
+      // test
+      configs.keySet should equal (Set(jobId))
+      configs(jobId) should equal (expectedConfig)
+    }
+
+    it("should be able to get previously saved config") {
+      // config saved in prior test
+
+      // get job configs
+      val configs = Await.result(dao.getJobConfigs, timeout)
+
+      // test
+      configs.keySet should equal (Set(jobId))
+      configs(jobId) should equal (expectedConfig)
+    }
+
+    it("Save a new config, bring down DB, bring up DB, should get configs from DB") {
+      val jobId2: String = genJobInfo(genJarInfo(false, false), false, false, true).jobId
+      val jobConfig2: Config = ConfigFactory.parseString("{merry=xmas}")
+      val expectedConfig2 = ConfigFactory.empty().withValue("merry", ConfigValueFactory.fromAnyRef("xmas"))
+      // config previously saved
+
+      // save new job config
+      dao.saveJobConfig(jobId2, jobConfig2)
+
+      // Destroy and bring up the DB again
+      dao = null
+      dao = new JobCassandraDAO(config)
+
+      // Get all configs
+      val configs = Await.result(dao.getJobConfigs, timeout)
+
+      // test
+      configs.keySet should equal (Set(jobId, jobId2))
+      configs.values.toSeq should contain (expectedConfig)
+      configs.values.toSeq should contain (expectedConfig2)
+    }
+  }
+
+  describe("Basic saveJobInfo() and getJobInfos() tests") {
+    it("should provide an empty Seq on getJobInfos() for an empty JOBS table") {
+      val jobs = Await.result(dao.getJobInfos(1), timeout)
+      (Seq.empty[JobInfo]) should equal (jobs)
+    }
+
+    it("should save a new JobInfo and get the same JobInfo") {
+      // save JobInfo
+      dao.saveJobInfo(jobInfoNoEndNoErr)
+
+      // get some JobInfos
+      val jobs = Await.result(dao.getJobInfos(10), timeout)
+
+      // test
+      jobs.head.jobId should equal (jobId)
+      jobs.head should equal (expectedJobInfo)
+    }
+
+    it("should be able to get previously saved JobInfo") {
+      // jobInfo saved in prior test
+
+      // get jobInfos
+      val jobInfo = Await.result(dao.getJobInfo(jobId), timeout).get
+
+      // test
+      jobInfo should equal (expectedJobInfo)
+    }
+
+    it("Save another new jobInfo, bring down DB, bring up DB, should JobInfos from DB") {
+      val jobInfo2 = genJobInfo(jarInfo, false, false, true)
+      val jobId2 = jobInfo2.jobId
+      val expectedJobInfo2 = jobInfo2
+      // jobInfo previously saved
+
+      // save new job config
+      dao.saveJobInfo(jobInfo2)
+
+      // Destroy and bring up the DB again
+      dao = null
+      dao = new JobCassandraDAO(config)
+
+      // Get jobInfos
+      val jobs = Await.result(dao.getJobInfos(2), timeout)
+      val jobIds = jobs map { _.jobId }
+
+      // test
+      jobIds should equal (Seq(jobId2, jobId))
+      jobs should equal (Seq(expectedJobInfo2, expectedJobInfo))
+    }
+
+    it("saving a JobInfo with the same jobId should update the JOBS table") {
+      val expectedNoEndSomeErr = jobInfoNoEndSomeErr
+      val expectedSomeEndNoErr = jobInfoSomeEndNoErr
+      val expectedSomeEndSomeErr = jobInfoSomeEndSomeErr
+      val exJobId = jobInfoNoEndNoErr.jobId
+
+      val info = genJarInfo(true, false)
+      info.uploadTime should equal (jarInfo.uploadTime)
+
+      // Get all jobInfos
+      val jobs: Seq[JobInfo] = Await.result(dao.getJobInfos(2), timeout)
+
+      // First Test
+      jobs.size should equal (2)
+      jobs.last should equal (expectedJobInfo)
+
+      // Second Test
+      // Cannot compare JobInfos directly if error is a Some(Throwable) because
+      // Throwable uses referential equality
+      dao.saveJobInfo(jobInfoNoEndSomeErr)
+      val jobs2 = Await.result(dao.getJobInfos(2), timeout)
+      jobs2.size should equal (2)
+      jobs2.last.endTime should equal (None)
+      jobs2.last.error.isDefined should equal (true)
+      intercept[Throwable] { jobs2.last.error.map(throw _) }
+      jobs2.last.error.get.getMessage should equal (throwable.getMessage)
+
+      // Third Test
+      dao.saveJobInfo(jobInfoSomeEndNoErr)
+      val jobs3 = Await.result(dao.getJobInfos(2), timeout)
+      jobs3.size should equal (2)
+      jobs3.last.error.isDefined should equal (false)
+      jobs3.last should equal (expectedSomeEndNoErr)
+
+      // Fourth Test
+      // Cannot compare JobInfos directly if error is a Some(Throwable) because
+      // Throwable uses referential equality
+      dao.saveJobInfo(jobInfoSomeEndSomeErr)
+      val jobs4 = Await.result(dao.getJobInfos(2), timeout)
+      jobs4.size should equal (2)
+      jobs4.last.endTime should equal (expectedSomeEndSomeErr.endTime)
+      jobs4.last.error.isDefined should equal (true)
+      intercept[Throwable] { jobs4.last.error.map(throw _) }
+      jobs4.last.error.get.getMessage should equal (throwable.getMessage)
+    }
+    it("retrieve by status equals running should be no end and no error") {
+      //save some job insure exist one running job
+      val dt1 = DateTime.now()
+      val dt2 = Some(DateTime.now())
+      val someError = Some(new Throwable("test-error"))
+      val finishedJob: JobInfo =
+        JobInfo(UUID.randomUUID.toString, "test", jarInfo, "test-class", dt1, dt2, None)
+      val errorJob: JobInfo =
+        JobInfo(UUID.randomUUID.toString, "test", jarInfo, "test-class", dt1, dt2, someError)
+      val runningJob: JobInfo =
+        JobInfo(UUID.randomUUID.toString, "test", jarInfo, "test-class", dt1, None, None)
+      dao.saveJobInfo(finishedJob)
+      dao.saveJobInfo(runningJob)
+      dao.saveJobInfo(errorJob)
+
+      //retrieve by status equals RUNNING
+      val retrieved = Await.result(dao.getJobInfos(3, Some(JobStatus.Running)), 60 seconds).head
+
+      //test
+      retrieved.endTime.isDefined should equal (false)
+      retrieved.error.isDefined should equal (false)
+    }
+    it("retrieve by status equals finished should be some end and no error") {
+
+      //retrieve by status equals FINISHED
+      val retrieved = Await.result(dao.getJobInfos(3, Some(JobStatus.Finished)), 60 seconds).head
+
+      //test
+      retrieved.endTime.isDefined should equal (true)
+      retrieved.error.isDefined should equal (false)
+    }
+
+    it("retrieve by status equals error should be some error") {
+      //retrieve by status equals ERROR
+      val retrieved = Await.result(dao.getJobInfos(3, Some(JobStatus.Error)), 60 seconds).head
+
+      //test
+      retrieved.error.isDefined should equal (true)
+    }
+  }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -33,7 +33,7 @@ object JobServerBuild extends Build {
   lazy val jobServer = Project(id = "job-server", base = file("job-server"),
     settings = commonSettings ++ revolverSettings ++ Assembly.settings ++ Seq(
       description  := "Spark as a Service: a RESTful job server for Apache Spark",
-      libraryDependencies ++= sparkDeps ++ slickDeps ++ securityDeps ++ coreTestDeps,
+      libraryDependencies ++= sparkDeps ++ slickDeps ++ cassandraDeps ++ securityDeps ++ coreTestDeps,
 
       // Automatically package the test jar when we run tests here
       // And always do a clean before package (package depends on clean) to clear out multiple versions

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -57,6 +57,11 @@ object Dependencies {
     "org.flywaydb" % "flyway-core" % flyway
   )
 
+  lazy val cassandraDeps = Seq(
+    "com.datastax.cassandra" % "cassandra-driver-core" % cassandra,
+    "com.datastax.cassandra" % "cassandra-driver-mapping" % cassandra
+  )
+
   lazy val logbackDeps = Seq(
     "ch.qos.logback" % "logback-classic" % logback
   )
@@ -66,7 +71,8 @@ object Dependencies {
   lazy val coreTestDeps = Seq(
     scalaTestDep,
     "com.typesafe.akka" %% "akka-testkit" % akka % "test",
-    "io.spray" %% "spray-testkit" % spray % "test"
+    "io.spray" %% "spray-testkit" % spray % "test",
+    "org.cassandraunit" % "cassandra-unit" % "2.2.2.1" % "test"
   )
 
   lazy val securityDeps = Seq(

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -13,6 +13,7 @@ object Versions {
   lazy val slick = "3.1.1"
   lazy val h2 = "1.3.176"
   lazy val postgres = "9.4.1209"
+  lazy val cassandra = "3.0.3"
   lazy val commons = "1.4"
   lazy val flyway = "3.2.1"
   lazy val logback = "1.0.7"


### PR DESCRIPTION
Support for cassandra datastorage backend. We discussed this with @velvia at gitter.
Implemented for cassandra 2.* 

Some details still need to be improved:
1. wontfix?: filter in cassandra, instead of application (by job status)

Schema: 
`
CREATE TABLE spark_jobserver.jobs (
    job_id uuid PRIMARY KEY,
    app_name text,
    binary_type text,
    classpath text,
    context_name text,
    end_time timestamp,
    error text,
    job_config text,
    start_date date,
    start_time timestamp,
    upload_time timestamp
) 

CREATE TABLE spark_jobserver.jobs_chronological (
    start_date date,
    start_time timestamp,
    job_id uuid,
    app_name text,
    binary_type text,
    classpath text,
    context_name text,
    end_time timestamp,
    error text,
    job_config text,
    upload_time timestamp,
    PRIMARY KEY (start_date, start_time, job_id)
) 

CREATE TABLE spark_jobserver.binaries (
    app_name text,
    binary_type text,
    upload_time timestamp,
    chunk_index int,
    binary blob,
    PRIMARY KEY ((app_name, binary_type, upload_time), chunk_index)
) 

CREATE TABLE spark_jobserver.jars_chronological (
    app_name text PRIMARY KEY,
    binary_type text,
    upload_time timestamp
) 
`