### PR TITLE
Blob storage

### DIFF
--- a/job-server/src/main/scala/db/h2/migration/V0_7_3/V0_7_3__Migrate_Blobs.scala
+++ b/job-server/src/main/scala/db/h2/migration/V0_7_3/V0_7_3__Migrate_Blobs.scala
@@ -1,0 +1,61 @@
+package db.h2.migration.V0_7_3
+
+import java.sql.Connection
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.TimeoutException
+import scala.concurrent.duration.DurationInt
+
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration
+import org.slf4j.LoggerFactory
+
+import javax.sql.rowset.serial.SerialBlob
+import slick.dbio.DBIO
+import slick.driver.H2Driver.api.actionBasedSQLInterpolation
+import slick.jdbc.GetResult
+import slick.jdbc.PositionedParameters
+import slick.jdbc.SetParameter
+import spark.jobserver.slick.unmanaged.UnmanagedDatabase
+
+class V0_7_3__Migrate_Blobs extends JdbcMigration {
+  private val Timeout = 10 minutes
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private case class BinArray(id: Int, binary: Array[Byte])
+
+  private def logErrors = PartialFunction[Throwable, Unit] {
+    case e: Throwable => logger.error(e.getMessage, e)
+  }
+
+  private def insertBlob(db: UnmanagedDatabase, b: BinArray): Unit = {
+    implicit object SetSerialBlob extends SetParameter[SerialBlob] {
+      def apply(v: SerialBlob, pp: PositionedParameters) {
+        pp.setBlob(v)
+      }
+    }
+    val blob = new SerialBlob(b.binary)
+    val updateBlob = sqlu"""UPDATE BINARIES SET BINARY=${blob} WHERE BIN_ID=${b.id}"""
+    Await.ready(db.run(updateBlob).recover{logErrors}, Timeout)
+  }
+
+  def migrate(c: Connection): Unit = {
+    val renameBinaryToBinArray = sqlu"""ALTER TABLE BINARIES ALTER COLUMN BINARY RENAME TO BINARRAY"""
+    val addBlobColumn = sqlu"""ALTER TABLE BINARIES ADD COLUMN BINARY BLOB"""
+    val dropBinArray = sqlu"""ALTER TABLE BINARIES DROP COLUMN BINARRAY"""
+    implicit val getBinArrayResult = GetResult[BinArray](r => BinArray(r.nextInt(), r.nextBytes()))
+    val getBinArrays = sql"""SELECT BIN_ID, BINARRAY FROM BINARIES""".as[BinArray]
+
+    val db = new UnmanagedDatabase(c)
+    c.setAutoCommit(false)
+    Await.ready(
+        for {
+          _ <- db.run(renameBinaryToBinArray)
+          _ <- db.run(addBlobColumn)
+          _ <- db.stream(getBinArrays).foreach(b => insertBlob(db, b))
+          _ <- db.run(dropBinArray)
+        } yield Unit, Timeout
+    ).recover{logErrors}
+    c.commit()
+  }
+}

--- a/job-server/src/main/scala/db/postgresql/migration/V0_7_3/V0_7_3__Migrate_Blobs.scala
+++ b/job-server/src/main/scala/db/postgresql/migration/V0_7_3/V0_7_3__Migrate_Blobs.scala
@@ -1,0 +1,64 @@
+package db.postgresql.migration.V0_7_3
+
+import java.sql.Connection
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.TimeoutException
+import scala.concurrent.duration.DurationInt
+
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration
+import org.slf4j.LoggerFactory
+
+import javax.sql.rowset.serial.SerialBlob
+import slick.dbio.DBIO
+import slick.driver.PostgresDriver.api.actionBasedSQLInterpolation
+import slick.jdbc.GetResult
+import slick.jdbc.PositionedParameters
+import slick.jdbc.SetParameter
+import spark.jobserver.slick.unmanaged.UnmanagedDatabase
+
+class V0_7_3__Migrate_Blobs extends JdbcMigration {
+  private val Timeout = 10 minutes
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private case class BinArray(id: Int, binary: Array[Byte])
+
+  private def logErrors = PartialFunction[Throwable, Unit] {
+    case e: Throwable => logger.error(e.getMessage, e)
+  }
+
+  private def insertBlob(db: UnmanagedDatabase, b: BinArray): Unit = {
+    implicit object SetSerialBlob extends SetParameter[SerialBlob] {
+      def apply(v: SerialBlob, pp: PositionedParameters) {
+        pp.setBlob(v)
+      }
+    }
+    val blob = new SerialBlob(b.binary)
+    val updateBlob = sqlu"""UPDATE "BINARIES" SET "BINARY"=${blob} WHERE "BIN_ID"=${b.id}"""
+    Await.ready(db.run(updateBlob).recover{logErrors}, Timeout)
+  }
+
+  def migrate(c: Connection): Unit = {
+    val renameBinaryToBinArray = sqlu"""ALTER TABLE "BINARIES" RENAME COLUMN "BINARY" TO "BINARRAY""""
+    val addBlobColumn = sqlu"""ALTER TABLE "BINARIES" ADD COLUMN "BINARY" OID"""
+    val cleanupTrigger = sqlu"""CREATE TRIGGER t_binary BEFORE UPDATE OR DELETE ON "BINARIES"
+                        FOR EACH ROW EXECUTE PROCEDURE lo_manage("BINARY")"""
+    val dropBinArray = sqlu"""ALTER TABLE "BINARIES" DROP COLUMN "BINARRAY""""
+    implicit val getBinArrayResult = GetResult[BinArray](r => BinArray(r.nextInt(), r.nextBytes()))
+    val getBinArrays = sql"""SELECT "BIN_ID", "BINARRAY" FROM "BINARIES"""".as[BinArray]
+
+    val db = new UnmanagedDatabase(c)
+    c.setAutoCommit(false);
+    Await.ready(
+        for {
+          _ <- db.run(renameBinaryToBinArray)
+          _ <- db.run(addBlobColumn)
+          _ <- db.run(cleanupTrigger)
+          _ <- db.stream(getBinArrays).foreach(b => insertBlob(db, b))
+          _ <- db.run(dropBinArray)
+        } yield Unit, Timeout
+    ).recover{logErrors}
+    c.commit()
+  }
+}

