### PR TITLE
fix(akka): fix spark 2 compilation issues from PR 830

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
@@ -74,7 +74,7 @@ object JobManagerActor {
  * }}}
  */
 class JobManagerActor(contextConfig: Config, daoActor: ActorRef)
-  extends InstrumentedActor with SparkListener {
+  extends InstrumentedActor {
 
   import CommonMessages._
   import JobManagerActor._
@@ -125,9 +125,13 @@ class JobManagerActor(contextConfig: Config, daoActor: ActorRef)
   }
 
   // Handle external kill events (e.g. killed via YARN)
-  override def onApplicationEnd(event: SparkListenerApplicationEnd) {
-    logger.info("Got Spark Application end event, stopping job manger.")
-    self ! PoisonPill
+  private def sparkListener = {
+    new SparkListener() {
+      override def onApplicationEnd(event: SparkListenerApplicationEnd) {
+        logger.info("Got Spark Application end event, stopping job manager.")
+        self ! PoisonPill
+      }
+    }
   }
 
   def wrappedReceive: Receive = {
@@ -142,7 +146,7 @@ class JobManagerActor(contextConfig: Config, daoActor: ActorRef)
         }
         factory = getContextFactory()
         jobContext = factory.makeContext(config, contextConfig, contextName)
-        jobContext.sparkContext.addSparkListener(this)
+        jobContext.sparkContext.addSparkListener(sparkListener)
         sparkEnv = SparkEnv.get
         jobCache = new JobCacheImpl(jobCacheSize, daoActor, jobContext.sparkContext, jarLoader)
         getSideJars(contextConfig).foreach { jarUri => jobContext.sparkContext.addJar(jarUri) }


### PR DESCRIPTION
**Current behavior :**
PR #830 works fine with spark < 2.0 and `SparkListener` as a trait.
Spark 2.0 changed trait into an abstract class: https://github.com/apache/spark/commit/7143904700435265975d36f073cce2833467e121
This breaks the spark-2.0-preview builds: https://travis-ci.org/spark-jobserver/spark-jobserver/builds/236911458#L6808

**New behavior :**
Use anonymous innerclass instead of a mixin. Should work in master branch too.

