### PR TITLE
Fixes #746: Random failure of deleteBinaries test case

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/io/JobSqlDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobSqlDAO.scala
@@ -139,7 +139,9 @@ class JobSqlDAO(config: Config) extends JobDAO with FileCacher {
     * @param appName
     */
   override def deleteBinary(appName: String): Unit = {
-    deleteBinaryInfo(appName)
+    if (Await.result(deleteBinaryInfo(appName), 60 seconds) == 0) {
+      throw new SlickException(s"Failed to delete binary: $appName from database")
+    }
     cleanCacheBinaries(appName)
   }
 


### PR DESCRIPTION
(Updated description to hopefully avoid any further confusion about the goal of this PR):

(1) When calling **DELETE /binaries/<appName>**, WebApi sends a DeleteBinary request to BinaryManager actor which returns a Future. (On completion of the future, OK is returned to the calling HTTP client)
(2) BinaryManager thereby internally sends DeleteBinary(appName) to JobDAOActor
(3) JobDAOActor invokes deleteBinary on JobDAO trait and returns the result to BinaryManager 
	 => The used implementation is JobSqlDAO
(4) JobSqlDAO's deleteBinary method looks like this:
```
override def deleteBinary(appName: String): Unit = {
	deleteBinaryInfo(appName)
	cleanCacheBinaries(appName)
}
```

**HERE IS THE IMPORTANT POINT:**
	
(5)	
```
private def deleteBinaryInfo(appName: String): Future[Int] = {
	db.run(binaries.filter(_.appName === appName).delete)
}
```
	
returns a FUTURE, because Slick's run() method is async and returns a future
	
**HOWEVER, deleteBinary (4) treats deleteBinaryInfo as if it were a synchronous call and thus immediately returns. This makes the whole chain (4) => (3) => (2) => (1) immediately return (with a completed Future) even if the operation is not yet completed.**
	
Thus, the corresponding test case sometimes fails because it checks if the deletion was successful and in sometimes cases it does check BEFORE the deletion was actually carried out
	
Solution: the fixed implementation makes deleteBinary (4) wait until the Future in (5) is completed:
```
override def deleteBinary(appName: String): Unit = {
	if (Await.result(deleteBinaryInfo(appName), 60 seconds) == 0) {
		  throw new SlickException(s"Failed to delete binary: $appName from database")
	}
	cleanCacheBinaries(appName)
}
```