### PR TITLE
fix(job-server): Fix for issue #786 - Concurrent access to the jars w…

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/io/FileCacher.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/FileCacher.scala
@@ -27,20 +27,41 @@ trait FileCacher {
     appName + "-" + uploadTime.toString("yyyyMMdd_hhmmss_SSS") + s".${binaryType.extension}"
   }
 
+  // Random temporary filename suffix possible chars
+  val tempFileNamePossibleChars: Seq[Char] = ('a' to 'z') ++ ('0' to '9')
+  // Generate random temporary filename suffix
+  def randomTempFileNameSuffix(length: Int = 8): String = {
+    import scala.util.Random
+    (1 to length).map(_ => tempFileNamePossibleChars(Random.nextInt(tempFileNamePossibleChars.size)))
+      .mkString("_tmp-", "", "")
+  }
+
   // Cache the jar file into local file system.
   protected def cacheBinary(appName: String,
-                          binaryType: BinaryType,
-                          uploadTime: DateTime,
-                          binBytes: Array[Byte]) {
-    val outFile =
-      new File(rootDir, createBinaryName(appName, binaryType, uploadTime))
-    val bos = new BufferedOutputStream(new FileOutputStream(outFile))
+                            binaryType: BinaryType,
+                            uploadTime: DateTime,
+                            binBytes: Array[Byte]) {
+    val targetFullBinaryName = createBinaryName(appName, binaryType, uploadTime)
+    val tempSuffix = randomTempFileNameSuffix()
+    val tempBinaryName = targetFullBinaryName + tempSuffix
+    val tempOutFile = new File(rootDir, tempBinaryName)
+    val bos = new BufferedOutputStream(new FileOutputStream(tempOutFile))
+
     try {
-      logger.debug("Writing {} bytes to file {}", binBytes.length, outFile.getPath)
+      logger.debug("Writing {} bytes to a temporary file {}", binBytes.length, tempOutFile.getPath)
       bos.write(binBytes)
       bos.flush()
     } finally {
       bos.close()
+    }
+
+    logger.debug("Renaming the temporary file {} to the target full binary name {}", tempBinaryName, targetFullBinaryName:Any)
+    val tempFile = new File(rootDir, tempBinaryName)
+    if( ! tempFile.renameTo(new File(rootDir, targetFullBinaryName))) {
+      logger.debug("Renaming the temporary file {} failed, another process has probably already updated the target file - deleting the redundant temp file")
+      if( ! tempFile.delete()) {
+        logger.warn("Could not delete the temporary file {}", tempBinaryName)
+      }
     }
   }
 

--- a/job-server/src/main/scala/spark/jobserver/io/FileCacher.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/FileCacher.scala
@@ -55,10 +55,13 @@ trait FileCacher {
       bos.close()
     }
 
-    logger.debug("Renaming the temporary file {} to the target full binary name {}", tempBinaryName, targetFullBinaryName:Any)
+    logger.debug("Renaming the temporary file {} to the target full binary name {}",
+      tempBinaryName, targetFullBinaryName: Any)
+
     val tempFile = new File(rootDir, tempBinaryName)
     if( ! tempFile.renameTo(new File(rootDir, targetFullBinaryName))) {
-      logger.debug("Renaming the temporary file {} failed, another process has probably already updated the target file - deleting the redundant temp file")
+      logger.debug("Renaming the temporary file {} failed, another process has probably already updated " +
+        "the target file - deleting the redundant temp file", tempBinaryName)
       if( ! tempFile.delete()) {
         logger.warn("Could not delete the temporary file {}", tempBinaryName)
       }


### PR DESCRIPTION
…hen cashing on the file system resulting in ClassNotFoundError

* Modify/extend the FileCacher.cacheBinary(...) method to store the JAR/binary data into a temporary file first, and only after this completes, try to rename it to the expected full original name (with a new timestamp and so on). If the rename succeeds - everything is fine. If the rename fails (ex. there is already a file with the same target full filename), then it means that the other process was faster than us, and we're OK with this (but we have to delete our temporary file, its not needed anymore).

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?

**Current behavior :**
Main issue: #786 

**New behavior :**
As described in the commit message (see above)

**BREAKING CHANGES**
None

**Other information**:
None