### PR TITLE
Remove `spark-jobserver.pid` if such process does not exist

### DIFF
--- a/bin/server_stop.sh
+++ b/bin/server_stop.sh
@@ -18,15 +18,17 @@ else
 fi
 
 pidFilePath=$appdir/$PIDFILE
+PID="$(cat "$pidFilePath")"
 
 if [ ! -f "$pidFilePath" ] || ! kill -0 "$(cat "$pidFilePath")"; then
    echo 'Job server not running'
 else
   echo 'Stopping job server...'
-  PID="$(cat "$pidFilePath")"
   "$(dirname "$0")"/kill-process-tree.sh 15 $PID && rm "$pidFilePath"
   echo '...job server stopped'
 fi
 
-
-
+if [ -f "$pidFilePath" ]; then
+  echo "Removing PID file, cause there is not such process ${PID}."
+  rm "$pidFilePath"
+fi


### PR DESCRIPTION
When `bin/server-stop.sh` is executed but not corresponding PID exists,
the dead PID file exists forever, and that blocks all next `server-stop.sh`
executions from successfully terminating the SJS process.

This commit fix the issue by removing the PID file in case such a PID file
remains after the SJS termination attempt.

**Pull Request checklist**

- [X ] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [No ] Tests for the changes have been added (for bug fixes / features) ?
- [No ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Mentioned in the commit message


**New behavior :**

Mentioned in the commit message