### PR TITLE
fix: exclude org.jboss.netty classes

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
     // Akka is provided because Spark already includes it, and Spark's version is shaded so it's not safe
     // to use this one
     "com.typesafe.akka" %% "akka-slf4j" % akka % "provided",
-    "com.typesafe.akka" %% "akka-cluster" % akka exclude("com.typesafe.akka", "akka-remote"),
+    "com.typesafe.akka" %% "akka-cluster" % akka exclude("io.netty", "netty"),
     "io.spray" %% "spray-json" % sprayJson,
     "io.spray" %% "spray-can" % spray,
     "io.spray" %% "spray-caching" % spray,


### PR DESCRIPTION
The akka-remote transitive dependency brings an older io.netty jar
into the assembly causing an occasional Java verifier exception when
starting SJS.

See <https://github.com/sbt/sbt/issues/1518> why the simple exclude of
akka-remote does not work.

Per discussion in https://github.com/spark-jobserver/spark-jobserver/issues/644