### PR TITLE
Previously, the OK responses returned a string equal to OK that did n…

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/JobServerSprayProtocol.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobServerSprayProtocol.scala
@@ -1,0 +1,16 @@
+package spark.jobserver
+
+import spray.json.DefaultJsonProtocol
+import spray.json._
+
+/**
+  * Created by alexsilva on 8/20/16.
+  */
+case class JobServerResponse(status: String, result: String) {
+  def isSuccess:Boolean = status == "SUCCESS"
+}
+
+object JobServerSprayProtocol extends DefaultJsonProtocol {
+  implicit val jobServerResponseFormat: RootJsonFormat[JobServerResponse] = jsonFormat2(JobServerResponse)
+
+}

--- a/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
@@ -3,24 +3,32 @@ package spark.jobserver
 import akka.actor.{Actor, ActorSystem, Props}
 import com.typesafe.config.ConfigFactory
 import org.joda.time.DateTime
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 import spark.jobserver.JobManagerActor.JobKilledException
 import spark.jobserver.io._
+import spray.client.pipelining._
+import JobServerSprayProtocol._
+import org.scalatest.time.{Seconds, Span}
+import spray.http.{ContentType, HttpHeader, HttpHeaders, MediaTypes}
+import spray.httpx.SprayJsonSupport
 import spray.routing.HttpService
 import spray.testkit.ScalatestRouteTest
+
+import scala.concurrent.{Await, Future}
 
 
 // Tests web response codes and formatting
 // Does NOT test underlying Supervisor / JarManager functionality
 // HttpService trait is needed for the sealRoute() which wraps exception handling
 class WebApiSpec extends FunSpec with Matchers with BeforeAndAfterAll
-with ScalatestRouteTest with HttpService {
+with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport {
   import scala.collection.JavaConverters._
 
   def actorRefFactory: ActorSystem = system
 
   val bindConfKey = "spark.jobserver.bind-address"
-  val bindConfVal = "127.0.0.1"
+  val bindConfVal = "0.0.0.0"
   val masterConfKey = "spark.master"
   val masterConfVal = "spark://localhost:7077"
   val config = ConfigFactory.parseString(s"""
@@ -29,6 +37,7 @@ with ScalatestRouteTest with HttpService {
       jobserver.bind-address = "$bindConfVal"
       jobserver.short-timeout = 3 s
     }
+    spray.can.server {}
     shiro {
       authentication = off
     }
@@ -168,6 +177,57 @@ with ScalatestRouteTest with HttpService {
 
       case GetJobConfig("badjobid") => sender ! NoSuchJobId
       case GetJobConfig(_)          => sender ! config
+    }
+  }
+
+  implicit override val patienceConfig = PatienceConfig(timeout = Span(5, Seconds), interval = Span(1, Seconds))
+
+  override def beforeAll():Unit = {
+    api.start()
+  }
+
+  describe ("The WebApi") {
+
+    val jsonContentType = HttpHeaders.`Content-Type`(ContentType(MediaTypes.`application/json`))
+
+    it ("Should return valid JSON when a jar is uploaded succesfully") {
+      val p = sendReceive ~> unmarshal[JobServerResponse]
+      val valid:Future[JobServerResponse] = p(Post("http://127.0.0.1:9999/jars/test-app","valid"))
+      whenReady(valid) { r=>
+        r.isSuccess shouldBe true
+        r.status shouldBe "SUCCESS"
+        r.result shouldBe "Jar uploaded"
+      }
+    }
+
+    it ("Should return valid JSON when creating a context") {
+      val p = sendReceive ~> unmarshal[JobServerResponse]
+      val valid:Future[JobServerResponse] = p(Post("http://127.0.0.1:9999/contexts/test-ctx","{}"))
+      whenReady(valid) { r=>
+        r.isSuccess shouldBe true
+        r.status shouldBe "SUCCESS"
+        r.result shouldBe "Context initialized"
+      }
+    }
+
+    it ("Should return valid JSON when stopping a context") {
+      val p = sendReceive ~> unmarshal[JobServerResponse]
+      val valid:Future[JobServerResponse] = p(Delete("http://127.0.0.1:9999/contexts/test-ctx"))
+      whenReady(valid) { r=>
+        r.isSuccess shouldBe true
+        r.status shouldBe "SUCCESS"
+        r.result shouldBe "Context stopped"
+      }
+    }
+
+    it ("Should return valid JSON when resetting a context") {
+      val p = sendReceive ~> unmarshal[JobServerResponse]
+      val valid:Future[JobServerResponse] = p(Put("http://127.0.0.1:9999/contexts?reset=reboot"))
+      whenReady(valid) { r=>
+        r.isSuccess shouldBe true
+        r.status shouldBe "SUCCESS"
+        r.result shouldBe "Context reset"
+      }
     }
   }
 }


### PR DESCRIPTION
…ot comply to the application/json content-type. This was causing any client libraries to break. What I did was a simple (possible temporary) fix which modified all complete(StatusCodes.OK) in the WebApi class to return complete(StatusCodes.OK,Map(statusKey,resultKey). This way, the 200 responses will comply with the JSON content type.