### PR TITLE
fix(bin): make sure that PID is valid and process ended by server_stop.sh

### DIFF
--- a/bin/server_stop.sh
+++ b/bin/server_stop.sh
@@ -19,14 +19,22 @@ fi
 
 pidFilePath=$appdir/$PIDFILE
 
-if [ ! -f "$pidFilePath" ] || ! kill -0 "$(cat "$pidFilePath")"; then
-   echo 'Job server not running'
+if [ ! -f "$pidFilePath" ]; then
+  echo 'Job server not running'
 else
-  echo 'Stopping job server...'
   PID="$(cat "$pidFilePath")"
-  "$(dirname "$0")"/kill-process-tree.sh 15 $PID && rm "$pidFilePath"
-  echo '...job server stopped'
+  if ! kill -0 $PID; then
+    echo "PID file exists but the process $PID does not exist. Removing $pidFilePath"
+    rm "$pidFilePath"
+  else
+    echo 'Stopping job server...'
+    "$(dirname "$0")"/kill-process-tree.sh 15 $PID
+    if ! kill -0 $PID 2> /dev/null ; then
+      echo '...job server stopped'
+      rm "$pidFilePath"
+    else
+      echo '...?? job server is still running'
+    fi
+  fi
 fi
-
-
 


### PR DESCRIPTION
Issues:
- When `bin/server-stop.sh` is executed but no corresponding PID exists,
  the dead PID file will live forever, and that blocks all next
  `server-stop.sh` executions from successfully terminating the SJS process.
- Currently, there is no check of process termination after
  `kill-process-tree.sh` execution.

Fixes:
- Remove the PID file in case the mentioned process does not exist.
- Make sure that the process terminated after `kill-process-tree.sh`.

**Pull Request checklist**

- [X ] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [No ] Tests for the changes have been added (for bug fixes / features) ?
- [No ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
- When `bin/server-stop.sh` is executed but no corresponding PID exists,
  the dead PID file will live forever, and that blocks all next
  `server-stop.sh` executions from successfully terminating the SJS process.
- Currently, there is no check of process termination after
  `kill-process-tree.sh` execution.

**New behavior :**
- Remove the PID file in case the mentioned process does not exist.
- Make sure that the process terminated after `kill-process-tree.sh`.



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**: