### PR TITLE
Send result before finish event in job manager actor

### DIFF
--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -35,6 +35,14 @@ If your job returns a large job result, it may exceed Akka's maximum network mes
 
     akka.remote.netty.tcp.maximum-frame-size = 100 MiB
 
+## Job with status finished has no result
+
+On jobs with large results or many concurrent jobs, the REST API at `/job/abc..` might return status `FINISHED` but does not contains any result. This might happen in two cases:
+
+1. the job finished right now and results are in transfer.
+2. the job finished some time ago and results are remove from results cache already. See `spark.jobserver.job-result-cache-size` to increase the cache.
+
+
 ## AskTimeout when starting job server or contexts
 
 If you are loading large jars or dependent jars, either at startup or when creating a large context, the database such as H2 may take a really long time to write those bytes to disk.  You need to adjust the context timeout setting:

--- a/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
@@ -305,7 +305,6 @@ class JobManagerActor(contextConfig: Config, daoActor: ActorRef) extends Instrum
       }
     }(executionContext).andThen {
       case Success(result: Any) =>
-        statusActor ! JobFinished(jobId, DateTime.now())
         // TODO: If the result is Stream[_] and this is running with context-per-jvm=true configuration
         // serializing a Stream[_] blob across process boundaries is not desirable.
         // In that scenario an enhancement is required here to chunk stream results back.
@@ -316,6 +315,7 @@ class JobManagerActor(contextConfig: Config, daoActor: ActorRef) extends Instrum
         // Either way an enhancement would be required here to make Stream[_] responses work
         // with context-per-jvm=true configuration
         resultActor ! JobResult(jobId, result)
+        statusActor ! JobFinished(jobId, DateTime.now())
       case Failure(error: Throwable) =>
         // Wrapping the error inside a RuntimeException to handle the case of throwing custom exceptions.
         val wrappedError = wrapInRuntimeException(error)

--- a/job-server/src/test/scala/spark/jobserver/JobManagerSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobManagerSpec.scala
@@ -85,6 +85,18 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
       expectNoMsg()
     }
 
+    it("should start job and return result before job finish event") {
+      manager ! JobManagerActor.Initialize(None)
+      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+
+      uploadTestJar()
+      manager ! JobManagerActor.StartJob("demo", wordCountClass, stringConfig, allEvents)
+      expectMsgClass(startJobWait, classOf[JobStarted])
+      expectMsgClass(classOf[JobResult])
+      expectMsgClass(classOf[JobFinished])
+      expectNoMsg()
+    }
+
     it("should start job more than one time and return result successfully (all events)") {
       manager ! JobManagerActor.Initialize(None)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])

--- a/job-server/src/test/scala/spark/jobserver/JobWithNamedRddsSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobWithNamedRddsSpec.scala
@@ -26,6 +26,10 @@ class JobWithNamedRddsSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
   job.namedObjects = new JobServerNamedObjects(system)
   val namedTestRdds = job.namedRdds
 
+  before {
+    namedTestRdds.getNames().foreach { namedTestRdds.destroy }
+  }
+
   override def afterAll() {
     sc.stop()
     AkkaTestUtils.shutdownAndWait(system)

--- a/job-server/src/test/scala/spark/jobserver/WebApiMainRoutesSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiMainRoutesSpec.scala
@@ -279,8 +279,8 @@ class WebApiMainRoutesSpec extends WebApiSpec {
       }
     }
 
-    it("should be able to query job result from /jobs/<id> route") {
-      Get("/jobs/foobar") ~> sealRoute(routes) ~> check {
+    it("should be able to query a running job from /jobs/<id> route") {
+      Get("/jobs/_running") ~> sealRoute(routes) ~> check {
         status should be (OK)
         responseAs[Map[String, String]] should be (Map(
           "jobId" -> "foo-1",
@@ -288,9 +288,29 @@ class WebApiMainRoutesSpec extends WebApiSpec {
           "classPath" -> "com.abc.meme",
           "context"  -> "context",
           "duration" -> "Job not done yet",
-          StatusKey -> JobStatus.Running,
-          ResultKey -> "foobar!!!"
+          StatusKey -> JobStatus.Running
         ))
+      }
+    }
+
+    it("should be able to query finished job with result from /jobs/<id> route") {
+      Get("/jobs/_finished") ~> sealRoute(routes) ~> check {
+        status should be (OK)
+        responseAs[Map[String, String]] should be (Map(
+          "jobId" -> "foo-1",
+          "startTime" -> "2013-05-29T00:00:00.000Z",
+          "classPath" -> "com.abc.meme",
+          "context"  -> "context",
+          "duration" -> "300.0 secs",
+          StatusKey -> JobStatus.Finished,
+          ResultKey -> "_finished!!!"
+        ))
+      }
+    }
+
+    it("should respond with 404 Not Found from /jobs/<id> route if status of jobId does not exist") {
+      Get("/jobs/_no_status") ~> sealRoute(routes) ~> check {
+        status should be (NotFound)
       }
     }
 

--- a/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
@@ -87,15 +87,23 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
         sender ! JobResult("_seq", Seq(1, 2, Map("3" -> "three")))
       case GetJobResult("_stream") =>
         sender ! JobResult("_stream", "\"1, 2, 3, 4, 5, 6, 7\"".getBytes().toStream)
-      case GetJobStatus("_num") =>
-        sender ! finishedJobInfo
       case GetJobStatus("_stream") =>
+        sender ! finishedJobInfo
+      case GetJobStatus("_num") =>
         sender ! finishedJobInfo
       case GetJobResult("_num") =>
         sender ! JobResult("_num", 5000)
       case GetJobStatus("_unk") =>
         sender ! finishedJobInfo
       case GetJobResult("_unk") => sender ! JobResult("_case", Seq(1, math.BigInt(101)))
+      case GetJobStatus("_running") =>
+        sender ! baseJobInfo
+      case GetJobResult("_running") =>
+        sender ! baseJobInfo
+      case GetJobStatus("_finished") =>
+        sender ! finishedJobInfo
+      case GetJobStatus("_no_status") =>
+        sender ! NoSuchJobId
       case GetJobStatus("job_to_kill") => sender ! baseJobInfo
       case GetJobStatus(id) => sender ! baseJobInfo
       case GetJobResult(id) => sender ! JobResult(id, id + "!!!")


### PR DESCRIPTION
We poll the REST API for job status/result and sometimes the json contains status finished but no result. 
This happens if the job manager send a status update (finished) but did not yet finished the results transfer.

This PR fix the send order within the job manager actor and improves the web api error handling.
