### PR TITLE
doc(troubleshooting): Add note on results cache for SJS restart

### DIFF
--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -39,8 +39,9 @@ If your job returns a large job result, it may exceed Akka's maximum network mes
 
 On jobs with large results or many concurrent jobs, the REST API at `/job/abc..` might return status `FINISHED` but does not contains any result. This might happen in two cases:
 
-1. the job finished right now and results are in transfer.
-2. the job finished some time ago and results are remove from results cache already. See `spark.jobserver.job-result-cache-size` to increase the cache.
+1. The job finished right now and results are in transfer.
+2. The job finished some time ago and results are remove from results cache already. See `spark.jobserver.job-result-cache-size` to increase the cache.
+3. The spark jobserver instance restarted which clears the results cache.
 
 
 ## AskTimeout when starting job server or contexts


### PR DESCRIPTION
This would help users to understand why they are not seeing results after a
spark jobserver restart and it is expected. See issue #769