### PR TITLE
feat(api): asynchronous context reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,7 +779,7 @@ These routes are kept for legacy purposes but are deprecated in favour of the /b
     GET /contexts               - lists all current contexts
     POST /contexts/<name>       - creates a new context
     DELETE /contexts/<name>     - stops a context and all jobs running in it
-    PUT /contexts?reset=reboot  - kills all contexts and re-loads only the contexts from config
+    PUT /contexts?reset=reboot  - shuts down all contexts and re-loads only the contexts from config. Use ?sync=false to execute asynchronously.
 
 Spark context configuration params can follow `POST /contexts/<name>` as query params. See section below for more details.
 


### PR DESCRIPTION
**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?
- [X] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

The "context" endpoint offers a PUT method that allows shutting down all active contexts at once.
Currently, the PUT request will not be returned until all contexts have been shut down.

**New behavior :**

An optional "sync" parameter allows requesting the shut down of all context and returning before the request have been executed. 

**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**: