### PR TITLE
fix compilation issue #760

### DIFF
--- a/job-server-extras/src/main/java/spark/jobserver/JHiveTestJob.java
+++ b/job-server-extras/src/main/java/spark/jobserver/JHiveTestJob.java
@@ -10,7 +10,7 @@ public class JHiveTestJob implements JHiveJob<Row[]> {
 
     @Override
     public Row[] run(HiveContext sc, JobEnvironment runtime, Config data) {
-        return sc.sql(data.getString("sql")).collect();
+        return (Row[]) sc.sql(data.getString("sql")).collect();
     }
 
     @Override

--- a/job-server-extras/src/main/java/spark/jobserver/JHiveTestLoaderJob.java
+++ b/job-server-extras/src/main/java/spark/jobserver/JHiveTestLoaderJob.java
@@ -1,7 +1,8 @@
 package spark.jobserver;
 
 import com.typesafe.config.Config;
-import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import org.apache.spark.sql.hive.HiveContext;
 import spark.jobserver.api.JobEnvironment;
 import spark.jobserver.japi.JHiveJob;
@@ -22,7 +23,7 @@ public class JHiveTestLoaderJob implements JHiveJob<Long> {
         sc.sql(String.format("%s %s %s %s %s %s", tableCreate, tableArgs, tableRowFormat, tableColFormat, tableMapFormat, tableAs));
         sc.sql(String.format("LOAD DATA LOCAL INPATH %s OVERWRITE INTO TABLE `default`.`test_addresses`", loadPath));
 
-        final DataFrame addrRdd = sc.sql("SELECT * FROM `default`.`test_addresses`");
+        final Dataset<Row> addrRdd = sc.sql("SELECT * FROM `default`.`test_addresses`");
         return addrRdd.count();
     }
 

--- a/job-server-extras/src/main/java/spark/jobserver/JSqlTestJob.java
+++ b/job-server-extras/src/main/java/spark/jobserver/JSqlTestJob.java
@@ -10,7 +10,7 @@ import spark.jobserver.japi.JSqlJob;
 public class JSqlTestJob implements JSqlJob<Integer> {
     @Override
     public Integer run(SQLContext sc, JobEnvironment runtime, Config data) {
-        Row row = sc.sql("select 1+1").take(1)[0];
+        Row row = ((Row[]) sc.sql("select 1+1").take(1))[0];
         return row.getInt(0);
     }
 

--- a/job-server-extras/src/main/java/spark/jobserver/JStreamingTestJob.java
+++ b/job-server-extras/src/main/java/spark/jobserver/JStreamingTestJob.java
@@ -27,7 +27,11 @@ public class JStreamingTestJob implements JStreamingJob<Integer> {
 
         counts.print(5);
         jsc.start();
-        jsc.awaitTermination();
+        try {
+            jsc.awaitTermination();
+        } catch(InterruptedException e){
+            return -1;
+        }
         return 1;
     }
 


### PR DESCRIPTION
I introduced quick fix for compilation issue #760. The problem is in changes in Spark Dataframe/Dataset API in Spark 2.0. The method take using java API returns Object instead of Row[]. 

Also:
`jsc.awaitTermination();` can throw InterruptedException

After applying this changes  you should be to compile and build spark-jobserver for spark-2.0 once again 