### PR TITLE
fix(akka): mark actor as down on init errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 env:
   global:
     - _JAVA_OPTIONS="-Xmx1500m -XX:MaxPermSize=512m -Dakka.test.timefactor=3"
-    - SPARK_HOME=/tmp/spark-1.6.2-bin-hadoop2.6
+    - SPARK_HOME=/tmp/spark-1.6.3-bin-hadoop2.6
 scala:
    - 2.10.6
    - 2.11.8

--- a/ci/install-spark.sh
+++ b/ci/install-spark.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-curl -o /tmp/spark.tgz http://apache.mirror.anlx.net/spark/spark-1.6.2/spark-1.6.2-bin-hadoop2.6.tgz
+curl -o /tmp/spark.tgz http://apache.mirror.anlx.net/spark/spark-1.6.3/spark-1.6.3-bin-hadoop2.6.tgz
 tar -xvzf /tmp/spark.tgz -C /tmp

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -186,10 +186,12 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef) extends InstrumentedActor {
       Some(resultActor)))(Timeout(timeoutSecs.second)).onComplete {
       case Failure(e:Exception) =>
         logger.info("Failed to send initialize message to context " + ref, e)
+        cluster.down(ref.path.address)
         ref ! PoisonPill
         failureFunc(e)
       case Success(JobManagerActor.InitError(t)) =>
         logger.info("Failed to initialize context " + ref, t)
+        cluster.down(ref.path.address)
         ref ! PoisonPill
         failureFunc(t)
       case Success(JobManagerActor.Initialized(ctxName, resActor)) =>
@@ -198,6 +200,7 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef) extends InstrumentedActor {
         context.watch(ref)
         successFunc(ref)
       case _ => logger.info("Failed for unknown reason.")
+        cluster.down(ref.path.address)
         ref ! PoisonPill
         failureFunc(new RuntimeException("Failed for unknown reason."))
     }

--- a/notes/0.7.1.markdown
+++ b/notes/0.7.1.markdown
@@ -1,3 +1,4 @@
 #Scala #akka @ApacheSpark
 
+* Mark actor as down on context initialization errors. (@derSascha)
 * ENTER CHANGES HERE


### PR DESCRIPTION
**Current behavior :**
Start job server with `context-per-jvm: true` and create new context with some invalid configuration (e.g. `memory-per-node: invalid-value`. Context creation fails with some error as expected. The akka cluster becomes now unstable and don't accept new actors => its impossible to create a new context.

**New behavior :**
Mark actor as down on initialization errors and the cluster becomes stable again.
Same issue fixed in #624 at context delete.
