### PR TITLE
Convert SparkHiveJob to use new API

### DIFF
--- a/job-server-extras/src/spark.jobserver/HiveTestJob.scala
+++ b/job-server-extras/src/spark.jobserver/HiveTestJob.scala
@@ -1,14 +1,16 @@
 package spark.jobserver
 
-import com.typesafe.config.{Config, ConfigFactory}
-import org.apache.spark._
+import com.typesafe.config.Config
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.hive.HiveContext
+import org.scalactic._
+import spark.jobserver.api.{JobEnvironment, ValidationProblem}
 
 /**
- * A test job that accepts a HiveContext, as opposed to the regular SparkContext.
- * Initializes some dummy data into a table, reads it back out, and returns a count
- * (Will create Hive metastore at job-server/metastore_db if Hive isn't configured)
- */
+  * A test job that accepts a HiveContext as opposed to the regular SparkContext.
+  * Initializes some dummy data into a table, reads it back out, and returns a count.
+  * Will create Hive metastore at job-server/metastore_db if Hive isn't configured.
+  */
 object HiveLoaderJob extends SparkHiveJob {
   // The following data is stored at ./hive_test_job_addresses.txt
   // val addresses = Seq(
@@ -17,6 +19,9 @@ object HiveLoaderJob extends SparkHiveJob {
   //   Address("Randy", "Charles", "101 A St.", "San Jose")
   // )
 
+  type JobData = Config
+  type JobOutput = Long
+
   val tableCreate = "CREATE TABLE `default`.`test_addresses`"
   val tableArgs = "(`firstName` String, `lastName` String, `address` String, `city` String)"
   val tableRowFormat = "ROW FORMAT DELIMITED FIELDS TERMINATED BY '\001'"
@@ -24,12 +29,13 @@ object HiveLoaderJob extends SparkHiveJob {
   val tableMapFormat = "MAP KEYS TERMINATED BY '\003' STORED"
   val tableAs = "AS TextFile"
 
-  //Will fail with a 'SemanticException : Invalid path' if this file is not there
+  // Will fail with a 'SemanticException : Invalid path' if this file doesn't exist.
   val loadPath = "'test/spark.jobserver/hive_test_job_addresses.txt'"
 
-  def validate(hive: HiveContext, config: Config): SparkJobValidation = SparkJobValid
+  def validate(hive: HiveContext, runtime: JobEnvironment, config: Config):
+  JobData Or Every[ValidationProblem] = Good(config)
 
-  def runJob(hive: HiveContext, config: Config): Any = {
+  def runJob(hive: HiveContext, runtime: JobEnvironment, config: JobData): JobOutput = {
     hive.sql("DROP TABLE if exists `default`.`test_addresses`")
     hive.sql(s"$tableCreate $tableArgs $tableRowFormat $tableColFormat $tableMapFormat $tableAs")
 
@@ -40,12 +46,16 @@ object HiveLoaderJob extends SparkHiveJob {
 }
 
 /**
- * This job simply runs the Hive SQL in the config.
- */
+  * This job simply runs the Hive SQL in the config.
+  */
 object HiveTestJob extends SparkHiveJob {
-  def validate(hive: HiveContext, config: Config): SparkJobValidation = SparkJobValid
+  type JobData = Config
+  type JobOutput = Array[Row]
 
-  def runJob(hive: HiveContext, config: Config): Any = {
+  def validate(hive: HiveContext, runtime: JobEnvironment, config: Config):
+  JobData Or Every[ValidationProblem] = Good(config)
+
+  def runJob(hive: HiveContext, runtime: JobEnvironment, config: JobData): JobOutput = {
     hive.sql(config.getString("sql")).collect()
   }
 }

--- a/job-server-extras/src/spark.jobserver/SparkHiveJob.scala
+++ b/job-server-extras/src/spark.jobserver/SparkHiveJob.scala
@@ -2,6 +2,6 @@ package spark.jobserver
 
 import org.apache.spark.sql.hive.HiveContext
 
-trait SparkHiveJob extends SparkJobBase {
+trait SparkHiveJob extends spark.jobserver.api.SparkJobBase {
   type C = HiveContext
 }


### PR DESCRIPTION
I wanted to use Hive jobs but it _looks_ like the only way to do that is by converting my jobs to the old, less type safe API. So I made this.

I would've converted SQL jobs also but I wasn't sure if there was a reason why SparkHiveJob used the older API.
