### PR TITLE
fix(webapi,akka-app): Make sure -X DELETE for contexts is synchronous #395

### DIFF
--- a/job-server/src/test/scala/spark/jobserver/LocalContextSupervisorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/LocalContextSupervisorSpec.scala
@@ -3,12 +3,12 @@ package spark.jobserver
 import akka.actor._
 import akka.testkit.{ImplicitSender, TestKit}
 import com.typesafe.config.ConfigFactory
-import spark.jobserver.io.{JobDAO, JobDAOActor}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
-import scala.concurrent.duration._
-
 import spark.jobserver.common.akka
 import spark.jobserver.common.akka.AkkaTestUtils
+import spark.jobserver.io.{JobDAO, JobDAOActor}
+
+import scala.concurrent.duration._
 
 
 object LocalContextSupervisorSpec {
@@ -128,7 +128,6 @@ class LocalContextSupervisorSpec extends TestKit(LocalContextSupervisorSpec.syst
       supervisor ! StopContext("c1")
       expectMsg(ContextStopped)
 
-      Thread.sleep(2000) // wait for a while since deleting context is an asyc call
       supervisor ! ListContexts
       expectMsg(Seq.empty[String])
     }


### PR DESCRIPTION
This pull request fixes issue #395 by making DELETE context a synchronous operation.

Instead of sending a PoisonPill message to the actor managing the context, it uses akka.pattern.gracefulStop with a timeout of two seconds to gracefully shut the context down. The effect is exactly the same as PoisonPill with the difference that the Future returned by gracefulStop gives feedback about completion.  In case of an error, WebApi will return a HTTP 500 with the corresponding StackTrace)

Removed the Thread.sleep(2000) in the corresponding test: LocalContextSupervisorSpec.scala, line 131