### PR TITLE
Upgrade spark to 2.1.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -124,7 +124,7 @@ lazy val dockerSettings = Seq(
     val artifact = (assemblyOutputPath in assembly in jobServerExtras).value
     val artifactTargetPath = s"/app/${artifact.name}"
 
-    val sparkBuild = s"spark-$sparkVersion"
+    val sparkBuild = s"spark-${Versions.spark}"
     val sparkBuildCmd = scalaBinaryVersion.value match {
       case "2.11" =>
         "./make-distribution.sh -Dscala-2.11 -Phadoop-2.7 -Phive"
@@ -132,11 +132,11 @@ lazy val dockerSettings = Seq(
     }
 
     new sbtdocker.mutable.Dockerfile {
-      from(s"openjdk:$javaVersion")
+      from(s"openjdk:${Versions.java}")
       // Dockerfile best practices: https://docs.docker.com/articles/dockerfile_best-practices/
       expose(8090)
       expose(9999) // for JMX
-      env("MESOS_VERSION", mesosVersion)
+      env("MESOS_VERSION", Versions.mesos)
       runRaw(
         """echo "deb http://repos.mesosphere.io/ubuntu/ trusty main" > /etc/apt/sources.list.d/mesosphere.list && \
                 apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
@@ -178,10 +178,10 @@ lazy val dockerSettings = Seq(
                         repository = "spark-jobserver",
                         tag = Some(
                           s"${version.value}" +
-                          s".mesos-${mesosVersion.split('-')(0)}" +
-                          s".spark-$sparkVersion" +
+                          s".mesos-${Versions.mesos.split('-')(0)}" +
+                          s".spark-${Versions.spark}" +
                           s".scala-${scalaBinaryVersion.value}" +
-                          s".jdk-$javaVersion")
+                          s".jdk-${Versions.java}")
                         )
   )
 )

--- a/job-server-extras/src/main/java/spark/jobserver/JHiveTestJob.java
+++ b/job-server-extras/src/main/java/spark/jobserver/JHiveTestJob.java
@@ -1,5 +1,6 @@
 package spark.jobserver;
 
+import java.util.List;
 import com.typesafe.config.Config;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.hive.HiveContext;
@@ -10,7 +11,9 @@ public class JHiveTestJob implements JHiveJob<Row[]> {
 
     @Override
     public Row[] run(HiveContext sc, JobEnvironment runtime, Config data) {
-        return sc.sql(data.getString("sql")).collect();
+        List<Row> rowList = sc.sql(data.getString("sql")).collectAsList();
+        Row[] rows = new Row[rowList.size()];
+        return rowList.toArray(rows);
     }
 
     @Override

--- a/job-server-extras/src/main/java/spark/jobserver/JHiveTestLoaderJob.java
+++ b/job-server-extras/src/main/java/spark/jobserver/JHiveTestLoaderJob.java
@@ -1,7 +1,8 @@
 package spark.jobserver;
 
 import com.typesafe.config.Config;
-import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import org.apache.spark.sql.hive.HiveContext;
 import spark.jobserver.api.JobEnvironment;
 import spark.jobserver.japi.JHiveJob;
@@ -22,7 +23,7 @@ public class JHiveTestLoaderJob implements JHiveJob<Long> {
         sc.sql(String.format("%s %s %s %s %s %s", tableCreate, tableArgs, tableRowFormat, tableColFormat, tableMapFormat, tableAs));
         sc.sql(String.format("LOAD DATA LOCAL INPATH %s OVERWRITE INTO TABLE `default`.`test_addresses`", loadPath));
 
-        final DataFrame addrRdd = sc.sql("SELECT * FROM `default`.`test_addresses`");
+        final Dataset<Row> addrRdd = sc.sql("SELECT * FROM `default`.`test_addresses`");
         return addrRdd.count();
     }
 

--- a/job-server-extras/src/main/java/spark/jobserver/JSqlTestJob.java
+++ b/job-server-extras/src/main/java/spark/jobserver/JSqlTestJob.java
@@ -10,7 +10,7 @@ import spark.jobserver.japi.JSqlJob;
 public class JSqlTestJob implements JSqlJob<Integer> {
     @Override
     public Integer run(SQLContext sc, JobEnvironment runtime, Config data) {
-        Row row = sc.sql("select 1+1").take(1)[0];
+        Row row = sc.sql("select 1+1").takeAsList(1).get(0);
         return row.getInt(0);
     }
 

--- a/job-server-extras/src/main/java/spark/jobserver/JStreamingTestJob.java
+++ b/job-server-extras/src/main/java/spark/jobserver/JStreamingTestJob.java
@@ -27,7 +27,11 @@ public class JStreamingTestJob implements JStreamingJob<Integer> {
 
         counts.print(5);
         jsc.start();
-        jsc.awaitTermination();
+        try {
+          jsc.awaitTermination();
+        } catch (InterruptedException e) {
+          return -1;
+        }
         return 1;
     }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,27 +22,22 @@ object Dependencies {
     "io.spray" %% "spray-json" % sprayJson,
     "io.spray" %% "spray-can" % spray,
     "io.spray" %% "spray-caching" % spray,
-    "io.spray" %% "spray-routing-shapeless23" % "1.3.3",
+    "io.spray" %% "spray-routing-shapeless23" % "1.3.4",
     "io.spray" %% "spray-client" % spray,
     yammerDeps
   )
 
-  val javaVersion = sys.env.getOrElse("JAVA_VERSION", "8-jdk")
-
-  val mesosVersion = sys.env.getOrElse("MESOS_VERSION", mesos)
-
-  val sparkVersion = sys.env.getOrElse("SPARK_VERSION", spark)
   lazy val sparkDeps = Seq(
-    "org.apache.spark" %% "spark-core" % sparkVersion % "provided" excludeAll(excludeNettyIo, excludeQQ),
+    "org.apache.spark" %% "spark-core" % spark % "provided" excludeAll(excludeNettyIo, excludeQQ),
     // Force netty version.  This avoids some Spark netty dependency problem.
-    "io.netty" % "netty-all" % "4.0.37.Final"
+    "io.netty" % "netty-all" % netty
   )
 
   lazy val sparkExtraDeps = Seq(
-    "org.apache.spark" %% "spark-mllib" % sparkVersion % Provided excludeAll(excludeNettyIo, excludeQQ),
-    "org.apache.spark" %% "spark-sql" % sparkVersion % Provided excludeAll(excludeNettyIo, excludeQQ),
-    "org.apache.spark" %% "spark-streaming" % sparkVersion % Provided excludeAll(excludeNettyIo, excludeQQ),
-    "org.apache.spark" %% "spark-hive" % sparkVersion % Provided excludeAll(
+    "org.apache.spark" %% "spark-mllib" % spark % Provided excludeAll(excludeNettyIo, excludeQQ),
+    "org.apache.spark" %% "spark-sql" % spark % Provided excludeAll(excludeNettyIo, excludeQQ),
+    "org.apache.spark" %% "spark-streaming" % spark % Provided excludeAll(excludeNettyIo, excludeQQ),
+    "org.apache.spark" %% "spark-hive" % spark % Provided excludeAll(
       excludeNettyIo, excludeQQ, excludeScalaTest
     )
   )

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,25 +1,28 @@
+import scala.util.Properties.isJavaAtLeast
+
 object Versions {
-  val jdkVersion = scala.util.Properties.isJavaAtLeast("1.8")
-  lazy val typeSafeConfig = if(jdkVersion) "1.3.0" else "1.2.1"
-  lazy val metrics = "2.2.0"
-  lazy val jodaTime = "2.9.3"
-  lazy val jodaConvert = "1.8.1"
+  lazy val spark = sys.env.getOrElse("SPARK_VERSION", "2.1.0")
+
   lazy val akka = "2.4.9"
-  lazy val spray = "1.3.3"
-  lazy val sprayJson = "1.3.2"
-  lazy val spark = "2.0.1"
-  lazy val mesos = "1.0.0-2.0.89.ubuntu1404"
-  lazy val netty =  "4.0.29.Final"
-  lazy val slick = "3.1.1"
-  lazy val h2 = "1.3.176"
-  lazy val postgres = "9.4.1209"
   lazy val cassandra = "3.0.3"
+  lazy val cassandraUnit = "2.2.2.1"
   lazy val commons = "1.4"
   lazy val flyway = "3.2.1"
+  lazy val h2 = "1.3.176"
+  lazy val java = sys.env.getOrElse("JAVA_VERSION", "8-jdk")
+  lazy val jodaConvert = "1.8.1"
+  lazy val jodaTime = "2.9.3"
   lazy val logback = "1.0.7"
+  lazy val mesos = sys.env.getOrElse("MESOS_VERSION", "1.0.0-2.0.89.ubuntu1404")
+  lazy val metrics = "2.2.0"
+  lazy val netty =  "4.0.42.Final"
+  lazy val postgres = "9.4.1209"
+  lazy val py4j = "0.10.3"
   lazy val scalaTest = "2.2.6"
   lazy val scalatic = "2.2.6"
   lazy val shiro = "1.2.4"
-  lazy val cassandraUnit = "2.2.2.1"
-  lazy val py4j = "0.10.3"
+  lazy val slick = "3.1.1"
+  lazy val spray = "1.3.3"
+  lazy val sprayJson = "1.3.2"
+  lazy val typeSafeConfig = if (isJavaAtLeast("1.8")) "1.3.0" else "1.2.1"
 }


### PR DESCRIPTION
Also,
- Fix existing compile errors.
- Sort variables in `Versions.scala` for readability.
- Update shapeless to latest version.
- Make `Versions.scala` the one-stop for all version resolution rather than re-resolving them in `Dependencies.scala`.