### PR TITLE
feat(webapi): add route for getting context info

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Let's try running our sample job with an invalid configuration:
 
 ### NEW SparkJob API with Spark v2.1
 
-Deploying Spark JobServer with Spark v2.x cluster, you can create a SparkSession context which enables Spark-SQL and Hive support 
+Deploying Spark JobServer with Spark v2.x cluster, you can create a SparkSession context which enables Spark-SQL and Hive support
 ```scala
 curl -i -d "" 'http://localhost:8090/contexts/sql-context-1?num-cpu-cores=2&memory-per-node=512M&context-factory=spark.jobserver.context.SessionContextFactory'
 ```
@@ -777,6 +777,7 @@ These routes are kept for legacy purposes but are deprecated in favour of the /b
 ### Contexts
 
     GET /contexts               - lists all current contexts
+    GET /contexts/<name>        - gets info about a context, such as the spark UI url
     POST /contexts/<name>       - creates a new context
     DELETE /contexts/<name>     - stops a context and all jobs running in it
     PUT /contexts?reset=reboot  - shuts down all contexts and re-loads only the contexts from config. Use ?sync=false to execute asynchronously.
@@ -928,17 +929,17 @@ If we encounter a data type that is not supported, then the entire result will b
 
 ### HTTP Override
 
-Spark Job Server offers HTTP override functionality. 
+Spark Job Server offers HTTP override functionality.
 Often reverse proxies and firewall implement access limitations to, for example, DELETE and PUT requests.
 HTTP override allows overcoming these limitations by wrapping, for example, a DELETE request into a POST request.
 
-Requesting the destruction of a context can be accomplished through HTTP override using the following syntax: 
-    
+Requesting the destruction of a context can be accomplished through HTTP override using the following syntax:
+
     $ curl -X POST "localhost:8090/contexts/test_context?_method=DELETE"
 
 Here, a DELETE request is passed to Spark Job Server "through" a POST request.
-    
-    
+
+
 ## Clients
 
 Spark Jobserver project has a

--- a/job-server/src/main/scala/spark/jobserver/WebApi.scala
+++ b/job-server/src/main/scala/spark/jobserver/WebApi.scala
@@ -331,6 +331,7 @@ class WebApi(system: ActorSystem,
   /**
    * Routes for listing, adding, and stopping contexts
    *     GET /contexts         - lists all current contexts
+   *     GET /contexts/<contextName> - returns some info about the context (such as spark UI url)
    *     POST /contexts/<contextName> - creates a new context
    *     DELETE /contexts/<contextName> - stops a context and all jobs running in it
    */
@@ -339,6 +340,20 @@ class WebApi(system: ActorSystem,
 
     // user authentication
     authenticate(authenticator) { authInfo =>
+      (get & path(Segment)) { (contextName) =>
+        respondWithMediaType(MediaTypes.`application/json`) { ctx =>
+          val future = supervisor ? GetSparkWebUI(contextName)
+          future.map {
+            case WebUIForContext(name, Some(url)) =>
+              ctx.complete(200, Map("context" -> contextName, "url" -> url))
+            case WebUIForContext(name, None) => ctx.complete(200, Map("context" -> contextName))
+            case NoSuchContext => ctx.complete(404, s"can't find context with name $contextName")
+
+          }.recover {
+            case e: Exception => ctx.complete(500, errMap(e, "ERROR"))
+          }
+        }
+      } ~
       get { ctx =>
         (supervisor ? ListContexts).mapTo[Seq[String]]
           .map { contexts =>
@@ -428,10 +443,10 @@ class WebApi(system: ActorSystem,
                     ctx.complete(StatusCodes.OK, successMap("Context reset"))
                   }
                 case _ => ctx.complete("ERROR")
-              }
             }
           }
         }
+      }
     }
   }
 

--- a/job-server/src/test/scala/spark/jobserver/WebApiMainRoutesSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiMainRoutesSpec.scala
@@ -496,6 +496,19 @@ class WebApiMainRoutesSpec extends WebApiSpec {
         status should be (OK)
       }
     }
+
+    it("should return the sparkWebUi url if we get a context/id") {
+      Get("/contexts/context1") ~> sealRoute(routes) ~> check {
+        status should be (OK)
+        responseAs[Map[String, String]] should be (Map("context" -> "context1", "url" -> "http://spark:4040"))
+      }
+    }
+    it("should return the context name if even no URL can be found") {
+      Get("/contexts/context2") ~> sealRoute(routes) ~> check {
+        status should be (OK)
+        responseAs[Map[String, String]] should be (Map("context" -> "context2"))
+      }
+    }
   }
 }
 

--- a/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
@@ -121,6 +121,7 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
       }
 
 
+
       case ListBinaries(Some(BinaryType.Jar)) =>
         sender ! Map("demo1" -> (BinaryType.Jar, dt), "demo2" -> (BinaryType.Jar, dt.plusHours(1)))
 
@@ -196,6 +197,9 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
 
       case StoreJobConfig(_, _) => sender ! JobConfigStored
       case KillJob(jobId) => sender ! JobKilled(jobId, DateTime.now())
+
+      case GetSparkWebUI("context1") => sender ! WebUIForContext("context1", Some("http://spark:4040"))
+      case GetSparkWebUI("context2") => sender ! WebUIForContext("context1", None)
     }
   }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Currently, you can't easily get the URL of the web API or other info about a context
**New behavior :**

This adds a route to retrieve information about a context, `GET /contexts/<name>` which returns some info. At the moment, this is primarily just the spark web UI url

**BREAKING CHANGES**

No breaking changes
**Other information**: