### PR TITLE
Fixes test issues on Windows

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,10 @@ lazy val jobServer = Project(id = "job-server", base = file("job-server"))
       .dependsOn(clean in Compile in jobServerTestJar)
       .dependsOn(buildPython in jobServerPython)
       .dependsOn(clean in Compile in jobServerPython),
+    testOnly in Test <<= (testOnly in Test).dependsOn(packageBin in Compile in jobServerTestJar)
+      .dependsOn(clean in Compile in jobServerTestJar)
+      .dependsOn(buildPython in jobServerPython)
+      .dependsOn(clean in Compile in jobServerPython),
     console in Compile <<= Defaults.consoleTask(fullClasspath in Compile, console in Compile),
     fullClasspath in Compile <<= (fullClasspath in Compile).map { classpath =>
       extraJarPaths ++ classpath
@@ -50,6 +54,12 @@ lazy val jobServerExtras = Project(id = "job-server-extras", base = file("job-se
   .settings(jobServerExtrasSettings)
   .settings(
     test in Test <<= (test in Test)
+      .dependsOn(packageBin in Compile in jobServerTestJar)
+      .dependsOn(clean in Compile in jobServerTestJar)
+      .dependsOn(buildPython in jobServerPython)
+      .dependsOn(buildPyExamples in jobServerPython)
+      .dependsOn(clean in Compile in jobServerPython),
+    testOnly in Test <<= (testOnly in Test)
       .dependsOn(packageBin in Compile in jobServerTestJar)
       .dependsOn(clean in Compile in jobServerTestJar)
       .dependsOn(buildPython in jobServerPython)

--- a/job-server-extras/src/main/scala/spark/jobserver/python/PythonJob.scala
+++ b/job-server-extras/src/main/scala/spark/jobserver/python/PythonJob.scala
@@ -57,7 +57,8 @@ case class PythonJob[X <: PythonContextLike](eggPath: String,
     logger.info(s"Running $modulePath from $eggPath")
     val ep = endpoint(sc, runtime.contextConfig, runtime.jobId, data)
     val server = new GatewayServer(ep, 0)
-    val pythonPath = (eggPath +: sc.pythonPath).mkString(":")
+    val pythonPathDelimiter : String = if(System.getProperty("os.name").indexOf("Win") >= 0) ";" else ":"
+    val pythonPath = (eggPath +: sc.pythonPath).mkString(pythonPathDelimiter)
     logger.info(s"Using Python path of ${pythonPath}")
     val subProcessOutcome = Try {
       //Server runs asynchronously on a dedicated thread. See Py4J source for more detail

--- a/job-server-extras/src/test/scala/spark/jobserver/python/PythonHiveContextFactorySpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/python/PythonHiveContextFactorySpec.scala
@@ -7,6 +7,7 @@ import org.scalatest.{BeforeAndAfter, Matchers, FunSpec}
 
 import java.nio.file.Files
 import java.nio.file.Paths
+import spark.jobserver.WindowsIgnore
 import scala.collection.JavaConverters._
 
 
@@ -21,6 +22,7 @@ object PythonHiveContextFactorySpec {
     *
     * This approach wouldn't be suitable in a production scenario, but ok for tests.
     */
+  // Note: Issue SPARK-10872 is RESOLVED by now with "Not A Problem"
   private def resetDerby(): Unit = {
     Files.deleteIfExists(Paths.get("/tmp/metastore_db/dbex.lck"))
     Files.deleteIfExists(Paths.get("/tmp/metastore_db/db.lck"))
@@ -40,15 +42,18 @@ class PythonHiveContextFactorySpec extends FunSpec with Matchers with BeforeAndA
     PythonHiveContextFactorySpec.resetDerby()
   }
 
+  /**
+    * resetDerby workaround doesn't work on Windows (file remains locked), so ignore the tests
+    * for now
+   */
   describe("PythonHiveContextFactory") {
-
-    it("should create PythonHiveContexts") {
+    it("should create PythonHiveContexts", WindowsIgnore) {
       val factory = new PythonHiveContextFactory()
       context = factory.makeContext(sparkConf, config, "test-create")
       context shouldBe an[HiveContext with PythonContextLike]
     }
 
-    it("should create JobContainers") {
+    it("should create JobContainers", WindowsIgnore) {
       val factory = new PythonHiveContextFactory()
       val result = factory.loadAndValidateJob("test", DateTime.now(), "path.to.Job", DummyJobCache)
       result.isGood should be (true)
@@ -95,13 +100,13 @@ class PythonHiveContextFactorySpec extends FunSpec with Matchers with BeforeAndA
       }
     }
 
-    it("should return jobs which can be successfully run") {
+    it("should return jobs which can be successfully run", WindowsIgnore) {
       val factory = new PythonHiveContextFactory()
       context = factory.makeContext(sparkConf, config, "test-create")
       runHiveTest(factory, context, config)
     }
 
-    it("should successfully run jobs using python3") {
+    it("should successfully run jobs using python3", WindowsIgnore) {
       val factory = new PythonHiveContextFactory()
       val p3Config = ConfigFactory.parseString(
         """

--- a/job-server-extras/src/test/scala/spark/jobserver/python/PythonSQLContextFactorySpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/python/PythonSQLContextFactorySpec.scala
@@ -4,6 +4,7 @@ import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.spark.sql.SQLContext
 import org.joda.time.DateTime
 import org.scalatest.{BeforeAndAfter, Matchers, FunSpec}
+import spark.jobserver.WindowsIgnore
 import scala.collection.JavaConverters._
 
 class PythonSQLContextFactorySpec extends FunSpec with Matchers with BeforeAndAfter{
@@ -75,7 +76,7 @@ class PythonSQLContextFactorySpec extends FunSpec with Matchers with BeforeAndAf
       runSqlTest(factory, context, config)
     }
 
-    it("should successfully run jobs using python3") {
+    it("should successfully run jobs using python3", WindowsIgnore) {
       val factory = new PythonSQLContextFactory()
       val p3Config = ConfigFactory.parseString(
         """

--- a/job-server-extras/src/test/scala/spark/jobserver/python/PythonSparkContextFactorySpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/python/PythonSparkContextFactorySpec.scala
@@ -107,7 +107,8 @@ object PythonSparkContextFactorySpec {
       |]
       |
       |python.executable = "python"
-    """.stripMargin)
+    """.replace("\\","\\\\") // Windows-compatibility
+      .stripMargin)
 
   lazy val sparkConf = new SparkConf().setMaster("local[*]").setAppName("PythonSparkContextFactorySpec")
 }
@@ -173,7 +174,7 @@ class PythonSparkContextFactorySpec extends FunSpec with Matchers with BeforeAnd
       runTest(factory, context, config)
     }
 
-    it("should successfully run jobs using python3") {
+    it("should successfully run jobs using python3", WindowsIgnore) {
       val factory = new PythonSparkContextFactory()
       val p3Config = ConfigFactory.parseString(
         """

--- a/job-server-python/src/python/build.cmd
+++ b/job-server-python/src/python/build.cmd
@@ -1,0 +1,10 @@
+set SJS_VERSION=%1
+
+setlocal
+cd %~dp0
+
+python %~dp0%2 build --build-base ../../target/python^
+ egg_info --egg-base ../../target/python^
+ bdist_egg --bdist-dir /tmp/bdist --dist-dir ../../target/python --skip-build
+
+endlocal

--- a/job-server-python/src/python/run-tests.cmd
+++ b/job-server-python/src/python/run-tests.cmd
@@ -1,0 +1,24 @@
+@IF NOT DEFINED SPARK_HOME (
+ ECHO SPARK_HOME MUST BE SET
+ EXIT /B -1
+)
+
+@IF NOT DEFINED HADOOP_HOME (
+ ECHO HADOOP_HOME MUST BE SET
+ EXIT /B -1
+)
+
+mkdir C:\tmp\hive
+%HADOOP_HOME%\bin\winutils chmod -R 777 \tmp\hive
+
+setlocal
+cd %~dp0
+
+set PYTHONPATH=%~dp0;%SPARK_HOME%\python\lib\pyspark.zip;%SPARK_HOME%\python\lib\py4j-0.9-src.zip;%PYTHONPATH%
+python test\apitests.py
+set exitCode=%ERRORLEVEL%
+REM This sleep is here so that all of Spark's shutdown stdout if written before we exit,
+REM so that we return cleanly to the command prompt.
+timeout /t 2 /nobreak > nil
+endlocal
+exit /B %exitCode%

--- a/job-server-python/src/test/scala/spark/jobserver/python/SubprocessSpec.scala
+++ b/job-server-python/src/test/scala/spark/jobserver/python/SubprocessSpec.scala
@@ -84,11 +84,12 @@ trait IdentifiedContext {
 class SubprocessSpec extends FunSpec with Matchers with BeforeAndAfterAll {
 
   import SubprocessSpec._
+  val pythonPathDelimiter : String = if(System.getProperty("os.name").indexOf("Win") >= 0) ";" else ":"
 
   lazy val pythonPath = {
 
     val pathList = Seq(jobServerPath) ++ sparkPaths ++ originalPythonPath.toSeq
-    val p = pathList.mkString(":")
+    val p = pathList.mkString(pythonPathDelimiter)
     // Scarman 10-13-2016
     //println(p)
     p

--- a/job-server/src/test/scala/spark/jobserver/WindowsIgnore.scala
+++ b/job-server/src/test/scala/spark/jobserver/WindowsIgnore.scala
@@ -1,0 +1,5 @@
+package spark.jobserver
+
+import org.scalatest.Tag
+
+object WindowsIgnore extends Tag ("WindowsIgnore")

--- a/project/PythonTasks.scala
+++ b/project/PythonTasks.scala
@@ -3,13 +3,15 @@ import java.io.File
 import scala.sys.process.Process
 
 object PythonTasks {
+  val ext : String = if(System.getProperty("os.name").indexOf("Win") >= 0) "cmd" else "sh"
 
   def workingDirectory(baseDirectory: File): File =
-    new File(baseDirectory.getAbsolutePath + Seq("src", "python").mkString("/", "/", ""))
+    new File(baseDirectory.getAbsolutePath + Seq("src", "python")
+      .mkString("/", "/", ""))
 
   def testPythonTask(baseDirectory: File): Unit = {
     val cwd = workingDirectory(baseDirectory)
-    val exitCode = Process(cwd.getAbsolutePath + "/run-tests.sh", cwd).!
+    val exitCode = Process(cwd.getAbsolutePath + "/run-tests." + ext, cwd).!
     if(exitCode != 0) {
       sys.error(s"Running python tests received non-zero exit code $exitCode")
     }
@@ -17,7 +19,8 @@ object PythonTasks {
 
   def buildPythonTask(baseDirectory: File, version: String): Unit = {
     val cwd = workingDirectory(baseDirectory)
-    val exitCode = Process(Seq(cwd.getAbsolutePath + "/build.sh", version, "setup.py"), cwd).!
+    val exitCode = Process(Seq(cwd.getAbsolutePath + "/build." + ext,
+      version, "setup.py"), cwd).!
     if(exitCode != 0) {
       sys.error(s"Building python API received non-zero exit code $exitCode")
     }
@@ -25,7 +28,8 @@ object PythonTasks {
 
   def buildExamplesTask(baseDirectory: File, version: String): Unit = {
     val cwd = workingDirectory(baseDirectory)
-    val exitCode = Process(Seq(cwd.getAbsolutePath + "/build.sh", version,  "setup-examples.py"), cwd).!
+    val exitCode = Process(Seq(cwd.getAbsolutePath + "/build." + ext, version,
+      "setup-examples.py"), cwd).!
     if(exitCode != 0) {
       sys.error(s"Building python examples received non-zero exit code $exitCode")
     }


### PR DESCRIPTION
I'm one of those poor guys who mainly (has to) develop(s) on Windows. 
Tests for job-server-python and job-server-extras don't run without errors on Windows 7 (might be different for Windows 10 with Linux subsystem). So, I tried to fix the test-issues on Windows. With a very few exceptions (see below), I was successful. Would really ease my work if this got merged.

Thanks and best regards, Tim

* Adds Windows-scripts for Python tasks: build.cmd and run-tests.cmd
* Makes a minimal change to PythonJob to create OS-specific pythonPath-delimiters (Windows needs a semicolon instead of a colon)
* Introduces tag "WindowsIgnore" to mark (the very few) tests that do not run on Windows
* Tags PythonHiveContextFactorySpec tests as WindowsIgnore, because "delete Derby lock file"-workaround for SPARK-10872 does not work on Windows. Also tags the "execute python3" tasks as WindowsIgnore

Test execution on Windows:
**sbt <enter>
test-only -- -l WindowsIgnore**
![image](https://cloud.githubusercontent.com/assets/9676200/22629766/cfecf69a-ebec-11e6-825e-f2b48572701c.png)
