### PR TITLE
Use relative paths so it works if running in a context-path

### DIFF
--- a/job-server/src/main/resources/html/js/spark-jobserver-ui.js
+++ b/job-server/src/main/resources/html/js/spark-jobserver-ui.js
@@ -1,6 +1,6 @@
 function showJobs(filter,$tableBody) {
     $.getJSON(
-        '/jobs',
+        'jobs',
         filter,
         function(jobs) {
             $tableBody.html("");
@@ -29,7 +29,7 @@ function getJobs() {
 
 function getContexts() {
     $.getJSON(
-        '/contexts',
+        'contexts',
         '',
         function(contexts) {
             $('#contextsTable tbody').empty();
@@ -44,7 +44,7 @@ function getContexts() {
 
 function getJars() {
     $.getJSON(
-        '/jars',
+        'jars',
         '',
         function(jars) {
             $('#jarsTable tbody').empty();


### PR DESCRIPTION
We try to run the job-server behind reverse proxy with authentication as https://admin.example.org/spark-job-server/ but since the JSON is hardcoded to fetch root paths it will return 404. This change makes sure it requests the json relative to the root of the job-server directory