### PR TITLE
Fix compilation errors in Hive tests using TestHiveContext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,26 +1,23 @@
-# Editor related ignores
-*.swp
-.ensime*
-.idea*
-
 # Standard sbt ignores
+target/
+src_managed/
+project/boot/
+test-reports/
 *.log*
 *.patch
-*.pyc
+.ensime*
+.idea*
 .vagrant
-job-server-extras/spark-warehouse/
-project/boot/
-src_managed/
-target/
-test-reports/
+*.pyc
 
 # ignore deployment configs
 config/*.conf
-config/*.ini
 config/*.sh
+config/*.ini
 job-server/config/*.conf
-job-server/config/*.ini
 job-server/config/*.sh
+job-server/config/*.ini
+job-server-extras/spark-warehouse/
 metastore_db/
 
 #ignore generated config

--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,26 @@
-# Standard sbt ignores
-target/
-src_managed/
-project/boot/
-test-reports/
-*.log*
-*.patch
+# Editor related ignores
+*.swp
 .ensime*
 .idea*
-.vagrant
+
+# Standard sbt ignores
+*.log*
+*.patch
 *.pyc
+.vagrant
+job-server-extras/spark-warehouse/
+project/boot/
+src_managed/
+target/
+test-reports/
 
 # ignore deployment configs
 config/*.conf
-config/*.sh
 config/*.ini
+config/*.sh
 job-server/config/*.conf
-job-server/config/*.sh
 job-server/config/*.ini
+job-server/config/*.sh
 metastore_db/
 
 #ignore generated config

--- a/job-server-api/src/main/scala/spark/jobserver/context/JavaSparkContextFactory.scala
+++ b/job-server-api/src/main/scala/spark/jobserver/context/JavaSparkContextFactory.scala
@@ -3,38 +3,17 @@ package spark.jobserver.context
 import com.typesafe.config.Config
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.{SparkConf, SparkContext}
-import org.joda.time.DateTime
-import org.scalactic._
-import spark.jobserver.japi.{JSparkJob, JavaJob}
-import spark.jobserver.{ContextLike, JobCache}
+import spark.jobserver.ContextLike
+import spark.jobserver.japi.{BaseJavaJob, JSparkJob, JavaJob}
 
-class JavaSparkContextFactory extends SparkContextFactory {
+class JavaSparkContextFactory extends JavaContextFactory {
   type C = JavaSparkContext with ContextLike
-  type J = ScalaJobContainer
 
-  def loadAndValidateJob(appName: String,
-                         uploadTime: DateTime,
-                         classPath: String,
-                         jobCache: JobCache): J Or LoadingError = {
-
-    val j = try {
-      jobCache.getJavaJob(appName, uploadTime, classPath)
-    } catch {
-      case _: ClassNotFoundException => return Bad(JobClassNotFound)
-      case err: Exception => return Bad(JobLoadError(err))
-    }
-    if (j.job.isInstanceOf[JSparkJob[_]]) {
-      Good(ScalaJobContainer(JavaJob(j.job)))
-    } else {
-      Bad(JobWrongType)
-    }
-  }
+  def isValidJob(job: BaseJavaJob[_, _]): Boolean = job.isInstanceOf[JSparkJob[_]]
 
   def makeContext(sparkConf: SparkConf, config: Config, contextName: String): C = {
-    val jsc = new JavaSparkContext(sparkConf) with ContextLike {
+    new JavaSparkContext(sparkConf) with ContextLike {
       override def sparkContext: SparkContext = this.sc
     }
-    jsc
   }
-
 }

--- a/job-server-api/src/main/scala/spark/jobserver/context/SparkContextFactory.scala
+++ b/job-server-api/src/main/scala/spark/jobserver/context/SparkContextFactory.scala
@@ -77,12 +77,10 @@ trait ScalaContextFactory extends SparkContextFactory {
 
   val logger = LoggerFactory.getLogger(getClass)
 
-  def loadAndValidateJob(
-    appName: String,
-    uploadTime: DateTime,
-    classPath: String,
-    jobCache: JobCache
-  ): J Or LoadingError = {
+  def loadAndValidateJob(appName: String,
+                         uploadTime: DateTime,
+                         classPath: String,
+                         jobCache: JobCache): J Or LoadingError = {
     logger.info("Loading class {} for app {}", classPath, appName: Any)
     try {
       val jobJarInfo = jobCache.getSparkJob(appName, uploadTime, classPath)
@@ -111,12 +109,10 @@ trait JavaContextFactory extends SparkContextFactory {
 
   val logger = LoggerFactory.getLogger(getClass)
 
-  def loadAndValidateJob(
-    appName: String,
-    uploadTime: DateTime,
-    classPath: String,
-    jobCache: JobCache
-  ): J Or LoadingError = {
+  def loadAndValidateJob(appName: String,
+                         uploadTime: DateTime,
+                         classPath: String,
+                         jobCache: JobCache): J Or LoadingError = {
     logger.info("Loading class {} for app {}", classPath, appName: Any)
     try {
       val jobJarInfo = jobCache.getJavaJob(appName, uploadTime, classPath)

--- a/job-server-extras/src/main/java/spark/jobserver/JHiveTestJob.java
+++ b/job-server-extras/src/main/java/spark/jobserver/JHiveTestJob.java
@@ -3,21 +3,21 @@ package spark.jobserver;
 import java.util.List;
 import com.typesafe.config.Config;
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.hive.HiveContext;
+import org.apache.spark.sql.hive.test.TestHiveContext;
 import spark.jobserver.api.JobEnvironment;
-import spark.jobserver.japi.JHiveJob;
+import spark.jobserver.japi.JTestHiveJob;
 
-public class JHiveTestJob implements JHiveJob<Row[]> {
+public class JHiveTestJob implements JTestHiveJob<Row[]> {
 
     @Override
-    public Row[] run(HiveContext sc, JobEnvironment runtime, Config data) {
+    public Row[] run(TestHiveContext sc, JobEnvironment runtime, Config data) {
         List<Row> rowList = sc.sql(data.getString("sql")).collectAsList();
         Row[] rows = new Row[rowList.size()];
         return rowList.toArray(rows);
     }
 
     @Override
-    public Config verify(HiveContext sc, JobEnvironment runtime, Config config) {
+    public Config verify(TestHiveContext sc, JobEnvironment runtime, Config config) {
         return config;
     }
 }

--- a/job-server-extras/src/main/java/spark/jobserver/JHiveTestLoaderJob.java
+++ b/job-server-extras/src/main/java/spark/jobserver/JHiveTestLoaderJob.java
@@ -3,11 +3,11 @@ package spark.jobserver;
 import com.typesafe.config.Config;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.hive.HiveContext;
+import org.apache.spark.sql.hive.test.TestHiveContext;
 import spark.jobserver.api.JobEnvironment;
-import spark.jobserver.japi.JHiveJob;
+import spark.jobserver.japi.JTestHiveJob;
 
-public class JHiveTestLoaderJob implements JHiveJob<Long> {
+public class JHiveTestLoaderJob implements JTestHiveJob<Long> {
 
     private final String tableCreate = "CREATE TABLE `default`.`test_addresses`";
     private final String tableArgs = "(`firstName` String, `lastName` String, `address` String, `city` String)";
@@ -18,7 +18,7 @@ public class JHiveTestLoaderJob implements JHiveJob<Long> {
     private final String loadPath = "'src/main/resources/hive_test_job_addresses.txt'";
 
     @Override
-    public Long run(HiveContext sc, JobEnvironment runtime, Config data) {
+    public Long run(TestHiveContext sc, JobEnvironment runtime, Config data) {
         sc.sql("DROP TABLE if exists `default`.`test_addresses`");
         sc.sql(String.format("%s %s %s %s %s %s", tableCreate, tableArgs, tableRowFormat, tableColFormat, tableMapFormat, tableAs));
         sc.sql(String.format("LOAD DATA LOCAL INPATH %s OVERWRITE INTO TABLE `default`.`test_addresses`", loadPath));
@@ -28,7 +28,7 @@ public class JHiveTestLoaderJob implements JHiveJob<Long> {
     }
 
     @Override
-    public Config verify(HiveContext sc, JobEnvironment runtime, Config config) {
+    public Config verify(TestHiveContext sc, JobEnvironment runtime, Config config) {
         return config;
     }
 }

--- a/job-server-extras/src/main/scala/spark/jobserver/context/JavaSqlContextFactory.scala
+++ b/job-server-extras/src/main/scala/spark/jobserver/context/JavaSqlContextFactory.scala
@@ -7,32 +7,13 @@ import org.apache.spark.sql.hive.HiveContext
 import org.apache.spark.streaming.{Milliseconds, StreamingContext}
 import org.apache.spark.streaming.api.java.JavaStreamingContext
 import org.apache.spark.{SparkConf, SparkContext}
-import org.joda.time.DateTime
-import org.scalactic._
-import spark.jobserver.japi._
-import spark.jobserver.{ContextLike, JobCache}
+import spark.jobserver.ContextLike
+import spark.jobserver.japi.{BaseJavaJob, JHiveJob, JSqlJob, JStreamingJob}
 
-class JavaSqlContextFactory extends SparkContextFactory {
+class JavaSqlContextFactory extends JavaContextFactory {
   type C = SQLContext with ContextLike
-  type J = ScalaJobContainer
 
-  def loadAndValidateJob(appName: String,
-                         uploadTime: DateTime,
-                         classPath: String,
-                         jobCache: JobCache): J Or LoadingError = {
-
-    val j = try {
-      jobCache.getJavaJob(appName, uploadTime, classPath)
-    } catch {
-      case _: ClassNotFoundException => return Bad(JobClassNotFound)
-      case err: Exception => return Bad(JobLoadError(err))
-    }
-    if (j.job.isInstanceOf[JSqlJob[_]]) {
-      Good(ScalaJobContainer(JavaJob(j.job)))
-    } else {
-      Bad(JobWrongType)
-    }
-  }
+  def isValidJob(job: BaseJavaJob[_, _]): Boolean = job.isInstanceOf[JSqlJob[_]]
 
   def makeContext(sparkConf: SparkConf, config: Config, contextName: String): C = {
     val sc = new SparkContext(sparkConf)
@@ -42,27 +23,10 @@ class JavaSqlContextFactory extends SparkContextFactory {
   }
 }
 
-class JavaHiveContextFactory extends SparkContextFactory {
+class JavaHiveContextFactory extends JavaContextFactory {
   type C = HiveContext with ContextLike
-  type J = ScalaJobContainer
 
-  def loadAndValidateJob(appName: String,
-                         uploadTime: DateTime,
-                         classPath: String,
-                         jobCache: JobCache): J Or LoadingError = {
-
-    val j = try {
-      jobCache.getJavaJob(appName, uploadTime, classPath)
-    } catch {
-      case _: ClassNotFoundException => return Bad(JobClassNotFound)
-      case err: Exception => return Bad(JobLoadError(err))
-    }
-    if (j.job.isInstanceOf[JHiveJob[_]]) {
-      Good(ScalaJobContainer(JavaJob(j.job)))
-    } else {
-      Bad(JobWrongType)
-    }
-  }
+  def isValidJob(job: BaseJavaJob[_, _]): Boolean = job.isInstanceOf[JHiveJob[_]]
 
   def makeContext(sparkConf: SparkConf, config: Config, contextName: String): C = {
     contextFactory(sparkConf)
@@ -73,28 +37,10 @@ class JavaHiveContextFactory extends SparkContextFactory {
   }
 }
 
-
-class JavaStreamingContextFactory extends SparkContextFactory {
+class JavaStreamingContextFactory extends JavaContextFactory {
   type C = StreamingContext with ContextLike
-  type J = ScalaJobContainer
 
-  def loadAndValidateJob(appName: String,
-                         uploadTime: DateTime,
-                         classPath: String,
-                         jobCache: JobCache): J Or LoadingError = {
-
-    val j = try {
-      jobCache.getJavaJob(appName, uploadTime, classPath)
-    } catch {
-      case _: ClassNotFoundException => return Bad(JobClassNotFound)
-      case err: Exception => return Bad(JobLoadError(err))
-    }
-    if (j.job.isInstanceOf[JStreamingJob[_]]) {
-      Good(ScalaJobContainer(JavaJob(j.job)))
-    } else {
-      Bad(JobWrongType)
-    }
-  }
+  def isValidJob(job: BaseJavaJob[_, _]): Boolean = job.isInstanceOf[JStreamingJob[_]]
 
   def makeContext(sparkConf: SparkConf, config: Config, contextName: String): C = {
     val interval = config.getInt("streaming.batch_interval")

--- a/job-server-extras/src/main/scala/spark/jobserver/japi/JSqlJob.scala
+++ b/job-server-extras/src/main/scala/spark/jobserver/japi/JSqlJob.scala
@@ -2,10 +2,13 @@ package spark.jobserver.japi
 
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.hive.HiveContext
+import org.apache.spark.sql.hive.test.TestHiveContext
 import org.apache.spark.streaming.StreamingContext
 
 trait JSqlJob[R] extends BaseJavaJob[R, SQLContext]
 
 trait JHiveJob[R] extends BaseJavaJob[R, HiveContext]
+
+trait JTestHiveJob[R] extends BaseJavaJob[R, TestHiveContext]
 
 trait JStreamingJob[R] extends BaseJavaJob[R, StreamingContext]

--- a/job-server-extras/src/test/scala/spark/jobserver/JavaHiveSpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/JavaHiveSpec.scala
@@ -1,18 +1,27 @@
 package spark.jobserver
 
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.hive.test.TestHiveContext
 import org.apache.spark.{SparkConf, SparkContext}
 import spark.jobserver.CommonMessages.JobResult
-import spark.jobserver.context.{HiveContextLike, JavaHiveContextFactory}
+import spark.jobserver.context.{HiveContextLike, JavaContextFactory}
 import spark.jobserver.io.JobDAOActor
+import spark.jobserver.japi.{BaseJavaJob, JHiveJob}
 
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
-class JavaTestHiveContextFactory extends JavaHiveContextFactory {
-  override protected def contextFactory(conf: SparkConf): C = {
+class JavaTestHiveContextFactory extends JavaContextFactory {
+  type C = TestHiveContext with ContextLike
+
+  def isValidJob(job: BaseJavaJob[_, _]): Boolean = job.isInstanceOf[JHiveJob[_]]
+
+  def makeContext(sparkConf: SparkConf, config: Config, contextName: String): C = {
+    contextFactory(sparkConf)
+  }
+
+  protected def contextFactory(conf: SparkConf): C = {
     val sc = SparkContext.getOrCreate(conf)
     Try(new TestHiveContext(sc) with HiveContextLike) match {
       case Success(hc) => hc

--- a/job-server-extras/src/test/scala/spark/jobserver/JavaHiveSpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/JavaHiveSpec.scala
@@ -1,13 +1,14 @@
 package spark.jobserver
 
 import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.spark.SparkConf
+import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.hive.test.TestHiveContext
-import org.apache.spark.{SparkConf, SparkContext}
 import spark.jobserver.CommonMessages.JobResult
 import spark.jobserver.context.{HiveContextLike, JavaContextFactory}
 import spark.jobserver.io.JobDAOActor
-import spark.jobserver.japi.{BaseJavaJob, JHiveJob}
+import spark.jobserver.japi.{BaseJavaJob, JTestHiveJob}
 
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
@@ -15,15 +16,13 @@ import scala.util.{Failure, Success, Try}
 class JavaTestHiveContextFactory extends JavaContextFactory {
   type C = TestHiveContext with ContextLike
 
-  def isValidJob(job: BaseJavaJob[_, _]): Boolean = job.isInstanceOf[JHiveJob[_]]
+  def isValidJob(job: BaseJavaJob[_, _]): Boolean = job.isInstanceOf[JTestHiveJob[_]]
 
-  def makeContext(sparkConf: SparkConf, config: Config, contextName: String): C = {
-    contextFactory(sparkConf)
-  }
+  def makeContext(sparkConf: SparkConf, config: Config, contextName: String): C = contextFactory(sparkConf)
 
   protected def contextFactory(conf: SparkConf): C = {
-    val sc = SparkContext.getOrCreate(conf)
-    Try(new TestHiveContext(sc) with HiveContextLike) match {
+    val sc = new JavaSparkContext(conf)
+    Try(new TestHiveContext(sc, false) with HiveContextLike) match {
       case Success(hc) => hc
       case Failure(e) =>
         sc.stop


### PR DESCRIPTION
- Fixed the compilation errors (Final fix for #760).
- The Java ContextFactories were not DRY enough. Fixed that too.
- Sorted contents of `.gitignore` to make it more readable. Added `*.swp` and `job-server-extras/spark-warehouse/` (generated after running `HiveJobSpec`) to it.

However, the `JavaHiveSpec` now fails with
```
java.lang.AssertionError: assertion failed: expected class spark.jobserver.JobManagerActor$Initialized, found class spark.jobserver.JobManagerActor$InitError (InitError(java.lang.NullPointerException))
```
I feel the fix for this is in the #667 PR. Though I am not sure. Can use some guidance there to get this fixed.