### PR TITLE
Pass codecov.io env variables to docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ install:
   - sudo chown $USER docker/latest_cache.tar.gz
 
 script:
-  - docker run --rm -t -i $DOCKER_IMAGE
+  - docker run `/bin/bash <(curl -s https://codecov.io/env)` --rm -t -i $DOCKER_IMAGE


### PR DESCRIPTION
Now the tests are running inside the docker. But codecov is unable to detect CI system. 
So pass codecov environment variables to docker run.