### PR TITLE
Refactor contextSupervisors, fix atomic context

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -4,18 +4,15 @@ import java.io.IOException
 import java.nio.file.{Files, Paths}
 import java.nio.charset.Charset
 import java.util.concurrent.TimeUnit
+import scala.collection.mutable
+import scala.util.Try
 
 import akka.actor._
-import akka.cluster.Cluster
-import akka.cluster.ClusterEvent.{InitialStateAsEvents, MemberEvent, MemberUp}
-import akka.util.Timeout
-import com.typesafe.config.{Config, ConfigFactory, ConfigRenderOptions}
+import akka.cluster.{Cluster, Member}
+import akka.cluster.ClusterEvent.{InitialStateAsEvents, MemberEvent}
+import com.typesafe.config.{Config, ConfigRenderOptions}
 import spark.jobserver.util.SparkJobUtils
-import scala.collection.mutable
-import scala.util.{Failure, Success, Try}
 import scala.sys.process._
-
-import spark.jobserver.common.akka.InstrumentedActor
 
 /**
  * The AkkaClusterSupervisorActor launches Spark Contexts as external processes
@@ -35,13 +32,10 @@ import spark.jobserver.common.akka.InstrumentedActor
  *   }
  * }}}
  */
-class AkkaClusterSupervisorActor(daoActor: ActorRef) extends InstrumentedActor {
-  import ContextSupervisor._
+class AkkaClusterSupervisorActor(daoActor: ActorRef) extends BaseSupervisorActor {
   import scala.collection.JavaConverters._
   import scala.concurrent.duration._
 
-  val config = context.system.settings.config
-  val defaultContextConfig = config.getConfig("spark.context-settings")
   val contextInitTimeout = config.getDuration("spark.context-settings.context-init-timeout",
                                                 TimeUnit.SECONDS)
   val managerStartCommand = config.getString("deploy.manager-start-cmd")
@@ -51,17 +45,11 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef) extends InstrumentedActor {
   //TODO: try to pass this state to the jobManager at start instead of having to track
   //extra state.  What happens if the WebApi process dies before the forked process
   //starts up?  Then it never gets initialized, and this state disappears.
-  private val contextInitInfos = mutable.HashMap.empty[String, (Boolean, ActorRef => Unit, Throwable => Unit)]
-
-  // actor name -> (JobManagerActor ref, ResultActor ref)
-  private val contexts = mutable.HashMap.empty[String, (ActorRef, ActorRef)]
+  protected val contextInitInfos =
+    mutable.HashMap.empty[String, (Boolean, ActorRef => Unit, Throwable => Unit)]
 
   private val cluster = Cluster(context.system)
   private val selfAddress = cluster.selfAddress
-
-  // This is for capturing results for ad-hoc jobs. Otherwise when ad-hoc job dies, resultActor also dies,
-  // and there is no way to retrieve results.
-  val globalResultActor = context.actorOf(Props[JobResultActor], "global-result-actor")
 
   logger.info("AkkaClusterSupervisor initialized on {}", selfAddress)
 
@@ -75,137 +63,47 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef) extends InstrumentedActor {
     cluster.leave(selfAddress)
   }
 
-  def wrappedReceive: Receive = {
-    case MemberUp(member) =>
-      if (member.hasRole("manager")) {
-        val memberActors = RootActorPath(member.address) / "user" / "*"
-        context.actorSelection(memberActors) ! Identify(memberActors)
-      }
-
-    case ActorIdentity(memberActors, actorRefOpt) =>
-      actorRefOpt.foreach{ actorRef =>
-        val actorName = actorRef.path.name
-        if (actorName.startsWith("jobManager")) {
-          logger.info("Received identify response, attempting to initialize context at {}", memberActors)
-          (for { (isAdHoc, successFunc, failureFunc) <- contextInitInfos.remove(actorName) }
-           yield {
-             initContext(actorName, actorRef, contextInitTimeout)(isAdHoc, successFunc, failureFunc)
-           }).getOrElse({
-            logger.warn("No initialization or callback found for jobManager actor {}", actorRef.path)
-            actorRef ! PoisonPill
-          })
-        }
-      }
-
-
-    case AddContextsFromConfig =>
-      addContextsFromConfig(config)
-
-    case ListContexts =>
-      sender ! contexts.keys.toSeq
-
-    case AddContext(name, contextConfig) =>
-      val originator = sender()
-      val mergedConfig = contextConfig.withFallback(defaultContextConfig)
-      // TODO(velvia): This check is not atomic because contexts is only populated
-      // after SparkContext successfully created!  See
-      // https://github.com/spark-jobserver/spark-jobserver/issues/349
-      if (contexts contains name) {
-        originator ! ContextAlreadyExists
-      } else {
-        startContext(name, mergedConfig, false) { ref =>
-          originator ! ContextInitialized
-        } { err =>
-          originator ! ContextInitError(err)
-        }
-      }
-
-    case StartAdHocContext(classPath, contextConfig) =>
-      val originator = sender()
-      val mergedConfig = contextConfig.withFallback(defaultContextConfig)
-
-      var contextName = ""
-      do {
-        contextName = java.util.UUID.randomUUID().toString().take(8) + "-" + classPath
-      } while (contexts contains contextName)
-      // TODO(velvia): Make the check above atomic.  See
-      // https://github.com/spark-jobserver/spark-jobserver/issues/349
-
-      startContext(contextName, mergedConfig, true) { ref =>
-        originator ! contexts(contextName)
-      } { err =>
-        originator ! ContextInitError(err)
-      }
-
-    case GetResultActor(name) =>
-      sender ! contexts.get(name).map(_._2).getOrElse(globalResultActor)
-
-    case GetContext(name) =>
-      if (contexts contains name) {
-        sender ! contexts(name)
-      } else {
-        sender ! NoSuchContext
-      }
-
-    case StopContext(name) =>
-      if (contexts contains name) {
-        logger.info("Shutting down context {}", name)
-        val contextActorRef = contexts(name)._1
-        cluster.down(contextActorRef.path.address)
-        contextActorRef ! PoisonPill
-        sender ! ContextStopped
-      } else {
-        sender ! NoSuchContext
-      }
-
-    case Terminated(actorRef) =>
-      val name: String = actorRef.path.name
-      logger.info("Actor terminated: {}", name)
-      contexts.retain { case (name, (jobMgr, resActor)) => jobMgr != actorRef }
-  }
-
-  private def initContext(actorName: String, ref: ActorRef, timeoutSecs: Long = 1)
-                         (isAdHoc: Boolean,
-                          successFunc: ActorRef => Unit,
-                          failureFunc: Throwable => Unit): Unit = {
-    import akka.pattern.ask
-
-    val resultActor = if (isAdHoc) globalResultActor else context.actorOf(Props(classOf[JobResultActor]))
-    (ref ? JobManagerActor.Initialize(
-      Some(resultActor)))(Timeout(timeoutSecs.second)).onComplete {
-      case Failure(e:Exception) =>
-        logger.info("Failed to send initialize message to context " + ref, e)
-        ref ! PoisonPill
-        failureFunc(e)
-      case Success(JobManagerActor.InitError(t)) =>
-        logger.info("Failed to initialize context " + ref, t)
-        ref ! PoisonPill
-        failureFunc(t)
-      case Success(JobManagerActor.Initialized(ctxName, resActor)) =>
-        logger.info("SparkContext {} joined", ctxName)
-        contexts(ctxName) = (ref, resActor)
-        context.watch(ref)
-        successFunc(ref)
-      case _ => logger.info("Failed for unknown reason.")
-        ref ! PoisonPill
-        failureFunc(new RuntimeException("Failed for unknown reason."))
+  protected def onMemberUp(member: Member): Unit = {
+    if (member.hasRole("manager")) {
+      val memberActors = RootActorPath(member.address) / "user" / "*"
+      context.actorSelection(memberActors) ! Identify(memberActors)
     }
   }
 
-  private def startContext(name: String, contextConfig: Config, isAdHoc: Boolean)
-                          (successFunc: ActorRef => Unit)(failureFunc: Throwable => Unit): Unit = {
-    require(!(contexts contains name), "There is already a context named " + name)
-    val contextActorName = "jobManager-" + java.util.UUID.randomUUID().toString.substring(16)
+  protected def onActorIdentity(memberActors: Any, actorRefOpt: Option[ActorRef]): Unit = {
+    actorRefOpt.foreach { (actorRef) =>
+      val actorName = actorRef.path.name
+      if (actorName.startsWith("jobManager")) {
+        logger.info("Received identify response, attempting to initialize context at {}", memberActors)
+        (for { (isAdHoc, successFunc, failureFunc) <- contextInitInfos.remove(actorName) }
+         yield {
+           initContext(actorName, actorRef, getTimeout())(isAdHoc, successFunc, failureFunc)
+         }).getOrElse({
+          logger.warn("No initialization or callback found for jobManager actor {}", actorRef.path)
+          actorRef ! PoisonPill
+        })
+      }
+    }
+  }
 
-    logger.info("Starting context with actor name {}", contextActorName)
+  protected def onStopContext(actor: ActorRef): Unit = {
+    cluster.down(actor.path.address)
+  }
+  protected def getTimeout(): Long = contextInitTimeout
+
+  protected def startContext(
+    name: String, actorName: String, contextConfig: Config, isAdHoc: Boolean
+  )(successFunc: ActorRef => Unit, failureFunc: Throwable => Unit): Unit = {
+
+    logger.info("Starting context with actor name {}", actorName)
 
     val contextDir: java.io.File = try {
-        createContextDir(name, contextConfig, isAdHoc, contextActorName)
-      } catch {
-        case e: Exception =>
-          failureFunc(e)
-          return
-      }
+      createContextDir(name, contextConfig, isAdHoc, actorName)
+    } catch {
+      case e: Exception =>
+        failureFunc(e)
+        return
+    }
 
     //extract spark.proxy.user from contextConfig, if available and pass it to $managerStartCommand
     var cmdString = s"$managerStartCommand $contextDir ${selfAddress.toString}"
@@ -215,10 +113,12 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef) extends InstrumentedActor {
     }
 
     val pb = Process(cmdString)
-    val pio = new ProcessIO(_ => (),
-                        stdout => scala.io.Source.fromInputStream(stdout)
-                          .getLines.foreach(println),
-                        stderr => scala.io.Source.fromInputStream(stderr).getLines().foreach(println))
+    val pio = new ProcessIO(
+      (_) => (),
+      (stdout) => scala.io.Source.fromInputStream(stdout)
+        .getLines.foreach(println),
+      (stderr) => scala.io.Source.fromInputStream(stderr).getLines().foreach(println)
+    )
     logger.info("Starting to execute sub process {}", pb)
     val processStart = Try {
       val process = pb.run(pio)
@@ -229,49 +129,43 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef) extends InstrumentedActor {
     }
 
     if (processStart.isSuccess) {
-      contextInitInfos(contextActorName) = (isAdHoc, successFunc, failureFunc)
+      contextInitInfos(actorName) = (isAdHoc, successFunc, failureFunc)
     } else {
       failureFunc(processStart.failed.get)
     }
-
   }
 
-  private def createContextDir(name: String,
-                               contextConfig: Config,
-                               isAdHoc: Boolean,
-                               actorName: String): java.io.File = {
+  private def createContextDir(
+    name: String,
+    contextConfig: Config,
+    isAdHoc: Boolean,
+    actorName: String
+   ): java.io.File = {
     // Create a temporary dir, preferably in the LOG_DIR
     val encodedContextName = java.net.URLEncoder.encode(name, "UTF-8")
+
     val tmpDir = Option(System.getProperty("LOG_DIR")).map { logDir =>
       Files.createTempDirectory(Paths.get(logDir), s"jobserver-$encodedContextName")
     }.getOrElse(Files.createTempDirectory("jobserver"))
+
     logger.info("Created working directory {} for context {}", tmpDir: Any, name)
 
     // Now create the contextConfig merged with the values we need
-    val mergedConfig = ConfigFactory.parseMap(
-                         Map("is-adhoc" -> isAdHoc.toString,
-                             "context.name" -> name,
-                             "context.actorname" -> actorName).asJava
-                       ).withFallback(contextConfig)
+    val mergedConfig = createMergedActorConfig(name, actorName, contextConfig, isAdHoc)
 
     // Write out the config to the temp dir
-    Files.write(tmpDir.resolve("context.conf"),
-                Seq(mergedConfig.root.render(ConfigRenderOptions.concise)).asJava,
-                Charset.forName("UTF-8"))
+    Files.write(
+      tmpDir.resolve("context.conf"),
+      Seq(mergedConfig.root.render(ConfigRenderOptions.concise)).asJava,
+      Charset.forName("UTF-8")
+    )
 
     tmpDir.toFile
   }
 
-  private def addContextsFromConfig(config: Config) {
-    for (contexts <- Try(config.getObject("spark.contexts"))) {
-      contexts.keySet().asScala.foreach { contextName =>
-        val contextConfig = config.getConfig("spark.contexts." + contextName)
-          .withFallback(defaultContextConfig)
-        startContext(contextName, contextConfig, false) { ref => } {
-          e => logger.error("Unable to start context" + contextName, e)
-        }
-      }
-    }
-
+  // we don't need any sleep between contexts in a cluster
+  override protected def createContextSleep(): Unit = {
   }
+
+
 }

--- a/job-server/src/main/scala/spark/jobserver/BaseSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/BaseSupervisorActor.scala
@@ -1,0 +1,260 @@
+package spark.jobserver
+
+import scala.collection.mutable
+import scala.util.{Failure, Success, Try}
+
+import akka.actor._
+import akka.cluster.Member
+import akka.cluster.ClusterEvent.MemberUp
+import akka.util.Timeout
+import com.typesafe.config.{Config, ConfigFactory}
+
+import spark.jobserver.common.akka.InstrumentedActor
+import spark.jobserver.JobManagerActor.{SparkContextAlive, SparkContextDead, SparkContextStatus}
+
+/** Messages common to all ContextSupervisors */
+object ContextSupervisor {
+  // Messages/actions
+  case object AddContextsFromConfig // Start up initial contexts
+  case object ListContexts
+  case class AddContext(name: String, contextConfig: Config)
+  case class StartAdHocContext(classPath: String, contextConfig: Config)
+  case class GetContext(name: String) // returns JobManager, JobResultActor
+  case class GetResultActor(name: String)  // returns JobResultActor
+  case class StopContext(name: String, retry: Boolean = true)
+
+  // Errors/Responses
+  case object ContextInitialized
+  case class ContextInitError(t: Throwable)
+  case object ContextAlreadyExists
+  case object NoSuchContext
+  case object ContextStopped
+}
+
+/**
+ * Abstract class that defines all the messages to be implemented
+ * in other supervisors
+ */
+abstract class BaseSupervisorActor extends InstrumentedActor {
+  import ContextSupervisor._
+  import scala.collection.JavaConverters._
+  import scala.concurrent.duration._
+
+  val config = context.system.settings.config
+  val defaultContextConfig = config.getConfig("spark.context-settings")
+
+  import context.dispatcher   // to get ExecutionContext for futures
+  import akka.pattern.ask
+
+  // This is for capturing results for ad-hoc jobs. Otherwise when ad-hoc job dies, resultActor also dies,
+  // and there is no way to retrieve results.
+  val globalResultActor = context.actorOf(Props[JobResultActor], "global-result-actor")
+
+  type SJSContext = (String, Option[ActorRef], Option[ActorRef])
+  // actor name -> (String contextActorName, Option[JobManagerActor] ref, Option[ResultActor] ref)
+  private val contexts = mutable.HashMap.empty[String, SJSContext]
+
+  def wrappedReceive: Receive = {
+    case MemberUp(member) =>
+      onMemberUp(member)
+
+    case ActorIdentity(memberActors, actorRefOpt) =>
+      onActorIdentity(memberActors, actorRefOpt)
+
+    case AddContextsFromConfig =>
+      addContextsFromConfig(config)
+
+    case ListContexts =>
+      sender ! listContexts()
+
+    case AddContext(name, contextConfig) =>
+      val originator = sender()
+      val mergedConfig = contextConfig.withFallback(defaultContextConfig)
+      if (haveContext(name)) {
+        originator ! ContextAlreadyExists
+      } else {
+        registerAndStartContext(name, mergedConfig, false)(
+          (ref) => originator ! ContextInitialized,
+          (err) => originator ! ContextInitError(err)
+        )
+      }
+
+    case StartAdHocContext(classPath, contextConfig) =>
+      val originator = sender()
+      val mergedConfig = contextConfig.withFallback(defaultContextConfig)
+
+      var contextName = ""
+      do {
+        contextName = java.util.UUID.randomUUID().toString().take(8) + "-" + classPath
+      } while (haveContext(contextName))
+      registerAndStartContext(contextName, mergedConfig, true)(
+        (ref) => originator ! getContext(contextName),
+        (err) => originator ! ContextInitError(err)
+      )
+
+    case GetResultActor(name) =>
+      if (haveContext(name)) {
+        sender ! getContext(name)._3.getOrElse(globalResultActor)
+      } else {
+        sender ! globalResultActor
+      }
+
+    case GetContext(name) =>
+      if (haveContext(name)) {
+        val actorOpt = getContext(name)._2
+        if (actorOpt.isDefined) {
+          val future = (actorOpt.get ? SparkContextStatus)(getTimeout().seconds)
+          val originator = sender
+          future.collect {
+            case SparkContextAlive => originator ! getContext(name)
+            case SparkContextDead =>
+              logger.info("SparkContext {} is dead", name)
+              self ! StopContext(name)
+              originator ! NoSuchContext
+          }
+        }
+      } else {
+        sender ! NoSuchContext
+      }
+
+    case StopContext(name, retry) =>
+      if (haveContext(name)) {
+        val contextActorOpt = getContext(name)._2
+        if (contextActorOpt.isDefined) {
+          val contextActorRef = contextActorOpt.get
+          logger.info("Shutting down context {}", name)
+          onStopContext(contextActorRef)
+          contextActorRef ! PoisonPill
+          sender ! ContextStopped
+        } else if (retry) {
+          logger.info(
+            "Context {} is not yet started, will try and stop after {} seconds",
+            name,
+            getTimeout()
+          )
+          // send another stopContext, but make the original sender appear as originator
+          context.system.scheduler.scheduleOnce(
+            getTimeout().seconds, self, StopContext(name, false)
+          )(context.dispatcher, sender)
+        } else {
+          logger.error("Context {} never started and was not removed, unexpected!, stopping!")
+          self ! PoisonPill
+        }
+      } else {
+        // if not in retry, its possible something else removed the context
+        // be safe and signal that the context was stopped
+        if (retry) {
+          sender ! NoSuchContext
+        } else {
+          sender ! ContextStopped
+        }
+      }
+
+    case Terminated(actorRef) =>
+      val name: String = actorRef.path.name
+      logger.info("Actor terminated: {}", name)
+      removeContext(name)
+  }
+
+  protected def haveContext(name: String): Boolean = contexts.contains(name)
+  protected def getContext(name: String): SJSContext = contexts(name)
+  protected def removeContext(actorName: String): Unit = {
+    contexts.retain { case (_, (curName, _, _)) => actorName != curName }
+  }
+  protected def listContexts(): Seq[String] = contexts.keys.toSeq
+
+  protected def addContextStarting(name: String, actorName: String) = {
+    contexts(name) = (actorName, None, None)
+  }
+  protected def addContext(name: String, context: SJSContext) = {
+    contexts(name) = context
+  }
+
+  protected def onMemberUp(member: Member): Unit
+  protected def onActorIdentity(memberActors: Any, actorRefOpt: Option[ActorRef]): Unit
+  protected def onStopContext(actor: ActorRef): Unit
+  protected def getTimeout(): Long
+
+  protected def startContext(
+    name: String, actorName: String, contextConfig: Config, isAdHoc: Boolean
+  )(successFunc: ActorRef => Unit, failureFunc: Throwable => Unit): Unit
+
+
+  protected def buildActorName(): String = "jobManager-" + java.util.UUID.randomUUID().toString.substring(16)
+
+  protected def registerAndStartContext(
+    name: String, contextConfig: Config, isAdHoc: Boolean
+  )(successFunc: ActorRef => Unit, failureFunc: Throwable => Unit): Unit = {
+    logger.info("Creating a SparkContext named {}", name)
+    val actorName = buildActorName()
+    addContextStarting(name, actorName)
+    startContext(name, actorName, contextConfig, isAdHoc)(successFunc, failureFunc)
+  }
+
+  protected def initContext(
+    actorName: String, ref: ActorRef, timeoutSecs: Long = 1
+  )(
+    isAdHoc: Boolean,
+    successFunc: ActorRef => Unit,
+    failureFunc: Throwable => Unit
+  ): Unit = {
+    val resultActor = if (isAdHoc) globalResultActor else context.actorOf(Props(classOf[JobResultActor]))
+    (ref ? JobManagerActor.Initialize(
+      Some(resultActor)))(Timeout(timeoutSecs.second)).onComplete {
+      case Failure(e:Exception) =>
+        logger.info("Failed to send initialize message to context " + ref, e)
+        removeContext(actorName)
+        ref ! PoisonPill
+        failureFunc(e)
+      case Success(JobManagerActor.InitError(t)) =>
+        logger.info("Failed to initialize context " + ref, t)
+        removeContext(actorName)
+        ref ! PoisonPill
+        failureFunc(t)
+      case Success(JobManagerActor.Initialized(ctxName, resActor)) =>
+        logger.info("SparkContext {} joined", ctxName)
+        // re-add the context, now with references
+        addContext(ctxName, (actorName, Some(ref), Some(resActor)))
+        context.watch(ref)
+        successFunc(ref)
+      case _ =>
+        logger.info("Failed for unknown reason.")
+        removeContext(actorName)
+        ref ! PoisonPill
+        failureFunc(new RuntimeException("Failed for unknown reason."))
+    }
+  }
+
+  // sleep between context creation
+  protected def createContextSleep(): Unit = {
+    Thread.sleep(500)
+  }
+
+
+  protected def createMergedActorConfig(
+    name: String, actorName: String, contextConfig: Config, isAdHoc: Boolean
+  ): Config = {
+    ConfigFactory.parseMap(
+      Map(
+        "is-adhoc" -> isAdHoc.toString,
+        "context.name" -> name,
+        "context.actorname" -> actorName
+      ).asJava
+    ).withFallback(contextConfig)
+  }
+
+  private def addContextsFromConfig(config: Config): Unit = {
+    for (contexts <- Try(config.getObject("spark.contexts"))) {
+      contexts.keySet().asScala.foreach { contextName =>
+        val contextConfig = config.getConfig("spark.contexts." + contextName)
+          .withFallback(defaultContextConfig)
+        registerAndStartContext(contextName, contextConfig, false)(
+          (ref) => Unit,
+          (e) => logger.error("Unable to start context" + contextName, e)
+        )
+        createContextSleep()
+      }
+    }
+  }
+
+}

--- a/job-server/src/main/scala/spark/jobserver/Exceptions.scala
+++ b/job-server/src/main/scala/spark/jobserver/Exceptions.scala
@@ -1,0 +1,4 @@
+package spark.jobserver
+
+class ContextNotReadyException extends Exception("context not yet ready, try again soon")
+class ContextNotFoundException extends Exception("context does not exist")

--- a/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
@@ -1,39 +1,10 @@
 package spark.jobserver
 
-import akka.actor.{ActorRef, PoisonPill, Props, Terminated}
-import akka.pattern.ask
-import akka.util.Timeout
+import akka.actor.ActorRef
+import akka.cluster.Member
 import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
-import spark.jobserver.JobManagerActor.{SparkContextAlive, SparkContextDead, SparkContextStatus}
-import spark.jobserver.io.JobDAO
+
 import spark.jobserver.util.SparkJobUtils
-import scala.collection.mutable
-import scala.concurrent.Await
-import scala.util.{Failure, Success, Try}
-
-import org.joda.time.DateTime
-import org.joda.time.format.DateTimeFormat
-import spark.jobserver.common.akka.InstrumentedActor
-
-/** Messages common to all ContextSupervisors */
-object ContextSupervisor {
-  // Messages/actions
-  case object AddContextsFromConfig // Start up initial contexts
-  case object ListContexts
-  case class AddContext(name: String, contextConfig: Config)
-  case class StartAdHocContext(classPath: String, contextConfig: Config)
-  case class GetContext(name: String) // returns JobManager, JobResultActor
-  case class GetResultActor(name: String)  // returns JobResultActor
-  case class StopContext(name: String)
-
-  // Errors/Responses
-  case object ContextInitialized
-  case class ContextInitError(t: Throwable)
-  case object ContextAlreadyExists
-  case object NoSuchContext
-  case object ContextStopped
-}
 
 /**
  * This class starts and stops JobManagers / Contexts in-process.
@@ -68,139 +39,23 @@ object ContextSupervisor {
  *   }
  * }}}
  */
-class LocalContextSupervisorActor(dao: ActorRef) extends InstrumentedActor {
-  import ContextSupervisor._
-  import scala.collection.JavaConverters._
-  import scala.concurrent.duration._
+class LocalContextSupervisorActor(dao: ActorRef) extends BaseSupervisorActor {
 
-  val config = context.system.settings.config
-  val defaultContextConfig = config.getConfig("spark.context-settings")
-  val contextTimeout = SparkJobUtils.getContextTimeout(config)
-  import context.dispatcher   // to get ExecutionContext for futures
+  val localContextTimeout = SparkJobUtils.getContextTimeout(config)
 
-  private val contexts = mutable.HashMap.empty[String, (ActorRef, ActorRef)]
+  protected def startContext(
+    name: String, actorName: String, contextConfig: Config, isAdHoc: Boolean
+  )(successFunc: ActorRef => Unit, failureFunc: Throwable => Unit) = {
 
-  // This is for capturing results for ad-hoc jobs. Otherwise when ad-hoc job dies, resultActor also dies,
-  // and there is no way to retrieve results.
-  val globalResultActor = context.actorOf(Props[JobResultActor], "global-result-actor")
-
-  def wrappedReceive: Receive = {
-    case AddContextsFromConfig =>
-      addContextsFromConfig(config)
-
-    case ListContexts =>
-      sender ! contexts.keys.toSeq
-
-    case AddContext(name, contextConfig) =>
-      val originator = sender // Sender is a mutable reference, must capture in immutable val
-      val mergedConfig = contextConfig.withFallback(defaultContextConfig)
-      if (contexts contains name) {
-        originator ! ContextAlreadyExists
-      } else {
-        startContext(name, mergedConfig, false, contextTimeout) { contextMgr =>
-          originator ! ContextInitialized
-        } { err =>
-          originator ! ContextInitError(err)
-        }
-      }
-
-    case StartAdHocContext(classPath, contextConfig) =>
-      val originator = sender // Sender is a mutable reference, must capture in immutable val
-      logger.info("Creating SparkContext for adhoc jobs.")
-
-      val mergedConfig = contextConfig.withFallback(defaultContextConfig)
-
-      // Keep generating context name till there is no collision
-      var contextName = ""
-      do {
-        contextName = java.util.UUID.randomUUID().toString().substring(0, 8) + "-" + classPath
-      } while (contexts contains contextName)
-
-      // Create JobManagerActor and JobResultActor
-      startContext(contextName, mergedConfig, true, contextTimeout) { contextMgr =>
-        originator ! contexts(contextName)
-      } { err =>
-        originator ! ContextInitError(err)
-      }
-
-    case GetResultActor(name) =>
-      sender ! contexts.get(name).map(_._2).getOrElse(globalResultActor)
-
-    case GetContext(name) =>
-      if (contexts contains name) {
-        val future = (contexts(name)._1 ? SparkContextStatus) (contextTimeout.seconds)
-        val originator = sender
-        future.collect {
-          case SparkContextAlive => originator ! contexts(name)
-          case SparkContextDead =>
-            logger.info("SparkContext {} is dead", name)
-            self ! StopContext(name)
-            originator ! NoSuchContext
-        }
-      } else {
-        sender ! NoSuchContext
-      }
-
-    case StopContext(name) =>
-      if (contexts contains name) {
-        logger.info("Shutting down context {}", name)
-        contexts(name)._1 ! PoisonPill
-        sender ! ContextStopped
-      } else {
-        sender ! NoSuchContext
-      }
-
-    case Terminated(actorRef) =>
-      val name = actorRef.path.name
-      logger.info("Actor terminated: " + name)
-      contexts.remove(name)
+    val mergedConfig = createMergedActorConfig(name, actorName, contextConfig, isAdHoc)
+    val ref = context.actorOf(JobManagerActor.props(mergedConfig, dao), actorName)
+    initContext(actorName, ref, getTimeout())(isAdHoc, successFunc, failureFunc)
   }
 
-  private def startContext(name: String, contextConfig: Config, isAdHoc: Boolean, timeoutSecs: Int = 1)
-                          (successFunc: ActorRef => Unit)
-                          (failureFunc: Throwable => Unit) {
-    require(!(contexts contains name), "There is already a context named " + name)
-    logger.info("Creating a SparkContext named {}", name)
-
-    val resultActorRef = if (isAdHoc) Some(globalResultActor) else None
-    val mergedConfig = ConfigFactory.parseMap(
-                         Map("is-adhoc" -> isAdHoc.toString,
-                             "context.name" -> name,
-                             "context.actorname" -> name).asJava
-                       ).withFallback(contextConfig)
-    val ref = context.actorOf(JobManagerActor.props(mergedConfig, dao), name)
-    (ref ? JobManagerActor.Initialize(
-      resultActorRef))(Timeout(timeoutSecs.second)).onComplete {
-      case Failure(e: Exception) =>
-        logger.error("Exception after sending Initialize to JobManagerActor", e)
-        // Make sure we try to shut down the context in case it gets created anyways
-        ref ! PoisonPill
-        failureFunc(e)
-      case Success(JobManagerActor.Initialized(_, resultActor)) =>
-        logger.info("SparkContext {} initialized", name)
-        contexts(name) = (ref, resultActor)
-        context.watch(ref)
-        successFunc(ref)
-      case Success(JobManagerActor.InitError(t)) =>
-        ref ! PoisonPill
-        failureFunc(t)
-      case x =>
-        logger.warn("Unexpected message received by startContext: {}", x)
-    }
-  }
-
-  // Adds the contexts from the config file
-  private def addContextsFromConfig(config: Config) {
-    for (contexts <- Try(config.getObject("spark.contexts"))) {
-      contexts.keySet().asScala.foreach { contextName =>
-        val contextConfig = config.getConfig("spark.contexts." + contextName)
-          .withFallback(defaultContextConfig)
-        startContext(contextName, contextConfig, false, contextTimeout) { ref => } {
-          e => logger.error("Unable to start context " + contextName, e)
-        }
-        Thread sleep 500 // Give some spacing so multiple contexts can be created
-      }
-    }
-  }
+  protected def getTimeout(): Long = localContextTimeout.toLong
+  // both no-ops here
+  protected def onMemberUp(member: Member): Unit = {}
+  protected def onActorIdentity(memberActors: Any, actorRefOpt: Option[ActorRef]): Unit = {}
+  protected def onStopContext(actor: ActorRef): Unit = {}
 
 }

--- a/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorSpec.scala
@@ -1,0 +1,252 @@
+package spark.jobserver
+
+import akka.actor._
+import akka.pattern.AskTimeoutException
+import akka.testkit.{ImplicitSender, TestKit}
+import com.typesafe.config.{Config, ConfigFactory}
+import spark.jobserver.io.{JobDAO, JobDAOActor}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
+import scala.concurrent.duration._
+
+import spark.jobserver.common.akka
+import spark.jobserver.common.akka.AkkaTestUtils
+
+
+object AkkaClusterSupervisorSpec {
+  val config = ConfigFactory.parseString("""
+    akka {
+      actor {
+        provider = "akka.cluster.ClusterActorRefProvider"
+        warn-about-java-serializer-usage = off
+      }
+    }
+    deploy {
+      manager-start-cmd = "fake-thing"
+    }
+    spark {
+      master = "local[4]"
+      temp-contexts {
+        num-cpu-cores = 4           # Number of cores to allocate.  Required.
+        memory-per-node = 512m      # Executor memory per node, -Xmx style eg 512m, 1G, etc.
+      }
+      jobserver.job-result-cache-size = 100
+      jobserver.context-creation-timeout = 5 s
+      jobserver.yarn-context-creation-timeout = 40 s
+      jobserver.named-object-creation-timeout = 60 s
+      context-per-jvm = true
+      contexts {
+        olap-demo {
+          num-cpu-cores = 4
+          memory-per-node = 512m
+        }
+      }
+
+      context-settings {
+        num-cpu-cores = 2
+        memory-per-node = 512m
+        context-init-timeout = 2 s
+
+        context-factory = spark.jobserver.context.DefaultSparkContextFactory
+        passthrough {
+          spark.driver.allowMultipleContexts = true
+          spark.ui.enabled = false
+        }
+        hadoop {
+          mapreduce.framework.name = "ayylmao"
+        }
+      }
+    }
+    akka.log-dead-letters = 0
+    """)
+
+  val system = ActorSystem("test", config)
+}
+
+
+// This test DOES NOT cover actually spawning a seperate JVM,
+class AkkaClusterSupervisorSpec extends TestKit(AkkaClusterSupervisorSpec.system) with ImplicitSender
+    with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
+
+  val theTest = this
+  case class SendIdent()
+  class StubbedJobManagerActor(name: String, actorName: String, contextConfig: Config) extends Actor {
+    import CommonMessages._
+    import ContextSupervisor._
+    import JobInfoActor._
+    import JobManagerActor._
+
+    def receive: PartialFunction[Any, Unit] = {
+      case SendIdent => sender ! ActorIdentity(name, Some(self))
+      case SparkContextStatus => sender ! SparkContextAlive
+      case Initialize(_) =>
+        name match {
+          case "olap-demo" => sendGood(sender, "olap-demo")
+          case "c1" => sendGood(sender, "c1")
+          case "c2" => sendGood(sender, "c2")
+          case "d1" =>
+            Thread.sleep(500)
+            sendGood(sender, "d1")
+          case "d2" =>
+            Thread.sleep(10000)
+            sendGood(sender, "d2")
+        }
+    }
+    def sendGood(sender: ActorRef, name: String): Unit = {
+      val rActor = system.actorOf(Props(classOf[JobResultActor]))
+      sender ! JobManagerActor.Initialized(name, rActor)
+    }
+  }
+
+  class StubbedAkkaClusterSupervisorActor(daoActor: ActorRef) extends AkkaClusterSupervisorActor(daoActor) {
+    override def preStart(): Unit = {
+    }
+
+    override def postStop(): Unit = {
+    }
+    // stub this out for testing, won't be totally
+    // accurate as we won't have another process... but close enough :)
+    override protected def startContext(
+      name: String, actorName: String, contextConfig: Config, isAdHoc: Boolean
+    )(successFunc: ActorRef => Unit, failureFunc: Throwable => Unit): Unit = {
+      val jobManager = system.actorOf(
+        Props(classOf[StubbedJobManagerActor], theTest, name, actorName, contextConfig),
+        actorName
+      )
+
+      jobManager ! SendIdent
+      contextInitInfos(actorName) = (isAdHoc, successFunc, failureFunc)
+    }
+  }
+
+  override def afterAll() = {
+    AkkaTestUtils.shutdownAndWait(AkkaClusterSupervisorSpec.system)
+  }
+
+  var supervisor: ActorRef = _
+  var dao: JobDAO = _
+  var daoActor: ActorRef = _
+
+  val contextConfig = AkkaClusterSupervisorSpec.config.getConfig("spark.context-settings")
+
+  // This is needed to help tests pass on some MBPs when working from home
+  System.setProperty("spark.driver.host", "localhost")
+
+  before {
+    dao = new InMemoryDAO
+    daoActor = system.actorOf(JobDAOActor.props(dao))
+    supervisor = system.actorOf(Props(classOf[StubbedAkkaClusterSupervisorActor], this, daoActor))
+  }
+
+  after {
+    akka.AkkaTestUtils.shutdownAndWait(supervisor)
+  }
+
+  import ContextSupervisor._
+  import JobManagerActor._
+
+  describe("akka context management") {
+    it("should list empty contexts at startup") {
+      supervisor ! ListContexts
+      expectMsg(Seq.empty[String])
+    }
+
+    it("can add contexts from jobConfig") {
+      supervisor ! AddContextsFromConfig
+      Thread sleep 4000
+      supervisor ! ListContexts
+      expectMsg(40 seconds, Seq("olap-demo"))
+    }
+
+    it("should be able to add multiple new contexts") {
+      supervisor ! AddContext("c1", contextConfig)
+      expectMsg(ContextInitialized)
+      supervisor ! AddContext("c2", contextConfig)
+      expectMsg(ContextInitialized)
+      supervisor ! ListContexts
+      expectMsg(Seq("c1", "c2"))
+      supervisor ! GetResultActor("c1")
+      val rActor = expectMsgClass(classOf[ActorRef])
+      rActor.path.toString should not include "global"
+    }
+
+    it("should be able to get context") {
+      supervisor ! AddContext("c1", contextConfig)
+      expectMsg(ContextInitialized)
+      supervisor ! GetContext("c1")
+      expectMsgPF(5 seconds, "I can't find that context :'-(") {
+        case (actorName: String, Some(contextActor: ActorRef), Some(resultActor: ActorRef)) =>
+          actorName should startWith ("jobManager")
+      }
+    }
+
+    it("should be able to stop contexts already running") {
+      supervisor ! AddContext("c1", contextConfig)
+      expectMsg(ContextInitialized)
+      supervisor ! ListContexts
+      expectMsg(Seq("c1"))
+
+      supervisor ! StopContext("c1")
+      expectMsg(ContextStopped)
+
+      Thread.sleep(2000) // wait for a while since deleting context is an asyc call
+      supervisor ! ListContexts
+      expectMsg(Seq.empty[String])
+    }
+
+    it("should return NoSuchContext if attempt to stop nonexisting context") {
+      supervisor ! StopContext("c1")
+      expectMsg(NoSuchContext)
+    }
+
+    it("should not allow creation of an already existing context") {
+      supervisor ! AddContext("c1", contextConfig)
+      expectMsg(ContextInitialized)
+
+      supervisor ! AddContext("c1", contextConfig)
+      expectMsg(ContextAlreadyExists)
+    }
+
+    it("should allow stopping contexts that are not completely started") {
+      supervisor ! AddContext("d1", contextConfig)
+      Thread.sleep(50)
+      supervisor ! StopContext("d1")
+      // we expect to see an init and then a stop
+      expectMsg(ContextInitialized)
+      expectMsg(ContextStopped)
+    }
+
+    it("should not allow another context of same name even during it starting") {
+      supervisor ! AddContext("d1", contextConfig)
+      supervisor ! AddContext("d1", contextConfig)
+      expectMsg(ContextAlreadyExists)
+      supervisor ! StopContext("d1")
+      expectMsg(ContextInitialized)
+      expectMsg(ContextStopped)
+    }
+
+    it("should remove a context that does not start in time") {
+      supervisor ! AddContext("d2", contextConfig)
+      supervisor ! ListContexts
+      expectMsg(Seq("d2"))
+      expectMsgPF(3.seconds, "should have timed out by now...") {
+        case ContextInitError(e: Any) =>
+          e shouldBe an [AskTimeoutException]
+      }
+      supervisor ! ListContexts
+      expectMsg(Seq.empty[String])
+    }
+
+    it("should still successfully stop a context even if it doesn't start in time") {
+      supervisor ! AddContext("d2", contextConfig)
+      Thread.sleep(50)
+      supervisor ! StopContext("d2")
+      expectMsgPF(3.seconds, "should have timed out by now...") {
+        case ContextInitError(e: Any) =>
+          e shouldBe an [AskTimeoutException]
+      }
+      expectMsg(ContextStopped)
+      supervisor ! ListContexts
+      expectMsg(Seq.empty[String])
+    }
+  }
+}

--- a/job-server/src/test/scala/spark/jobserver/LocalContextSupervisorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/LocalContextSupervisorSpec.scala
@@ -110,7 +110,7 @@ class LocalContextSupervisorSpec extends TestKit(LocalContextSupervisorSpec.syst
       expectMsg(ContextInitialized)
       supervisor ! GetContext("c1")
       expectMsgPF(5 seconds, "I can't find that context :'-(") {
-        case (contextActor: ActorRef, resultActor: ActorRef) =>
+        case (actorName: String, Some(contextActor: ActorRef), Some(resultActor: ActorRef)) =>
           contextActor ! GetContextConfig
           val cc = expectMsgClass(classOf[ContextConfig])
           cc.contextName shouldBe "c1"

--- a/job-server/src/test/scala/spark/jobserver/WebApiMainRoutesSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiMainRoutesSpec.scala
@@ -344,6 +344,14 @@ class WebApiMainRoutesSpec extends WebApiSpec {
       }
     }
 
+    it("should respond with 404 Not Found if context is not ready") {
+      Post("/jobs?appName=foo&classPath=com.abc.meme&context=not-ready-context", " ") ~> sealRoute(routes) ~> check {
+        status should be (NotFound)
+        val resultMap = responseAs[Map[String, String]]
+        resultMap(StatusKey) should be (JobStatus.Error)
+      }
+    }
+
     it("should respond with 404 Not Found if app or class not found") {
       Post("/jobs?appName=no-app&classPath=com.abc.meme&context=one", " ") ~> sealRoute(routes) ~> check {
         status should be (NotFound)
@@ -455,7 +463,7 @@ class WebApiMainRoutesSpec extends WebApiSpec {
         status should be(OK)
       }
     }
-    
+
     it("should return OK if stopping known context") {
       Delete("/contexts/one", "") ~> sealRoute(routes) ~> check {
         status should be (OK)
@@ -492,4 +500,3 @@ class WebApiMainRoutesSpec extends WebApiSpec {
     }
   }
 }
-

--- a/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
@@ -141,8 +141,8 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
       case DataManagerActor.DeleteData("errorfileToRemove") => sender ! DataManagerActor.Error
 
       case ListContexts =>  sender ! Seq("context1", "context2")
-      case StopContext("none") => sender ! NoSuchContext
-      case StopContext(_)      => sender ! ContextStopped
+      case StopContext("none", _) => sender ! NoSuchContext
+      case StopContext(_, _)      => sender ! ContextStopped
       case AddContext("one", _) => sender ! ContextAlreadyExists
       case AddContext("custom-ctx", c) =>
         // see WebApiMainRoutesSpec => "context routes" =>
@@ -154,9 +154,10 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
       case AddContext(_, _)     => sender ! ContextInitialized
 
       case GetContext("no-context") => sender ! NoSuchContext
-      case GetContext(_)            => sender ! (self, self)
+      case GetContext("not-ready-context") => sender ! ("not-ready-context", None, None)
+      case GetContext(_)            => sender ! ("test-normal", Some(self), Some(self))
 
-      case StartAdHocContext(_, _) => sender ! (self, self)
+      case StartAdHocContext(_, _) => sender ! ("test-adhoc", Some(self), Some(self))
 
       // These routes are part of JobManagerActor
       case StartJob("no-app", _, _, _)   =>  sender ! NoSuchApplication

--- a/job-server/src/test/scala/spark/jobserver/auth/WebApiWithAuthenticationSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/auth/WebApiWithAuthenticationSpec.scala
@@ -85,7 +85,7 @@ class WebApiWithAuthenticationSpec extends FunSpec with Matchers with BeforeAndA
 
         BasicAuth(authenticator _, realm = "Shiro Private")
       }
-      
+
       override def initSecurityManager() {
         val ini = {
           val tmp = new Ini()
@@ -139,7 +139,7 @@ class WebApiWithAuthenticationSpec extends FunSpec with Matchers with BeforeAndA
           addedContexts.add(name)
           sender ! ContextSupervisor.ContextInitialized
         }
-      case ContextSupervisor.StopContext(name) =>
+      case ContextSupervisor.StopContext(name, _) =>
         addedContexts.remove(name)
         sender ! ContextSupervisor.ContextStopped
       case ContextSupervisor.AddContextsFromConfig =>
@@ -471,4 +471,3 @@ class WebApiWithAuthenticationSpec extends FunSpec with Matchers with BeforeAndA
     }
   }
 }
-


### PR DESCRIPTION
This commit refactors the Local and AkkaCluster context supervisor actor
classes. It introduces a new abstract class, BaseSupervisorActor that
both LocalContextSupervisorActor and AkkaClusterSupervisorActor extend.
This new base class has some improved functionality:
- atomic context creation, you can't double create a context during it
  starting (fixes #349)
- contexts that are starting are listed in the contexts (we should
  probably give contexts a status)
- if you try and stop a context that is still starting, it will ensure it
  properly gets stopped
- if a context fails to start, it will get removed from list of starting
  contexts
- create more specific exceptions for when a context isn't found but is
  in creating mode, allows us to send a better API error indiciating the
  problem

The base class does have to take on some of the concerns of the
AkkaCluster for simplicity sake (just handling a few messages), but this
really DRYs up the two different classes

AkkaClusterSupervisorActor also had no unit tests, it now is fairly well tested save
for the `startContext` method which actually spawns the new process

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/672)
<!-- Reviewable:end -->
