### PR TITLE
Change cluster status of removed contexts to down (fixes #466).

### DIFF
--- a/job-server/src/spark.jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/spark.jobserver/AkkaClusterSupervisorActor.scala
@@ -149,7 +149,9 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef) extends InstrumentedActor {
     case StopContext(name) =>
       if (contexts contains name) {
         logger.info("Shutting down context {}", name)
-        contexts(name)._1 ! PoisonPill
+        val contextActorRef = contexts(name)._1
+        cluster.down(contextActorRef.path.address)
+        contextActorRef ! PoisonPill
         sender ! ContextStopped
       } else {
         sender ! NoSuchContext


### PR DESCRIPTION
Running jobserver with context-per-jvm results in remote jobmanager
actors, manually joining the jobserver cluster. After removing a
context, the actor stops and becomes unreachable within the cluster. We
have to manually remove the actor from the cluster (status down) before
the cluster accepts new clients again.

See http://doc.akka.io/docs/akka/2.3.15/scala/cluster-usage.html#Automatic_vs__Manual_Downing