### PR TITLE
Add SparkSession Context Support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,6 +47,7 @@ lazy val jobServerTestJar = Project(id = "job-server-tests", base = file("job-se
 
 lazy val jobServerApi = Project(id = "job-server-api", base = file("job-server-api"))
   .settings(commonSettings)
+  .settings(jobServerApiSettings)
   .settings(publishSettings)
   .disablePlugins(SbtScalariform)
 
@@ -97,6 +98,8 @@ lazy val jobServerExtrasSettings = revolverSettings ++ Assembly.settings ++ publ
   test in assembly := {},
   exportJars := true
 )
+
+lazy val jobServerApiSettings = Seq(libraryDependencies ++= sparkDeps ++ sparkExtraDeps)
 
 lazy val testPython = taskKey[Unit]("Launch a sub process to run the Python tests")
 lazy val buildPython = taskKey[Unit]("Build the python side of python support into an egg")

--- a/job-server-extras/src/main/scala/spark/jobserver/SparkSessionJob.scala
+++ b/job-server-extras/src/main/scala/spark/jobserver/SparkSessionJob.scala
@@ -1,0 +1,25 @@
+package spark.jobserver
+
+import com.typesafe.config.Config
+import org.apache.spark.sql.SparkSession
+import org.scalactic._
+import spark.jobserver.api.{SparkJobBase, JobEnvironment, ValidationProblem}
+import spark.jobserver.context.SparkSessionContextLikeWrapper
+
+trait SparkSessionJob extends spark.jobserver.api.SparkJobBase {
+  type C = SparkSessionContextLikeWrapper
+
+  // Application should use this method to override
+  def runJob(sparkSession: SparkSession, runtime: JobEnvironment, data: JobData): JobOutput
+
+  override def runJob(sc: C, runtime: JobEnvironment, data: JobData): JobOutput
+   = runJob(sc.spark, runtime, data)
+
+  // Application should use this method to override
+  def validate(sparkSession: SparkSession, runtime: JobEnvironment, config: Config):
+      JobData Or Every[ValidationProblem]
+
+  override def validate(sc: C, runtime: JobEnvironment, config: Config):
+      JobData Or Every[ValidationProblem]
+    = validate(sc.spark, runtime, config)
+}

--- a/job-server-extras/src/main/scala/spark/jobserver/context/SessionContextFactory.scala
+++ b/job-server-extras/src/main/scala/spark/jobserver/context/SessionContextFactory.scala
@@ -1,0 +1,28 @@
+package spark.jobserver.context
+
+import com.typesafe.config.Config
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.SparkSession
+import org.slf4j.LoggerFactory
+import spark.jobserver.{ContextLike, SparkSessionJob}
+import spark.jobserver.api.SparkJobBase
+import spark.jobserver.util.SparkJobUtils
+
+case class SparkSessionContextLikeWrapper(spark: SparkSession) extends ContextLike {
+  def sparkContext: SparkContext = spark.sparkContext
+  def stop() {
+    spark.close()
+  }
+}
+
+class SessionContextFactory extends ScalaContextFactory {
+  type C = SparkSessionContextLikeWrapper
+
+  def isValidJob(job: SparkJobBase): Boolean = job.isInstanceOf[SparkSessionJob]
+
+  def makeContext(sparkConf: SparkConf, config: Config,  contextName: String): C = {
+    val spark = SparkSession.builder.config(sparkConf).appName(contextName).enableHiveSupport().getOrCreate()
+    for ((k, v) <- SparkJobUtils.getHadoopConfig(config)) spark.sparkContext.hadoopConfiguration.set(k, v)
+    SparkSessionContextLikeWrapper(spark)
+  }
+}

--- a/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
@@ -216,7 +216,7 @@ class JobManagerActor(contextConfig: Config, daoActor: ActorRef) extends Instrum
       None
     }
 
-    val daoAskTimeout = Timeout(3 seconds)
+    val daoAskTimeout = Timeout(600 seconds)
     // TODO: refactor so we don't need Await, instead flatmap into more futures
     val resp = Await.result(
       (daoActor ? JobDAOActor.GetLastUploadTimeAndType(appName))(daoAskTimeout).


### PR DESCRIPTION
This adds support to create a SparkSession context

Here is the usage for creating the context of type SparkSession
```curl -X POST \
  'http://127.0.0.1:8090/contexts/sql-context-1?num-cpu-cores=2&memory-per-node=512M&context-factory=spark.jobserver.context.SessionContextFactory'
```
Spark JobServer application shall extend the SparkSessionJob, here is an example 

```
import com.typesafe.config.Config
import org.apache.spark.sql.SparkSession
import org.scalactic._
import spark.jobserver.SparkSessionJob
import spark.jobserver.api.{JobEnvironment, SingleProblem, ValidationProblem}

import scala.util.Try

object WordCountExampleSparkSession extends SparkSessionJob {
  type JobData = Seq[String]
  type JobOutput = collection.Map[String, Long]

  override def runJob(sparkSession: SparkSession, runtime: JobEnvironment, data: JobData): JobOutput =
    sparkSession.sparkContext.parallelize(data).countByValue

  override def validate(sparkSession: SparkSession, runtime: JobEnvironment, config: Config):
  JobData Or Every[ValidationProblem] = {
    Try(config.getString("input.string").split(" ").toSeq)
      .map(words => Good(words))
      .getOrElse(Bad(One(SingleProblem("No input.string param"))))
  }
}
```
Testing has been done converting our jobs from v0.62 to extending from SparkSessionJob and successfully running the jobs in SJS built from spark-2.0-preview branch with these additional changes in PR and Spark v2.1.1 cluster

please take a look and let me know if there are any comments
