### PR TITLE
Add -p to mkdir to create full path

### DIFF
--- a/bin/ec2_deploy.sh
+++ b/bin/ec2_deploy.sh
@@ -8,7 +8,7 @@ bin=`cd "$bin"; pwd`
 SPARK_DIR=ec2Cluster
 if [ ! -d "$bin"/../$SPARK_DIR ]; then
     mkdir "$bin"/../$SPARK_DIR
-    mkdir "$bin"/../$SPARK_DIR/deploy.generic/root/spark-ec2
+    mkdir -p "$bin"/../$SPARK_DIR/deploy.generic/root/spark-ec2
     wget -P "$bin"/../$SPARK_DIR/deploy.generic/root/spark-ec2 https://raw.githubusercontent.com/amplab/spark-ec2/branch-1.6/deploy.generic/root/spark-ec2/ec2-variables.sh
     wget -P "$bin"/../$SPARK_DIR https://raw.githubusercontent.com/amplab/spark-ec2/branch-1.6/spark_ec2.py
     wget -P "$bin"/../$SPARK_DIR https://raw.githubusercontent.com/amplab/spark-ec2/branch-1.6/spark-ec2


### PR DESCRIPTION
Running ec2_deploy.sh fails with:

mkdir: /Users/mnelson/git/spark-jobserver/bin/../ec2Cluster/deploy.generic/root: No such file or directory

because mkdir is trying to create multiple directory levels without the -p option.