### PR TITLE
Eliminate POST and DEL /job race conditions

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
@@ -159,7 +159,9 @@ class JobManagerActor(contextConfig: Config, daoActor: ActorRef) extends Instrum
 
     case KillJob(jobId: String) => {
       jobContext.sparkContext.cancelJobGroup(jobId)
-      statusActor ! JobKilled(jobId, DateTime.now())
+      val resp = JobKilled(jobId, DateTime.now())
+      statusActor ! resp
+      sender ! resp
     }
 
     case SparkContextStatus => {

--- a/job-server/src/main/scala/spark/jobserver/WebApi.scala
+++ b/job-server/src/main/scala/spark/jobserver/WebApi.scala
@@ -514,8 +514,12 @@ class WebApi(system: ActorSystem,
                 notFound(ctx, "No such job ID " + jobId)
               case JobInfo(_, contextName, _, classPath, _, None, _) =>
                 val jobManager = getJobManagerForContext(Some(contextName), config, classPath)
-                jobManager.get ! KillJob(jobId)
-                ctx.complete(Map(StatusKey -> JobStatus.Killed))
+                val future = jobManager.get ? KillJob(jobId)
+                future.map {
+                  case JobKilled(_, _) => ctx.complete(Map(StatusKey -> JobStatus.Killed))
+                }.recover {
+                  case e: Exception => ctx.complete(500, errMap(e, "ERROR"))
+                }
               case JobInfo(_, _, _, _, _, _, Some(ex)) =>
                 ctx.complete(Map(StatusKey -> JobStatus.Error, "ERROR" -> formatException(ex)))
               case JobInfo(_, _, _, _, _, Some(e), None) =>
@@ -598,8 +602,12 @@ class WebApi(system: ActorSystem,
                           Map[String, String]("jobId" -> jobId) ++ errMap(ex, "ERROR")
                         )
                         case JobStarted(_, jobInfo) =>
-                          jobInfoActor ! StoreJobConfig(jobInfo.jobId, postedJobConfig)
-                          ctx.complete(202, getJobReport(jobInfo, true))
+                          val future = jobInfoActor ? StoreJobConfig(jobInfo.jobId, postedJobConfig)
+                          future.map {
+                            case JobConfigStored => ctx.complete(202, getJobReport(jobInfo, true))
+                          }.recover {
+                            case e: Exception => ctx.complete(500, errMap(e, "ERROR"))
+                          }
                         case JobValidationFailed(_, _, ex) =>
                           ctx.complete(400, errMap(ex, "VALIDATION FAILED"))
                         case NoSuchApplication => notFound(ctx, "appName " + appName + " not found")

--- a/job-server/src/test/scala/spark/jobserver/JobManagerSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobManagerSpec.scala
@@ -243,15 +243,16 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
       expectMsgPF(5.seconds.dilated, "Did not get JobResult") {
         case JobStarted(id, _) =>
           manager ! KillJob(id)
+          // we need this twice as we send both to sender and manager, in unit tests they are the same
+          // in usage they may be different
           expectMsgClass(classOf[JobKilled])
-
+          expectMsgClass(classOf[JobKilled])
       }
     }
 
     it("should fail a job that requires job jar dependencies but doesn't provide the jar"){
       manager ! JobManagerActor.Initialize(None)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
-
 
       uploadTestJar()
       val jobJarDepsConfigs = ConfigFactory.parseString(

--- a/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
@@ -183,8 +183,12 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
         if (events.contains(classOf[JobResult])) sender ! JobResult("foo.stream", result)
         statusActor ! Unsubscribe("foo.stream", sender)
 
+
       case GetJobConfig("badjobid") => sender ! NoSuchJobId
       case GetJobConfig(_)          => sender ! config
+
+      case StoreJobConfig(_, _) => sender ! JobConfigStored
+      case KillJob(jobId) => sender ! JobKilled(jobId, DateTime.now())
     }
   }
 
@@ -239,4 +243,3 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
     }
   }
 }
-


### PR DESCRIPTION
For both these routes, there was a race condition when you immediately
try and check the status of a job after starting or stopping it.

For example, if you POST'ed an async job and then immediately try and
do a GET on that jobId, the jobInfoActor may not have persisted the job
yet, so you would get a 404. Similiar could happen for stopping a job,
if you immediately tried to GET after cancelling, it may still show as
  RUNNING