### PR TITLE
fix(job-server) : Add default driver-mode to application.conf and fix bug without default value

### DIFF
--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -11,6 +11,12 @@ spark {
     # If true, a separate JVM is forked for each Spark context
     context-per-jvm = false
 
+    # Default client mode will start up a new JobManager int local machine
+    # You can use mesos-cluster mode with REMOTE_JOBSERVER_DIR and MESOS_SPARK_DISPATCHER
+    # environment value set in xxxx.sh file to launch JobManager in remote node
+    # Mesos will take responsibility to offer resource to the JobManager process
+    driver-mode = client
+
     # Number of job results to keep per JobResultActor/context
     job-result-cache-size = 5000
 

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -208,7 +208,7 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef) extends InstrumentedActor {
 
     logger.info("Starting context with actor name {}", contextActorName)
 
-    val driverMode = Option(config.getString("spark.jobserver.driver-mode")).getOrElse("client")
+    val driverMode = Try(config.getString("spark.jobserver.driver-mode")).toOption.getOrElse("client")
     val (workDir, contextContent) = generateContext(name, contextConfig, isAdHoc, contextActorName)
     logger.info("Ready to create working directory {} for context {}", workDir: Any, name)
 


### PR DESCRIPTION
**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

* #681 
* #761 


**New behavior :**

When no driver-mode is set, job-server will use default client mode and no error thrown

**Other information**:

It is my mistake to use `Option` not `Try` to execute config.getString method, There is no default config for spark.jobserver.driver-mode So it will cause error.

Add a new line `driver-mode = client` to avoid this error, also change Option to Try if no default value is set to avoid throw an exception.