### PR TITLE
Include Python exception stacktrace on failure

### DIFF
--- a/ci/install-python-dependencies.sh
+++ b/ci/install-python-dependencies.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+pip install --upgrade pip
 pip install --user pyhocon
 pip3 install --user pyhocon
 pip install --user pep8

--- a/job-server-python/src/python/sparkjobserver/subprocess.py
+++ b/job-server-python/src/python/sparkjobserver/subprocess.py
@@ -22,7 +22,7 @@ from pyhocon import ConfigFactory
 from pyspark.context import SparkContext, SparkConf
 from pyspark.sql import SQLContext, HiveContext
 from sparkjobserver.api import ValidationProblem, JobEnvironment
-
+import traceback
 
 def exit_with_failure(message, exit_code=1):
     """
@@ -90,11 +90,11 @@ if __name__ == "__main__":
         else:
             exit_with_failure(
                     "Expected JavaSparkContext, SQLContext "
-                    "or HiveContext but received "+repr(context_class), 2)
+                    "or HiveContext but received %s" % repr(context_class), 2)
     try:
         job_data = job.validate(context, None, job_config)
     except Exception as error:
-        exit_with_failure("Error while calling 'validate'" + repr(error), 3)
+        exit_with_failure("Error while calling 'validate': %s\n%s" % (repr(error), traceback.format_exc()), 3)
     if isinstance(job_data, list) and \
             isinstance(job_data[0], ValidationProblem):
         entry_point.setValidationProblems([p.problem for p in job_data])
@@ -103,5 +103,5 @@ if __name__ == "__main__":
         try:
             result = job.run_job(context, job_env, job_data)
         except Exception as error:
-            exit_with_failure("Error while calling 'run_job'" + repr(error), 4)
+            exit_with_failure("Error while calling 'run_job': %s\n%s" % (repr(error), traceback.format_exc()), 4)
         entry_point.setResult(result)

--- a/job-server-python/src/python/sparkjobserver/subprocess.py
+++ b/job-server-python/src/python/sparkjobserver/subprocess.py
@@ -24,6 +24,7 @@ from pyspark.sql import SQLContext, HiveContext
 from sparkjobserver.api import ValidationProblem, JobEnvironment
 import traceback
 
+
 def exit_with_failure(message, exit_code=1):
     """
     Terminate the process with a specific message and error code
@@ -94,7 +95,9 @@ if __name__ == "__main__":
     try:
         job_data = job.validate(context, None, job_config)
     except Exception as error:
-        exit_with_failure("Error while calling 'validate': %s\n%s" % (repr(error), traceback.format_exc()), 3)
+        exit_with_failure(
+            "Error while calling 'validate': %s\n%s" %
+            (repr(error), traceback.format_exc()), 3)
     if isinstance(job_data, list) and \
             isinstance(job_data[0], ValidationProblem):
         entry_point.setValidationProblems([p.problem for p in job_data])
@@ -103,5 +106,7 @@ if __name__ == "__main__":
         try:
             result = job.run_job(context, job_env, job_data)
         except Exception as error:
-            exit_with_failure("Error while calling 'run_job': %s\n%s" % (repr(error), traceback.format_exc()), 4)
+            exit_with_failure(
+                "Error while calling 'run_job': %s\n%s" %
+                (repr(error), traceback.format_exc()), 4)
         entry_point.setResult(result)


### PR DESCRIPTION
Debugging exceptions was very difficult without the exception stack trace. There was also a whitespace missing.