### PR TITLE
fix(ci): Cache binary artifacts to avoid repeated downloads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,12 @@ services:
   - docker
 
 cache:
+  apt: true
   directories:
     - docker
+    - $HOME/.m2
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/scala-$TRAVIS_SCALA_VERSION
 
 before_install:
   - go get github.com/tonistiigi/buildcache/cmd/buildcache


### PR DESCRIPTION
There's an approach noted in travis-ci/travis-ci#1441 that suggests caching
various artifacts.

**Pull Request checklist**

- [X ] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?

**Current behavior :**

Every time test runs, artifacts are downloaded from internet which takes time.


**New behavior :**

Use travis cache support to store already downloaded artifacts.