### PR TITLE
fix(akka): Stop job manager actor on context stop

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -173,6 +173,7 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef) extends InstrumentedActor {
       val name: String = actorRef.path.name
       logger.info("Actor terminated: {}", name)
       contexts.retain { case (name, (jobMgr, resActor)) => jobMgr != actorRef }
+      cluster.down(actorRef.path.address)
   }
 
   private def initContext(actorName: String, ref: ActorRef, timeoutSecs: Long = 1)

--- a/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
@@ -8,6 +8,8 @@ import akka.actor.{ActorRef, PoisonPill, Props}
 import com.typesafe.config.Config
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.{SparkConf, SparkEnv}
+import org.apache.spark.scheduler.SparkListener
+import org.apache.spark.scheduler.SparkListenerApplicationEnd
 import org.joda.time.DateTime
 import org.scalactic._
 import spark.jobserver.api.JobEnvironment
@@ -71,7 +73,8 @@ object JobManagerActor {
  *   }
  * }}}
  */
-class JobManagerActor(contextConfig: Config, daoActor: ActorRef) extends InstrumentedActor {
+class JobManagerActor(contextConfig: Config, daoActor: ActorRef)
+  extends InstrumentedActor with SparkListener {
 
   import CommonMessages._
   import JobManagerActor._
@@ -121,6 +124,12 @@ class JobManagerActor(contextConfig: Config, daoActor: ActorRef) extends Instrum
     Option(jobContext).foreach(_.stop())
   }
 
+  // Handle external kill events (e.g. killed via YARN)
+  override def onApplicationEnd(event: SparkListenerApplicationEnd) {
+    logger.info("Got Spark Application end event, stopping job manger.")
+    self ! PoisonPill
+  }
+
   def wrappedReceive: Receive = {
     case Initialize(resOpt) =>
       statusActor = context.actorOf(JobStatusActor.props(daoActor))
@@ -133,6 +142,7 @@ class JobManagerActor(contextConfig: Config, daoActor: ActorRef) extends Instrum
         }
         factory = getContextFactory()
         jobContext = factory.makeContext(config, contextConfig, contextName)
+        jobContext.sparkContext.addSparkListener(this)
         sparkEnv = SparkEnv.get
         jobCache = new JobCacheImpl(jobCacheSize, daoActor, jobContext.sparkContext, jarLoader)
         getSideJars(contextConfig).foreach { jarUri => jobContext.sparkContext.addJar(jarUri) }


### PR DESCRIPTION
**Current behavior:**
1. Create a new context in YARN mode
2. Kill YARN app or call context.stop
3. Context is now in stopped mode and not usable anymore. Job Server lists the context as active and does not allow to start a new context with same name.

**New behavior:**
Listen to context events and stop job manager actor if context get stopped. This ensures that context gets also removed in job server.

PR contains another `cluster.down` call in case that an actor gets terminated.