### PR TITLE
misc: fix java 7 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Also see [Chinese docs / 中文](doc/chinese/job-server.md).
   - [WordCountExample walk-through](#wordcountexample-walk-through)
     - [Package Jar - Send to Server](#package-jar---send-to-server)
     - [Ad-hoc Mode - Single, Unrelated Jobs (Transient Context)](#ad-hoc-mode---single-unrelated-jobs-transient-context)
-    - [Persistent Context Mode - Faster & Required for Related Jobs](#persistent-context-mode---faster-&-required-for-related-jobs)
+    - [Persistent Context Mode - Faster & Required for Related Jobs](#persistent-context-mode---faster--required-for-related-jobs)
 - [Create a Job Server Project](#create-a-job-server-project)
   - [Creating a project from scratch using giter8 template](#creating-a-project-from-scratch-using-giter8-template)
   - [Creating a project manually assuming that you already have sbt project structure](#creating-a-project-manually-assuming-that-you-already-have-sbt-project-structure)
@@ -35,12 +35,14 @@ Also see [Chinese docs / 中文](doc/chinese/job-server.md).
   - [Authentication](#authentication)
 - [Deployment](#deployment)
   - [Manual steps](#manual-steps)
+  - [Java 7 vs. Java 8](#java-7-vs-java-8)
   - [Context per JVM](#context-per-jvm)
     - [Configuring Spark Jobserver meta data Database backend](#configuring-spark-jobserver-meta-data-database-backend)
   - [Chef](#chef)
 - [Architecture](#architecture)
 - [API](#api)
-  - [Jars](#jars)
+  - [Binaries](#binaries)
+  - [Jars (deprecated)](#jars-deprecated)
   - [Contexts](#contexts)
   - [Jobs](#jobs)
   - [Data](#data)
@@ -499,6 +501,14 @@ curl -k --basic --user 'user:pw' https://localhost:8090/contexts
 The `server_start.sh` script uses `spark-submit` under the hood and may be passed any of the standard extra arguments from `spark-submit`.
 
 NOTE: by default the assembly jar from `job-server-extras`, which includes support for SQLContext and HiveContext, is used.  If you face issues with all the extra dependencies, consider modifying the install scripts to invoke `sbt job-server/assembly` instead, which doesn't include the extra dependencies.
+
+### Java 7 vs. Java 8
+
+Add `export JAVA_VERSION=7-jdk` to `<environment>.sh` (see manual steps above) to get a java 7 compliant version.
+
+If you are not sure what java version you run on, start `spark-shell` (or `spark2-shell` depending on your distribution) on your cluster and type `System.getProperty("java.version")` into the prompt.
+
+NOTE: We highly recommend to use java 8 if possible. Running on a java 7 jvm requires outdated and unsupported dependencies (for example Akka 2.3.x).
 
 ### Context per JVM
 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -3,20 +3,22 @@ import scala.util.Properties.isJavaAtLeast
 object Versions {
   lazy val spark = sys.env.getOrElse("SPARK_VERSION", "2.1.0")
 
-  lazy val akka = "2.4.9"
+  lazy val java = sys.env.getOrElse("JAVA_VERSION", "8-jdk")
+  lazy val useJava7 = java == "7-jdk" || !isJavaAtLeast("1.8")
+
+  lazy val akka = if (useJava7) "2.3.16" else "2.4.9"
   lazy val cassandra = "3.0.3"
   lazy val cassandraUnit = "2.2.2.1"
   lazy val commons = "1.4"
   lazy val flyway = "3.2.1"
   lazy val h2 = "1.3.176"
-  lazy val java = sys.env.getOrElse("JAVA_VERSION", "8-jdk")
   lazy val jodaConvert = "1.8.1"
   lazy val jodaTime = "2.9.3"
   lazy val logback = "1.0.7"
   lazy val mesos = sys.env.getOrElse("MESOS_VERSION", "1.0.0-2.0.89.ubuntu1404")
   lazy val metrics = "2.2.0"
   lazy val netty =  "4.0.42.Final"
-  lazy val postgres = "9.4.1209"
+  lazy val postgres = if (useJava7) "9.4.1209.jre7" else "9.4.1209"
   lazy val py4j = "0.10.4"
   lazy val scalaTest = "2.2.6"
   lazy val scalatic = "2.2.6"
@@ -24,5 +26,5 @@ object Versions {
   lazy val slick = "3.1.1"
   lazy val spray = "1.3.3"
   lazy val sprayJson = "1.3.2"
-  lazy val typeSafeConfig = if (isJavaAtLeast("1.8")) "1.3.0" else "1.2.1"
+  lazy val typeSafeConfig = if (useJava7) "1.2.1" else "1.3.0"
 }


### PR DESCRIPTION
**Current behavior :** 
Dependency versions are selected by local java compiler version rather than target java version.

**New behavior :**
* Use `JAVA_VERSION` environment variable and java compiler version to decide what dependency version are chosen (java 7 or 8 compatible). Can be used in build config via `export JAVA_VERSION=7-jdk` in `config/....sh`.
* Downgrade/change akka and postgres versions in java 7 builds.

**Other information**:
Latest CDH 5.10 sandbox has java 7 installed...