### PR TITLE
Use absolute path for pep8 binary

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,8 +2,11 @@
 
 set -e
 
+echo "Running sbt test and coverage report"
 sbt clean coverage testPython test coverageReport
-find job-server-python/src/python -name *.py -exec pep8 {} +
+echo "Running pep8 over .py files"
+find job-server-python/src/python -name *.py -exec $HOME/.local/bin/pep8 {} +
 
 # report results
+echo "Publishing code coverage report codecov.io"
 bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This will allow python packages installed using "pip --user" option to be used
without any issues.

Also add some print statements for clarity.