### PR TITLE
fix(webapi,akka-app): make sure -X DELETE for contexts is synchronous…

### DIFF
--- a/job-server-api/src/main/scala/spark/jobserver/util/SparkJobUtils.scala
+++ b/job-server-api/src/main/scala/spark/jobserver/util/SparkJobUtils.scala
@@ -99,17 +99,30 @@ object SparkJobUtils {
     Try(config.getInt("spark.jobserver.max-jobs-per-context")).getOrElse(cpuCores)
   }
 
-  /**
-   * According "spark.master", returns the timeout of create sparkContext
-   */
-  def getContextTimeout(config: Config): Int = {
+  private def getContextTimeout(config: Config, yarn : String, standalone : String): Int = {
     config.getString("spark.master") match {
       case "yarn-client" =>
-        Try(config.getDuration("spark.jobserver.yarn-context-creation-timeout",
+        Try(config.getDuration(yarn,
               TimeUnit.MILLISECONDS).toInt / 1000).getOrElse(40)
       case _               =>
-        Try(config.getDuration("spark.jobserver.context-creation-timeout",
+        Try(config.getDuration(standalone,
               TimeUnit.MILLISECONDS).toInt / 1000).getOrElse(15)
     }
+  }
+
+  /**
+    * According "spark.master", returns the timeout of create sparkContext
+    */
+  def getContextCreationTimeout(config: Config): Int = {
+    getContextTimeout(config, "spark.jobserver.yarn-context-creation-timeout",
+        "spark.jobserver.context-creation-timeout")
+    }
+
+  /**
+    * According "spark.master", returns the timeout of delete sparkContext
+    */
+  def getContextDeletionTimeout(config: Config): Int = {
+    getContextTimeout(config, "spark.jobserver.yarn-context-deletion-timeout",
+      "spark.jobserver.context-deletion-timeout")
   }
 }

--- a/job-server-api/src/test/scala/util/SparkJobUtilsSpec.scala
+++ b/job-server-api/src/test/scala/util/SparkJobUtilsSpec.scala
@@ -29,5 +29,69 @@ class SparkJobUtilsSpec extends FunSpec with Matchers {
       val sparkConf = getSparkConf(Map("spark.cleaner.ttl" -> 86400))
       sparkConf.getInt("spark.cleaner.ttl", 0) should equal (86400)
     }
+
+    it("should read contextCreationTimeout for standalone mode") {
+      val config = ConfigFactory.parseMap(Map(
+        "spark.master" -> "local[4]",
+        "spark.jobserver.yarn-context-creation-timeout" -> 20000,
+        "spark.jobserver.context-creation-timeout" -> 10000
+      ).asJava)
+      SparkJobUtils.getContextCreationTimeout(config) should equal (10)
+    }
+
+    it("should read default contextCreationTimeout for standalone mode") {
+      val config = ConfigFactory.parseMap(Map(
+        "spark.master" -> "local[4]"
+      ).asJava)
+      SparkJobUtils.getContextCreationTimeout(config) should equal (15)
+    }
+
+    it("should read contextCreationTimeout for yarn-client mode") {
+      val config = ConfigFactory.parseMap(Map(
+        "spark.master" -> "yarn-client",
+        "spark.jobserver.yarn-context-creation-timeout" -> 20000,
+        "spark.jobserver.context-creation-timeout" -> 10000
+      ).asJava)
+      SparkJobUtils.getContextCreationTimeout(config) should equal (20)
+    }
+
+    it("should read default contextCreationTimeout for yarn-client mode") {
+      val config = ConfigFactory.parseMap(Map(
+        "spark.master" -> "yarn-client"
+      ).asJava)
+      SparkJobUtils.getContextCreationTimeout(config) should equal (40)
+    }
+
+    it("should read contextDeletionTimeout for standalone mode") {
+      val config = ConfigFactory.parseMap(Map(
+        "spark.master" -> "local[4]",
+        "spark.jobserver.yarn-context-deletion-timeout" -> 20000,
+        "spark.jobserver.context-deletion-timeout" -> 10000
+      ).asJava)
+      SparkJobUtils.getContextDeletionTimeout(config) should equal (10)
+    }
+
+    it("should read default contextDeletionTimeout for standalone mode") {
+      val config = ConfigFactory.parseMap(Map(
+        "spark.master" -> "local[4]"
+      ).asJava)
+      SparkJobUtils.getContextDeletionTimeout(config) should equal (15)
+    }
+
+    it("should read contextDeletionTimeout for yarn-client mode") {
+      val config = ConfigFactory.parseMap(Map(
+        "spark.master" -> "yarn-client",
+        "spark.jobserver.yarn-context-deletion-timeout" -> 20000,
+        "spark.jobserver.context-deletion-timeout" -> 10000
+      ).asJava)
+      SparkJobUtils.getContextDeletionTimeout(config) should equal (20)
+    }
+
+    it("should read default contextDeletionTimeout for yarn-client mode") {
+      val config = ConfigFactory.parseMap(Map(
+        "spark.master" -> "yarn-client"
+      ).asJava)
+      SparkJobUtils.getContextDeletionTimeout(config) should equal (40)
+    }
   }
 }

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -8,16 +8,16 @@ import java.util.concurrent.TimeUnit
 import akka.actor._
 import akka.cluster.Cluster
 import akka.cluster.ClusterEvent.{InitialStateAsEvents, MemberEvent, MemberUp}
-import akka.pattern.gracefulStop
 import akka.util.Timeout
 import com.typesafe.config.{Config, ConfigFactory, ConfigRenderOptions}
-import spark.jobserver.common.akka.InstrumentedActor
 import spark.jobserver.util.SparkJobUtils
-
 import scala.collection.mutable
-import scala.concurrent.{Await, Future}
-import scala.sys.process._
 import scala.util.{Failure, Success, Try}
+import scala.sys.process._
+
+import spark.jobserver.common.akka.InstrumentedActor
+import scala.concurrent.Await
+import akka.pattern.gracefulStop
 
 /**
  * The AkkaClusterSupervisorActor launches Spark Contexts as external processes
@@ -39,7 +39,6 @@ import scala.util.{Failure, Success, Try}
  */
 class AkkaClusterSupervisorActor(daoActor: ActorRef) extends InstrumentedActor {
   import ContextSupervisor._
-
   import scala.collection.JavaConverters._
   import scala.concurrent.duration._
 
@@ -161,7 +160,7 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef) extends InstrumentedActor {
           sender ! ContextStopped
         }
         catch {
-          case err :Exception => sender ! ContextStopError(err)
+          case err: Exception => sender ! ContextStopError(err)
         }
       } else {
         sender ! NoSuchContext

--- a/job-server/src/main/scala/spark/jobserver/JobServer.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobServer.scala
@@ -132,11 +132,11 @@ object JobServer {
             s"Python Egg packages (with extension .egg) are supported. Found $other")
       }
 
-      val contextTimeout = util.SparkJobUtils.getContextTimeout(config)
+      val contextCreationTimeout = util.SparkJobUtils.getContextCreationTimeout(config)
       val future =
-        (binaryManager ? StoreLocalBinaries(initialBinariesWithTypes))(contextTimeout.seconds)
+        (binaryManager ? StoreLocalBinaries(initialBinariesWithTypes))(contextCreationTimeout.seconds)
 
-      Await.result(future, contextTimeout.seconds) match {
+      Await.result(future, contextCreationTimeout.seconds) match {
         case InvalidBinary => sys.error("Could not store initial job binaries.")
         case BinaryStorageFailure(ex) =>
           logger.error("Failed to store initial binaries", ex)

--- a/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
@@ -1,16 +1,21 @@
 package spark.jobserver
 
 import akka.actor.{ActorRef, PoisonPill, Props, Terminated}
-import akka.pattern.{ask, gracefulStop}
+import akka.pattern.ask
 import akka.util.Timeout
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
 import spark.jobserver.JobManagerActor.{SparkContextAlive, SparkContextDead, SparkContextStatus}
-import spark.jobserver.common.akka.InstrumentedActor
+import spark.jobserver.io.JobDAO
 import spark.jobserver.util.SparkJobUtils
-
 import scala.collection.mutable
 import scala.concurrent.Await
 import scala.util.{Failure, Success, Try}
+
+import org.joda.time.DateTime
+import org.joda.time.format.DateTimeFormat
+import spark.jobserver.common.akka.InstrumentedActor
+import akka.pattern.gracefulStop
 
 /** Messages common to all ContextSupervisors */
 object ContextSupervisor {
@@ -68,7 +73,6 @@ object ContextSupervisor {
  */
 class LocalContextSupervisorActor(dao: ActorRef) extends InstrumentedActor {
   import ContextSupervisor._
-
   import scala.collection.JavaConverters._
   import scala.concurrent.duration._
 
@@ -149,7 +153,7 @@ class LocalContextSupervisorActor(dao: ActorRef) extends InstrumentedActor {
           sender ! ContextStopped
         }
         catch {
-          case err :Exception => sender ! ContextStopError(err)
+          case err: Exception => sender ! ContextStopError(err)
         }
       } else {
         sender ! NoSuchContext

--- a/job-server/src/main/scala/spark/jobserver/WebApi.scala
+++ b/job-server/src/main/scala/spark/jobserver/WebApi.scala
@@ -7,15 +7,15 @@ import javax.net.ssl.SSLContext
 import akka.actor.{ActorRef, ActorSystem}
 import akka.pattern.ask
 import akka.util.Timeout
-import com.typesafe.config.{Config, ConfigException, ConfigFactory, ConfigRenderOptions, ConfigValueFactory}
-import spark.jobserver.common.akka.web.JsonUtils.AnyJsonFormat
-import spark.jobserver.common.akka.web.{CommonRoutes, WebService}
+import com.typesafe.config._
 import org.apache.shiro.SecurityUtils
 import org.apache.shiro.config.IniSecurityManagerFactory
 import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
 import spark.jobserver.JobManagerActor.JobKilledException
 import spark.jobserver.auth._
+import spark.jobserver.common.akka.web.JsonUtils.AnyJsonFormat
+import spark.jobserver.common.akka.web.{CommonRoutes, WebService}
 import spark.jobserver.io.{BinaryType, JobInfo, JobStatus}
 import spark.jobserver.routes.DataRoutes
 import spark.jobserver.util.{SSLContextFactory, SparkJobUtils}
@@ -26,10 +26,9 @@ import spray.io.ServerSSLEngineProvider
 import spray.json.DefaultJsonProtocol._
 import spray.routing.directives.AuthMagnet
 import spray.routing.{HttpService, RequestContext, Route}
+
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.Try
-
-import spark.jobserver.common.akka.web.{CommonRoutes, WebService}
 
 
 object WebApi {
@@ -121,8 +120,9 @@ class WebApi(system: ActorSystem,
                         with ChunkEncodedStreamingSupport {
   import CommonMessages._
   import ContextSupervisor._
-  import scala.concurrent.duration._
   import WebApi._
+
+  import scala.concurrent.duration._
 
   // Get spray-json type classes for serializing Map[String, Any]
   import spark.jobserver.common.akka.web.JsonUtils._
@@ -396,6 +396,7 @@ class WebApi(system: ActorSystem,
               future.map {
                 case ContextStopped => ctx.complete(StatusCodes.OK, successMap("Context stopped"))
                 case NoSuchContext  => notFound(ctx, "context " + contextName + " not found")
+                case ContextStopError(e) => ctx.complete(500, errMap(e, "CONTEXT DELETE ERROR"))
               }
             }
           }
@@ -405,9 +406,9 @@ class WebApi(system: ActorSystem,
             respondWithMediaType(MediaTypes.`application/json`) { ctx =>
               reset match {
                 case "reboot" => {
-                  import ContextSupervisor._
-                  import collection.JavaConverters._
                   import java.util.concurrent.TimeUnit
+
+                  import ContextSupervisor._
 
                   logger.warn("refreshing contexts")
                   val future = (supervisor ? ListContexts).mapTo[Seq[String]]

--- a/job-server/src/main/scala/spark/jobserver/WebApi.scala
+++ b/job-server/src/main/scala/spark/jobserver/WebApi.scala
@@ -7,15 +7,15 @@ import javax.net.ssl.SSLContext
 import akka.actor.{ActorRef, ActorSystem}
 import akka.pattern.ask
 import akka.util.Timeout
-import com.typesafe.config._
+import com.typesafe.config.{Config, ConfigException, ConfigFactory, ConfigRenderOptions, ConfigValueFactory}
+import spark.jobserver.common.akka.web.JsonUtils.AnyJsonFormat
+import spark.jobserver.common.akka.web.{CommonRoutes, WebService}
 import org.apache.shiro.SecurityUtils
 import org.apache.shiro.config.IniSecurityManagerFactory
 import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
 import spark.jobserver.JobManagerActor.JobKilledException
 import spark.jobserver.auth._
-import spark.jobserver.common.akka.web.JsonUtils.AnyJsonFormat
-import spark.jobserver.common.akka.web.{CommonRoutes, WebService}
 import spark.jobserver.io.{BinaryType, JobInfo, JobStatus}
 import spark.jobserver.routes.DataRoutes
 import spark.jobserver.util.{SSLContextFactory, SparkJobUtils}
@@ -26,9 +26,10 @@ import spray.io.ServerSSLEngineProvider
 import spray.json.DefaultJsonProtocol._
 import spray.routing.directives.AuthMagnet
 import spray.routing.{HttpService, RequestContext, Route}
-
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.Try
+
+import spark.jobserver.common.akka.web.{CommonRoutes, WebService}
 
 
 object WebApi {
@@ -120,9 +121,8 @@ class WebApi(system: ActorSystem,
                         with ChunkEncodedStreamingSupport {
   import CommonMessages._
   import ContextSupervisor._
-  import WebApi._
-
   import scala.concurrent.duration._
+  import WebApi._
 
   // Get spray-json type classes for serializing Map[String, Any]
   import spark.jobserver.common.akka.web.JsonUtils._
@@ -138,7 +138,7 @@ class WebApi(system: ActorSystem,
   val ResultChunkSize = Option("spark.jobserver.result-chunk-size").filter(config.hasPath)
       .fold(100 * 1024)(config.getBytes(_).toInt)
 
-  val contextTimeout = SparkJobUtils.getContextTimeout(config)
+  val contextTimeout = SparkJobUtils.getContextCreationTimeout(config)
   val bindAddress = config.getString("spark.jobserver.bind-address")
 
   val logger = LoggerFactory.getLogger(getClass)
@@ -406,9 +406,9 @@ class WebApi(system: ActorSystem,
             respondWithMediaType(MediaTypes.`application/json`) { ctx =>
               reset match {
                 case "reboot" => {
-                  import java.util.concurrent.TimeUnit
-
                   import ContextSupervisor._
+                  import collection.JavaConverters._
+                  import java.util.concurrent.TimeUnit
 
                   logger.warn("refreshing contexts")
                   val future = (supervisor ? ListContexts).mapTo[Seq[String]]

--- a/job-server/src/test/scala/spark/jobserver/LocalContextSupervisorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/LocalContextSupervisorSpec.scala
@@ -3,12 +3,12 @@ package spark.jobserver
 import akka.actor._
 import akka.testkit.{ImplicitSender, TestKit}
 import com.typesafe.config.ConfigFactory
-import spark.jobserver.io.{JobDAO, JobDAOActor}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
-import scala.concurrent.duration._
-
 import spark.jobserver.common.akka
 import spark.jobserver.common.akka.AkkaTestUtils
+import spark.jobserver.io.{JobDAO, JobDAOActor}
+
+import scala.concurrent.duration._
 
 
 object LocalContextSupervisorSpec {
@@ -128,7 +128,6 @@ class LocalContextSupervisorSpec extends TestKit(LocalContextSupervisorSpec.syst
       supervisor ! StopContext("c1")
       expectMsg(ContextStopped)
 
-      Thread.sleep(2000) // wait for a while since deleting context is an asyc call
       supervisor ! ListContexts
       expectMsg(Seq.empty[String])
     }

--- a/job-server/src/test/scala/spark/jobserver/LocalContextSupervisorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/LocalContextSupervisorSpec.scala
@@ -3,12 +3,12 @@ package spark.jobserver
 import akka.actor._
 import akka.testkit.{ImplicitSender, TestKit}
 import com.typesafe.config.ConfigFactory
+import spark.jobserver.io.{JobDAO, JobDAOActor}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
+import scala.concurrent.duration._
+
 import spark.jobserver.common.akka
 import spark.jobserver.common.akka.AkkaTestUtils
-import spark.jobserver.io.{JobDAO, JobDAOActor}
-
-import scala.concurrent.duration._
 
 
 object LocalContextSupervisorSpec {
@@ -21,6 +21,7 @@ object LocalContextSupervisorSpec {
       }
       jobserver.job-result-cache-size = 100
       jobserver.context-creation-timeout = 5 s
+|     jobserver.context-deletion-timeout = 2 s
       jobserver.yarn-context-creation-timeout = 40 s
       jobserver.named-object-creation-timeout = 60 s
       contexts {

--- a/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
@@ -11,11 +11,15 @@ import spray.client.pipelining._
 import JobServerSprayProtocol._
 import org.scalatest.time.{Seconds, Span}
 import spray.http.{ContentType, HttpHeader, HttpHeaders, MediaTypes}
-import spray.httpx.SprayJsonSupport
+import spray.httpx.{SprayJsonSupport, UnsuccessfulResponseException}
 import spray.routing.HttpService
 import spray.testkit.ScalatestRouteTest
 
 import scala.concurrent.{Await, Future}
+import scala.concurrent.duration.Duration
+import scala.util.{Failure, Success}
+import java.util.concurrent.TimeUnit
+
 
 
 // Tests web response codes and formatting
@@ -143,8 +147,11 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
       case DataManagerActor.DeleteData("errorfileToRemove") => sender ! DataManagerActor.Error
 
       case ListContexts =>  sender ! Seq("context1", "context2")
+
       case StopContext("none") => sender ! NoSuchContext
+      case StopContext("timeout-ctx") => sender ! ContextStopError(new Throwable)
       case StopContext(_)      => sender ! ContextStopped
+
       case AddContext("one", _) => sender ! ContextAlreadyExists
       case AddContext("custom-ctx", c) =>
         // see WebApiMainRoutesSpec => "context routes" =>
@@ -153,7 +160,9 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
         c.getInt("num-cpu-cores") should be(2)
         c.getInt("override_me") should be(3)
         sender ! ContextInitialized
+      case AddContext("initError-ctx", _) => sender ! ContextInitError(new Throwable)
       case AddContext(_, _)     => sender ! ContextInitialized
+
 
       case GetContext("no-context") => sender ! NoSuchContext
       case GetContext(_)            => sender ! (self, self)
@@ -194,7 +203,8 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
     }
   }
 
-  implicit override val patienceConfig = PatienceConfig(timeout = Span(5, Seconds), interval = Span(1, Seconds))
+  implicit override val patienceConfig = PatienceConfig(timeout = Span(5, Seconds),
+    interval = Span(1, Seconds))
 
   override def beforeAll():Unit = {
     api.start()
@@ -204,7 +214,7 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
 
     val jsonContentType = HttpHeaders.`Content-Type`(ContentType(MediaTypes.`application/json`))
 
-    it ("Should return valid JSON when a jar is uploaded succesfully") {
+    it ("Should return valid JSON when a jar is uploaded successfully") {
       val p = sendReceive ~> unmarshal[JobServerResponse]
       val valid:Future[JobServerResponse] = p(Post("http://127.0.0.1:9999/jars/test-app","valid"))
       whenReady(valid) { r=>
@@ -224,6 +234,18 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
       }
     }
 
+    it ("Should return an error when actor returns ContextInitError") {
+      val p = sendReceive ~> unmarshal[JobServerResponse]
+      val valid:Future[JobServerResponse] = p(Post("http://127.0.0.1:9999/contexts/initError-ctx"))
+      Await.ready(valid, Duration.create(1, TimeUnit.SECONDS)).value.get match {
+        case Success(_) => fail("Should return an exception")
+        case Failure(r: UnsuccessfulResponseException) =>
+          r.response.status.intValue shouldBe 500
+          r.response.status.isFailure shouldBe true
+        case Failure(_) => fail("Should return an UnsuccessfulResponseException")
+      }
+    }
+
     it ("Should return valid JSON when stopping a context") {
       val p = sendReceive ~> unmarshal[JobServerResponse]
       val valid:Future[JobServerResponse] = p(Delete("http://127.0.0.1:9999/contexts/test-ctx"))
@@ -231,6 +253,18 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
         r.isSuccess shouldBe true
         r.status shouldBe "SUCCESS"
         r.result shouldBe "Context stopped"
+      }
+    }
+
+    it ("Should return an error when stopping a context times out") {
+      val p = sendReceive ~> unmarshal[JobServerResponse]
+      val valid:Future[JobServerResponse] = p(Delete("http://127.0.0.1:9999/contexts/timeout-ctx"))
+      Await.ready(valid, Duration.create(1, TimeUnit.SECONDS)).value.get match {
+        case Success(_) => fail("Should return an exception")
+        case Failure(r: UnsuccessfulResponseException) =>
+          r.response.status.intValue shouldBe 500
+          r.response.status.isFailure shouldBe true
+        case Failure(_) => fail("Should return an UnsuccessfulResponseException")
       }
     }
 

--- a/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
@@ -16,11 +16,9 @@ import spray.routing.HttpService
 import spray.testkit.ScalatestRouteTest
 
 import scala.concurrent.{Await, Future}
-import scala.concurrent.duration.Duration
 import scala.util.{Failure, Success}
 import java.util.concurrent.TimeUnit
-
-
+import scala.concurrent.duration.Duration
 
 // Tests web response codes and formatting
 // Does NOT test underlying Supervisor / JarManager functionality
@@ -147,11 +145,9 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
       case DataManagerActor.DeleteData("errorfileToRemove") => sender ! DataManagerActor.Error
 
       case ListContexts =>  sender ! Seq("context1", "context2")
-
       case StopContext("none") => sender ! NoSuchContext
       case StopContext("timeout-ctx") => sender ! ContextStopError(new Throwable)
       case StopContext(_)      => sender ! ContextStopped
-
       case AddContext("one", _) => sender ! ContextAlreadyExists
       case AddContext("custom-ctx", c) =>
         // see WebApiMainRoutesSpec => "context routes" =>
@@ -162,7 +158,6 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
         sender ! ContextInitialized
       case AddContext("initError-ctx", _) => sender ! ContextInitError(new Throwable)
       case AddContext(_, _)     => sender ! ContextInitialized
-
 
       case GetContext("no-context") => sender ! NoSuchContext
       case GetContext(_)            => sender ! (self, self)
@@ -203,8 +198,7 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
     }
   }
 
-  implicit override val patienceConfig = PatienceConfig(timeout = Span(5, Seconds),
-    interval = Span(1, Seconds))
+  implicit override val patienceConfig = PatienceConfig(timeout = Span(5, Seconds), interval = Span(1, Seconds))
 
   override def beforeAll():Unit = {
     api.start()


### PR DESCRIPTION
… #395

* DeleteContext operation is now synchronous, it doesn't return before
the corresponding
actor has been gracefully stopped. There is no need anymore to wait a
few 100 ms
before re-creating a context with the same name