--- a/job-server/src/main/scala/spark/jobserver/slick/unmanaged/UnmanagedDatabase.scala
+++ b/job-server/src/main/scala/spark/jobserver/slick/unmanaged/UnmanagedDatabase.scala
@@ -1,0 +1,29 @@
+package spark.jobserver.slick.unmanaged
+
+import java.sql.Connection
+
+import slick.jdbc.JdbcBackend
+import slick.jdbc.JdbcBackend.BaseSession
+import slick.jdbc.JdbcBackend.DatabaseDef
+import slick.jdbc.JdbcDataSource
+import slick.util.AsyncExecutor
+
+class UnmanagedDataSource(conn: Connection) extends JdbcDataSource {
+  def createConnection(): Connection = conn
+  def close(): Unit = ()
+}
+
+class UnmanagedSession(database: DatabaseDef) extends BaseSession(database) {
+  override def close(): Unit = ()
+}
+
+/**
+ * Slick database wrapper for a JDBC connection
+ *
+ * @param conn the JDBC connection to wrap
+ * @return database wrapper
+ */
+class UnmanagedDatabase(conn: Connection) extends JdbcBackend.DatabaseDef(
+    new UnmanagedDataSource(conn), AsyncExecutor("UmanagedDatabase-Executor", 1, -1)) {
+  override def createSession(): JdbcBackend.Session = new UnmanagedSession(this)
+}

--- a/job-server/src/test/scala/spark/jobserver/io/FlywayMigrationSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/FlywayMigrationSpec.scala
@@ -78,7 +78,7 @@ class FlywayMigrationSpec extends FunSpec with Matchers {
       val descBinariesIt = ResultSetIterator(descBinaries){ r: ResultSet =>
         r.getString("FIELD")
       }
-      descBinariesIt.toList should be (List("BIN_ID", "APP_NAME", "UPLOAD_TIME", "BINARY", "BINARY_TYPE"))
+      descBinariesIt.toList should be (List("BIN_ID", "APP_NAME", "UPLOAD_TIME", "BINARY_TYPE", "BINARY"))
       val descJobs = sqlConn.createStatement().executeQuery("SHOW COLUMNS FROM JOBS")
       val descJobsIt = ResultSetIterator(descJobs){ r: ResultSet =>
         r.getString("FIELD")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -51,6 +51,7 @@ object Dependencies {
     "com.typesafe.slick" %% "slick" % slick,
     "com.h2database" % "h2" % h2,
     "org.postgresql" % "postgresql" % postgres,
+    "mysql" % "mysql-connector-java" % mysql,
     "commons-dbcp" % "commons-dbcp" % commons,
     "org.flywaydb" % "flyway-core" % flyway
   )

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -17,6 +17,7 @@ object Versions {
   lazy val metrics = "2.2.0"
   lazy val netty = "4.0.42.Final"
   lazy val postgres = "9.4.1209"
+  lazy val mysql = "5.1.42"
   lazy val py4j = "0.10.4"
   lazy val scalaTest = "2.2.6"
   lazy val scalatic = "2.2.6"


### PR DESCRIPTION
**Pull Request checklist**

- [x ] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [x ] Tests for the changes have been added (for bug fixes / features) ?
existing tests have good test coverage for the new code
- [x ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (existing issues : #876)

On H2 and Postgresql BYTEA column type is used to store binaries via byte array in Scala code

**New behavior :**

Use column type BLOB on H2 and OID on Postgresql to store binaries using the large object type supported by the respective database platform. Use JDBC BLOB API for managing large object content.
In the Scala code binaries are still passed as byte arrays. This should be improved in a future change to use streaming in order to reduce memory consumption.

Data is migrated to the new column type if necessary (on H2 and Postgresql).

**Other information**: