### PR TITLE
Add config option to allow the script starting forked JVM contexts to…

### DIFF
--- a/job-server/config/docker.conf
+++ b/job-server/config/docker.conf
@@ -59,6 +59,7 @@ spark {
 
 deploy {
   manager-start-cmd = "app/manager_start.sh"
+  wait-for-manager-start = false
 }
 
 # Note that you can use this file to define settings not only for job server,

--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -237,4 +237,7 @@ shiro {
 
 deploy {
   manager-start-cmd = "./manager_start.sh"
+  # If true, wait for the process which starts contexts in a forked JVM to exit. Set to false
+  # if this process needs to remain in the foreground, e.g. when running in Docker.
+  wait-for-manager-start = true
 }

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -34,6 +34,7 @@ import akka.pattern.gracefulStop
  * {{{
  *   deploy {
  *     manager-start-cmd = "./manager_start.sh"
+ *     wait-for-manager-start = true
  *   }
  * }}}
  */
@@ -48,6 +49,7 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef) extends InstrumentedActor {
                                                 TimeUnit.SECONDS)
   val contextDeletionTimeout = SparkJobUtils.getContextDeletionTimeout(config)
   val managerStartCommand = config.getString("deploy.manager-start-cmd")
+  val waitForManagerStart = config.getBoolean("deploy.wait-for-manager-start")
   import context.dispatcher
 
   //actor name -> (context isadhoc, success callback, failure callback)
@@ -231,9 +233,11 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef) extends InstrumentedActor {
     logger.info("Starting to execute sub process {}", pb)
     val processStart = Try {
       val process = pb.run(pio)
-      val exitVal = process.exitValue()
-      if (exitVal != 0) {
-        throw new IOException("Failed to launch context process, got exit code " + exitVal)
+      if (waitForManagerStart) {
+        val exitVal = process.exitValue()
+        if (exitVal != 0) {
+          throw new IOException("Failed to launch context process, got exit code " + exitVal)
+        }
       }
     }
 


### PR DESCRIPTION
… keep its process in the foreground

While running in Docker with `context-per-jvm = true`, I was experiencing an issue whereby the spark-submit process to launch the new contexts would exit immediately when its parent process, the `manager-start.sh` script, exited. I tried all the usual suspects (nohup, disown, screen etc), but nothing worked except keeping the process in the foreground. (Running Docker version 17.03.0-ce, on ubuntu 14.04).

This will also address #739 as it means all the stdout from the forked contexts will go to the parent process's stdout, which is typically what you want in a Docker container.