### PR TITLE
fix(job-server) clean running jobs after context JobManager dies

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
@@ -28,6 +28,8 @@ object JobManagerActor {
                       subscribedEvents: Set[Class[_]])
   case class KillJob(jobId: String)
   case class JobKilledException(jobId: String) extends Exception(s"Job $jobId killed")
+  case class ContextTerminatedException(contextName: String)
+    extends Exception(s"Unexpected termination of context $contextName")
 
   case object GetContextConfig
   case object SparkContextStatus

--- a/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
@@ -8,12 +8,14 @@ import com.typesafe.config.ConfigFactory
 import spark.jobserver.JobManagerActor.{GetSparkWebUIUrl, NoSparkWebUI, SparkWebUIUrl}
 import spark.jobserver.JobManagerActor.{SparkContextAlive, SparkContextDead, SparkContextStatus}
 import spark.jobserver.util.SparkJobUtils
+
 import scala.collection.mutable
 import scala.concurrent.Await
 import scala.util.{Failure, Success, Try}
-
 import spark.jobserver.common.akka.InstrumentedActor
 import akka.pattern.gracefulStop
+import org.joda.time.DateTime
+import spark.jobserver.io.JobDAOActor.CleanContextJobInfos
 
 /** Messages common to all ContextSupervisors */
 object ContextSupervisor {
@@ -182,6 +184,7 @@ class LocalContextSupervisorActor(dao: ActorRef) extends InstrumentedActor {
       val name = actorRef.path.name
       logger.info("Actor terminated: " + name)
       contexts.remove(name)
+      dao ! CleanContextJobInfos(name, DateTime.now())
   }
 
   private def startContext(name: String, contextConfig: Config, isAdHoc: Boolean, timeoutSecs: Int = 1)

--- a/job-server/src/main/scala/spark/jobserver/io/JobCassandraDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobCassandraDAO.scala
@@ -6,7 +6,7 @@ import java.nio.ByteBuffer
 import java.nio.file.{Files, Paths}
 import java.util.UUID
 
-import com.datastax.driver.core.querybuilder.{QueryBuilder => QB}
+import com.datastax.driver.core.querybuilder.{Insert, QueryBuilder => QB}
 import com.datastax.driver.core.querybuilder.QueryBuilder._
 import com.datastax.driver.core._
 import com.datastax.driver.core.schemabuilder.SchemaBuilder.Direction
@@ -35,6 +35,7 @@ object Metadata {
 
   val JobsTable = "jobs"
   val JobsChronologicalTable = "jobs_chronological"
+  val RunningJobsTable = "jobs_running"
   val JobId = "job_id"
   val ContextName = "context_name"
   val JobConfig = "job_config"
@@ -163,24 +164,7 @@ class JobCassandraDAO(config: Config) extends JobDAO with FileCacher {
     ).from(JobsChronologicalTable).where(QB.eq(StartDate, today())).limit(limit)
 
     session.executeAsync(query).map { rs =>
-      val allJobs = JListWrapper(rs.all()).map { row =>
-        val endTime = row.getTimestamp(EndTime)
-        val error = row.getString(Error)
-
-        JobInfo(
-          row.getUUID(JobId).toString,
-          row.getString(ContextName),
-          BinaryInfo(
-            row.getString(AppName),
-            BinaryType.fromString(row.getString(BType)),
-            new DateTime(row.getTimestamp(UploadTime))
-          ),
-          row.getString(Classpath),
-          new DateTime(row.getTimestamp(StartTime)),
-          if (endTime != null) Option(new DateTime(endTime)) else None,
-          if (error != null) Option(new Throwable(error)) else None
-        )
-      }
+      val allJobs = JListWrapper(rs.all()).map(rowToJobInfo)
       status match {
         // !endTime.isDefined
         case Some(JobStatus.Running) => allJobs.filter(j => j.endTime.isEmpty && j.error.isEmpty)
@@ -190,6 +174,17 @@ class JobCassandraDAO(config: Config) extends JobDAO with FileCacher {
         case Some(JobStatus.Finished) => allJobs.filter(j => j.endTime.isDefined && j.error.isEmpty)
         case _ => allJobs
       }
+    }
+  }
+
+  override def getRunningJobInfosForContextName(contextName: String): Future[Seq[JobInfo]] = {
+    import Metadata._
+    val query = QB.select(
+      JobId, ContextName, AppName, BType, UploadTime, Classpath, StartTime, EndTime, Error
+    ).from(RunningJobsTable).where(QB.eq(ContextName, contextName))
+
+    session.executeAsync(query).map { rs =>
+      JListWrapper(rs.all()).map(rowToJobInfo)
     }
   }
 
@@ -226,6 +221,22 @@ class JobCassandraDAO(config: Config) extends JobDAO with FileCacher {
     tuples.map(_._2).foldLeft(Array[Byte]()) { _ ++ _ }
   }
 
+  private def rowToJobInfo(row: Row): JobInfo = {
+    JobInfo(
+      row.getUUID(Metadata.JobId).toString,
+      row.getString(ContextName),
+      BinaryInfo(
+        row.getString(AppName),
+        BinaryType.fromString(row.getString(BType)),
+        new DateTime(row.getTimestamp(UploadTime))
+      ),
+      row.getString(Classpath),
+      new DateTime(row.getTimestamp(StartTime)),
+      Option(row.getTimestamp(EndTime)).map(new DateTime(_)),
+      Option(row.getString(Error)).map(new Throwable(_))
+    )
+  }
+
   override def getJobInfo(jobId: String): Future[Option[JobInfo]] = {
     val query = QB.select(
       JobId, ContextName, AppName, BType, UploadTime, Classpath, StartTime, EndTime, Error
@@ -235,20 +246,7 @@ class JobCassandraDAO(config: Config) extends JobDAO with FileCacher {
 
     session.executeAsync(query).map { rs =>
       val row = rs.one()
-      Option(row).map(r =>
-        JobInfo(
-          r.getUUID(Metadata.JobId).toString,
-          r.getString(ContextName),
-          BinaryInfo(
-            r.getString(AppName),
-            BinaryType.fromString(r.getString(BType)),
-            new DateTime(r.getTimestamp(UploadTime))
-          ),
-          r.getString(Classpath),
-          new DateTime(r.getTimestamp(StartTime)),
-          Option(r.getTimestamp(EndTime)).map(new DateTime(_)),
-          Option(r.getString(Error)).map(new Throwable(_))
-        ))
+      Option(row).map(rowToJobInfo)
     }
   }
 
@@ -260,33 +258,32 @@ class JobCassandraDAO(config: Config) extends JobDAO with FileCacher {
 
     val localDate: LocalDate = LocalDate.fromMillisSinceEpoch(jobInfo.startTime.getMillis)
 
-    val insert = insertInto(JobsTable).
-      value(JobId, UUID.fromString(jobId)).
-      value(ContextName, contextName).
-      value(AppName, binaryInfo.appName).
-      value(BType, binaryInfo.binaryType.name).
-      value(UploadTime, binaryInfo.uploadTime.getMillis).
-      value(Classpath, classPath).
-      value(StartTime, startTime.getMillis).
-      value(StartDate, localDate)
+    def fillInsert(insert: Insert): Insert = {
+      insert.
+        value(JobId, UUID.fromString(jobId)).
+        value(ContextName, contextName).
+        value(AppName, binaryInfo.appName).
+        value(BType, binaryInfo.binaryType.name).
+        value(UploadTime, binaryInfo.uploadTime.getMillis).
+        value(Classpath, classPath).
+        value(StartTime, startTime.getMillis).
+        value(StartDate, localDate)
+      endOpt.foreach{e => insert.value(EndTime, e.getMillis)}
+      errOpt.foreach(insert.value(Error, _))
+      insert
+    }
 
-    endOpt.foreach{e => insert.value(EndTime, e.getMillis)}
-    errOpt.foreach(insert.value(Error, _))
-    session.execute(insert)
+    session.execute(fillInsert(insertInto(JobsTable)))
+    session.execute(fillInsert(insertInto(JobsChronologicalTable)))
 
-    val insert2 = insertInto(JobsChronologicalTable).
-      value(StartDate, localDate).
-      value(StartTime, startTime.getMillis).
-      value(JobId, UUID.fromString(jobId)).
-      value(ContextName, contextName).
-      value(AppName, binaryInfo.appName).
-      value(BType, binaryInfo.binaryType.name).
-      value(UploadTime, binaryInfo.uploadTime.getMillis).
-      value(Classpath, classPath)
-
-    endOpt.foreach{e => insert2.value(EndTime, e.getMillis)}
-    errOpt.foreach(insert2.value(Error, _))
-    session.execute(insert2)
+    if (!endTime.isDefined && !error.isDefined) {
+      session.execute(fillInsert(insertInto(RunningJobsTable)))
+    } else {
+      val deleteQuery = delete().from(RunningJobsTable)
+        .where(QB.eq(ContextName, contextName))
+        .and(QB.eq(JobId, UUID.fromString(jobId)))
+      session.execute(deleteQuery)
+    }
   }
 
   override def getJobConfigs: Future[Map[String, Config]] = {
@@ -388,6 +385,20 @@ class JobCassandraDAO(config: Config) extends JobDAO with FileCacher {
 
     session.execute(jobsChronologicalView)
 
+    val runningJobsView = SchemaBuilder.createTable(RunningJobsTable).ifNotExists().
+      addPartitionKey(ContextName, DataType.text).
+      addClusteringColumn(JobId, DataType.uuid).
+      addColumn(AppName, DataType.text).
+      addColumn(BType, DataType.text).
+      addColumn(UploadTime, DataType.timestamp).
+      addColumn(JobConfig, DataType.text).
+      addColumn(Classpath, DataType.text).
+      addColumn(StartTime, DataType.timestamp).
+      addColumn(StartDate, DataType.date).
+      addColumn(EndTime, DataType.timestamp).
+      addColumn(Error, DataType.text)
+
+    session.execute(runningJobsView)
   }
 
   override def getBinaryContent(appName: String, binaryType: BinaryType,

--- a/job-server/src/main/scala/spark/jobserver/io/JobDAOActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobDAOActor.scala
@@ -3,10 +3,13 @@ package spark.jobserver.io
 import akka.actor.Props
 import com.typesafe.config.Config
 import org.joda.time.DateTime
-import scala.concurrent.duration._
-import scala.util.Try
+import spark.jobserver.JobManagerActor.JobKilledException
 
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
 import spark.jobserver.common.akka.InstrumentedActor
+
+import scala.concurrent.Future
 
 object JobDAOActor {
 
@@ -36,6 +39,7 @@ object JobDAOActor {
   @deprecated("Leads to performance problems and OutOfMemory error ultimately", "0.7.1")
   case object GetJobConfigs extends JobDAORequest
   case class GetJobConfig(jobId: String) extends JobDAORequest
+  case class CleanContextJobInfos(contextName: String, endTime: DateTime)
 
   case class GetLastUploadTimeAndType(appName: String) extends JobDAORequest
 
@@ -96,5 +100,8 @@ class JobDAOActor(dao: JobDAO) extends InstrumentedActor {
 
     case GetBinaryContent(appName, binaryType, uploadTime) =>
       sender() ! BinaryContent(dao.getBinaryContent(appName, binaryType, uploadTime))
+
+    case CleanContextJobInfos(contextName, endTime) =>
+      dao.cleanRunningJobInfosForContext(contextName, endTime)
   }
 }

--- a/job-server/src/main/scala/spark/jobserver/io/JobFileDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobFileDAO.scala
@@ -208,6 +208,10 @@ class JobFileDAO(config: Config) extends JobDAO {
     filterJobs.take(limit)
   }
 
+  override def getRunningJobInfosForContextName(contextName: String): Future[Seq[JobInfo]] = Future {
+    jobs.values.toSeq.filter(j => j.endTime.isEmpty && j.error.isEmpty && j.contextName == contextName)
+  }
+
   override def saveJobConfig(jobId: String, jobConfig: Config) {
     writeJobConfig(jobConfigsOutputStream, jobId, jobConfig)
     configs(jobId) = jobConfig

--- a/job-server/src/main/scala/spark/jobserver/io/JobSqlDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobSqlDAO.scala
@@ -25,6 +25,7 @@ import javax.sql.DataSource
 import javax.sql.rowset.serial.SerialBlob
 import slick.driver.JdbcProfile
 import slick.lifted.ProvenShape.proveShapeOf
+import spark.jobserver.JobManagerActor.ContextTerminatedException
 
 class JobSqlDAO(config: Config) extends JobDAO with FileCacher {
   val slickDriverClass = config.getString("spark.jobserver.sqldao.slick-driver")
@@ -266,6 +267,21 @@ class JobSqlDAO(config: Config) extends JobDAO with FileCacher {
     }
   }
 
+  private def jobInfoFromRow(row: (String, String, String, String,
+    Timestamp, String, Timestamp,
+    Option[Timestamp], Option[String])): JobInfo = row match {
+    case (id, context, app, binType, upload, classpath, start, end, err) =>
+    JobInfo(
+      id,
+      context,
+      BinaryInfo(app, BinaryType.fromString(binType), convertDateSqlToJoda(upload)),
+      classpath,
+      convertDateSqlToJoda(start),
+      end.map(convertDateSqlToJoda),
+      err.map(new Throwable(_))
+    )
+  }
+
   override def getJobInfos(limit: Int, statusOpt: Option[String] = None): Future[Seq[JobInfo]] = {
 
     val joinQuery = for {
@@ -298,6 +314,37 @@ class JobSqlDAO(config: Config) extends JobDAO with FileCacher {
           err.map(new Throwable(_)))
       }
     }
+  }
+
+  /**
+    * Return all job ids to their job info.
+    *
+    * @return
+    */
+  override def getRunningJobInfosForContextName(contextName: String): Future[Seq[JobInfo]] = {
+    val joinQuery = for {
+      bin <- binaries
+      j <- jobs if (j.binId === bin.binId
+        && !j.endTime.isDefined && !j.error.isDefined
+        && j.contextName === contextName)
+    } yield {
+      (j.jobId, j.contextName, bin.appName, bin.binaryType,
+        bin.uploadTime, j.classPath, j.startTime, j.endTime, j.error)
+    }
+    db.run(joinQuery.result).map(_.map(jobInfoFromRow))
+  }
+
+
+  override def cleanRunningJobInfosForContext(contextName: String, endTime: DateTime): Future[Unit] = {
+    val sqlEndTime = Some(convertDateJodaToSql(endTime))
+    val error = Some(new ContextTerminatedException(contextName).getMessage())
+    val selectQuery = for {
+      j <- jobs if (!j.endTime.isDefined
+        && !j.error.isDefined
+        && j.contextName === contextName)
+    } yield (j.endTime, j.error)
+    val updateQuery = selectQuery.update((sqlEndTime, error))
+    db.run(updateQuery).map(_ => ())
   }
 
   override def getJobInfo(jobId: String): Future[Option[JobInfo]] = {

--- a/job-server/src/test/scala/spark/jobserver/InMemoryDAO.scala
+++ b/job-server/src/test/scala/spark/jobserver/InMemoryDAO.scala
@@ -65,6 +65,10 @@ class InMemoryDAO extends JobDAO {
     filterJobs.take(limit)
   }
 
+  override def getRunningJobInfosForContextName(contextName: String): Future[Seq[JobInfo]] = Future {
+    jobInfos.values.toSeq.filter(j => j.endTime.isEmpty && j.error.isEmpty && j.contextName == contextName)
+  }
+
   override def getJobInfo(jobId: String): Future[Option[JobInfo]] = Future {
     jobInfos.get(jobId)
   }

--- a/job-server/src/test/scala/spark/jobserver/LocalContextSupervisorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/LocalContextSupervisorSpec.scala
@@ -1,15 +1,15 @@
 package spark.jobserver
 
 import akka.actor._
-import akka.testkit.{ImplicitSender, TestKit}
-import com.typesafe.config.{ConfigValueFactory, ConfigFactory}
-import spark.jobserver.io.{JobDAO, JobDAOActor}
+import akka.testkit.{ImplicitSender, TestKit, TestProbe}
+import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
-import spark.jobserver.util.SparkJobUtils
-import scala.concurrent.duration._
-
 import spark.jobserver.common.akka
 import spark.jobserver.common.akka.AkkaTestUtils
+import spark.jobserver.io.JobDAOActor.CleanContextJobInfos
+import spark.jobserver.util.SparkJobUtils
+
+import scala.concurrent.duration._
 
 
 object LocalContextSupervisorSpec {
@@ -59,8 +59,7 @@ class LocalContextSupervisorSpec extends TestKit(LocalContextSupervisorSpec.syst
   }
 
   var supervisor: ActorRef = _
-  var dao: JobDAO = _
-  var daoActor: ActorRef = _
+  var daoProbe: TestProbe = _
 
   val contextConfig = LocalContextSupervisorSpec.config.getConfig("spark.context-settings")
 
@@ -68,9 +67,8 @@ class LocalContextSupervisorSpec extends TestKit(LocalContextSupervisorSpec.syst
   System.setProperty("spark.driver.host", "localhost")
 
   before {
-    dao = new InMemoryDAO
-    daoActor = system.actorOf(JobDAOActor.props(dao))
-    supervisor = system.actorOf(Props(classOf[LocalContextSupervisorActor], daoActor))
+    daoProbe = TestProbe()
+    supervisor = system.actorOf(Props(classOf[LocalContextSupervisorActor], daoProbe.ref))
   }
 
   after {
@@ -165,6 +163,17 @@ class LocalContextSupervisorSpec extends TestKit(LocalContextSupervisorSpec.syst
 
       supervisor ! AddContext("c1", contextConfig)
       expectMsg(ContextAlreadyExists)
+    }
+
+    it("should clean up context running jobs on context termination") {
+      supervisor ! AddContext("c1", contextConfig)
+      expectMsg(ContextInitialized)
+      supervisor ! GetContext("c1")
+      val (jobManager: ActorRef, _) = expectMsgType[(_, _)]
+
+      jobManager ! PoisonPill
+      val msg = daoProbe.expectMsgType[CleanContextJobInfos]
+      msg.contextName shouldBe "c1"
     }
   }
 }

--- a/job-server/src/test/scala/spark/jobserver/io/JobCassandraDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/JobCassandraDAOSpec.scala
@@ -64,14 +64,13 @@ class JobCassandraDAOSpec extends TestJarFinder with FunSpecLike with Matchers w
     genTestJarInfo _
   }
 
-  private def genJobInfoClosure = {
+  case class GenJobInfoClosure() {
     var count: Int = 0
 
-    def genTestJobInfo(jarInfo: BinaryInfo, hasEndTime: Boolean, hasError: Boolean, isNew:Boolean):JobInfo ={
+    def apply(jarInfo: BinaryInfo, hasEndTime: Boolean, hasError: Boolean, isNew:Boolean, contextName: String = "test-context"):JobInfo ={
       count = count + (if (isNew) 1 else 0)
 
       val id: String = UUIDs.random().toString
-      val contextName: String = "test-context"
       val classPath: String = "test-classpath"
       val startTime: DateTime = new DateTime()
 
@@ -87,11 +86,10 @@ class JobCassandraDAOSpec extends TestJarFinder with FunSpecLike with Matchers w
       JobInfo(id, contextName, jarInfo, classPath, startTime, endTime, error)
     }
 
-    genTestJobInfo _
   }
 
   def genJarInfo: (Boolean, Boolean) => BinaryInfo = genJarInfoClosure
-  def genJobInfo: (BinaryInfo, Boolean, Boolean, Boolean) => JobInfo = genJobInfoClosure
+  lazy val genJobInfo = GenJobInfoClosure()
   //**********************************
   override def beforeAll() {
     EmbeddedCassandraServerHelper.startEmbeddedCassandra()
@@ -353,6 +351,26 @@ class JobCassandraDAOSpec extends TestJarFinder with FunSpecLike with Matchers w
 
       //test
       retrieved.error.isDefined should equal (true)
+    }
+
+    it("retrieve running jobs by context name") {
+      val jobInfo = genJobInfo(jarInfo, false, false, true, "context")
+      dao.saveJobInfo(jobInfo)
+
+      val results = Await.result(dao.getRunningJobInfosForContextName("context"), timeout)
+      results should have size 1
+      results.head.jobId shouldBe jobInfo.jobId
+    }
+
+    it("should clean jobs for given context") {
+      val jobInfo = genJobInfo(jarInfo, false, false, false, "context")
+      dao.saveJobInfo(jobInfo)
+
+      Await.result(dao.cleanRunningJobInfosForContext("context", DateTime.now()), timeout)
+      val updatedJobInfo = Await.result(dao.getJobInfo(jobInfo.jobId), timeout)
+      updatedJobInfo shouldBe defined
+      updatedJobInfo.get.endTime shouldBe defined
+      updatedJobInfo.get.error shouldBe defined
     }
   }
 

--- a/job-server/src/test/scala/spark/jobserver/io/JobDAOActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/JobDAOActorSpec.scala
@@ -1,22 +1,23 @@
 package spark.jobserver.io
 
 import akka.actor.ActorSystem
-import akka.testkit.{ImplicitSender, TestKit}
+import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import com.typesafe.config.Config
 import org.joda.time.DateTime
 import org.scalatest.{BeforeAndAfterAll, FunSpecLike, Matchers}
 import spark.jobserver.io.JobDAOActor._
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
-
 import spark.jobserver.common.akka.AkkaTestUtils
 
 object JobDAOActorSpec {
   val system = ActorSystem("dao-test")
   val dt = DateTime.now()
   val dtplus1 = dt.plusHours(1)
+
+  val cleanupProbe = TestProbe()(system)
 
   object DummyDao extends JobDAO{
 
@@ -52,6 +53,8 @@ object JobDAOActorSpec {
     override def getJobInfos(limit: Int, status: Option[String]): Future[Seq[JobInfo]] =
       Future.successful(Seq())
 
+    override def getRunningJobInfosForContextName(contextName: String): Future[Seq[JobInfo]] = ???
+
     override def getJobInfo(jobId: String): Future[Option[JobInfo]] = ???
 
     override def saveJobInfo(jobInfo: JobInfo): Unit = ???
@@ -65,6 +68,11 @@ object JobDAOActorSpec {
         case "failOnThis" => throw new Exception("deliberate failure")
         case _ => //Do nothing
       }
+    }
+
+    override def cleanRunningJobInfosForContext(contextName: String, endTime: DateTime): Future[Unit] = {
+      cleanupProbe.ref ! contextName
+      Future.successful(())
     }
   }
 }
@@ -122,6 +130,11 @@ class JobDAOActorSpec extends TestKit(JobDAOActorSpec.system) with ImplicitSende
     it("should get binary content") {
       daoActor ! GetBinaryContent("succeed", BinaryType.Jar, DateTime.now)
       expectMsg(BinaryContent(DummyDao.jarContent))
+    }
+
+    it("should request jobs cleanup") {
+      daoActor ! CleanContextJobInfos("context", DateTime.now())
+      cleanupProbe.expectMsg("context")
     }
   }
 


### PR DESCRIPTION
* Create JobDAO methods for selecting and cleaning zombie jobs
* Implement methods in all implementation; Cassandra one requires new tables
* Make supervisor run cleanup of running job for context when its manager dies

BREAKING CHANGES :
* Cassandra schema change required

**Pull Request checklist**

- [*] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [*] Tests for the changes have been added (for bug fixes / features) ?
- [*] Docs have been added / updated (for bug fixes / features) ?
Docstrings for new methods.

**Current behavior :** 
#757, #856, #109

When fatal error occurs during job, JobManager terminates and job is left in RUNNING state forever.

**New behavior :**

When fatal error occurs during job, jobs are moved into error state.

**BREAKING CHANGES**

When Cassandra storage is used, new table must be created for running jobs. No migration is needed as no contexts should exist on cluster after launching new version, so no jobs are running.

**Other information**: