### PR TITLE
Fix DELETE binaries endpoint and response

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/BinaryManager.scala
+++ b/job-server/src/main/scala/spark/jobserver/BinaryManager.scala
@@ -33,6 +33,7 @@ case object InvalidBinary
 case object BinaryStored
 case object BinaryDeleted
 case class BinaryStorageFailure(ex: Throwable)
+case class BinaryDeletionFailure(ex: Throwable)
 
 /**
  * An Actor that manages the jars stored by the job server.   It's important that threads do not try to
@@ -106,6 +107,9 @@ class BinaryManager(jobDao: ActorRef) extends InstrumentedActor {
 
     case DeleteBinary(appName) =>
       logger.info(s"Deleting binary $appName")
-      deleteBinary(appName).pipeTo(sender)
+      deleteBinary(appName).map{
+        case Success(_) => BinaryDeleted
+        case Failure(ex) => BinaryDeletionFailure(ex)
+      }.pipeTo(sender)
   }
 }

--- a/job-server/src/main/scala/spark/jobserver/BinaryManager.scala
+++ b/job-server/src/main/scala/spark/jobserver/BinaryManager.scala
@@ -107,7 +107,7 @@ class BinaryManager(jobDao: ActorRef) extends InstrumentedActor {
 
     case DeleteBinary(appName) =>
       logger.info(s"Deleting binary $appName")
-      deleteBinary(appName).map{
+      deleteBinary(appName).map {
         case Success(_) => BinaryDeleted
         case Failure(ex) => BinaryDeletionFailure(ex)
       }.pipeTo(sender)

--- a/job-server/src/main/scala/spark/jobserver/io/FileCacher.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/FileCacher.scala
@@ -50,7 +50,8 @@ trait FileCacher {
       override def accept(dir: File, name: String): Boolean = {
         val prefix = appName + "-"
         if (name.startsWith(prefix)) {
-          true
+          val suffix = name.substring(prefix.length)
+          (Pattern findFirstIn suffix).isDefined
         } else {
           false
         }

--- a/job-server/src/main/scala/spark/jobserver/io/FileCacher.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/FileCacher.scala
@@ -50,8 +50,6 @@ trait FileCacher {
       override def accept(dir: File, name: String): Boolean = {
         val prefix = appName + "-"
         if (name.startsWith(prefix)) {
-          val suffix = name.substring(prefix.length)
-          (Pattern findFirstIn suffix).isDefined
           true
         } else {
           false

--- a/job-server/src/main/scala/spark/jobserver/io/FileCacher.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/FileCacher.scala
@@ -52,8 +52,10 @@ trait FileCacher {
         if (name.startsWith(prefix)) {
           val suffix = name.substring(prefix.length)
           (Pattern findFirstIn suffix).isDefined
+          true
+        } else {
+          false
         }
-        false
       }
     })
     if (binaries != null) {

--- a/job-server/src/test/scala/spark/jobserver/BinaryManagerSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/BinaryManagerSpec.scala
@@ -68,7 +68,7 @@ class BinaryManagerSpec extends TestKit(BinaryManagerSpec.system) with ImplicitS
 
     it("should respond when deleted successfully") {
       binaryManager ! DeleteBinary("valid")
-      expectMsg(Success({}))
+      expectMsg(BinaryDeleted)
     }
   }
 }

--- a/job-server/src/test/scala/spark/jobserver/io/FileCacherSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/FileCacherSpec.scala
@@ -16,6 +16,8 @@ class FileCacherSpec extends FileCacher with FunSpecLike with Matchers {
   }
 
   it("clean cache binaries") {
-    cleanCacheBinaries("job")
+    val f = File.createTempFile("jobTest-20161010_010000_000.jar", ".jar", new File(rootDir))
+    cleanCacheBinaries("jobTest")
+    f.exists() should be(false)
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Described here spark-jobserver/spark-jobserver#824

*Two things:*
1. The binaries DELETE endpoint returns a 500 error on successful deletion
2. The binaries DELETE endpoint does not initiate actual deletion of the cached binaries

**New behavior :**
*Two things:*
1. The binaries DELETE endpoint returns a 200 error on successful deletion
2. The binaries DELETE endpoint will now delete the cachedBinaries


**Other information**: