### PR TITLE
feat(api):add delete all data endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,6 +806,7 @@ It is sometime necessary to programmatically upload files to the server. Use the
                                prefix is the prefix of the actual filename used on the server (a timestamp is
                                added to ensure uniqueness)
     DELETE /data/<filename>  - Deletes the specified file (only if under control of the JobServer)
+    PUT /data?reset=reboot   - Deletes all uploaded files. Use ?sync=false to execute asynchronously.
 
 These files are uploaded to the server and are stored in a local temporary
 directory where the JobServer runs. The POST command returns the full

--- a/job-server/src/main/scala/spark/jobserver/DataManagerActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/DataManagerActor.scala
@@ -9,6 +9,7 @@ object DataManagerActor {
   // Messages to DataManager actor
   case class StoreData(name: String, bytes: Array[Byte])
   case class DeleteData(name: String)
+  case class DeleteAllData()
   case object ListData
 
   // Responses
@@ -27,6 +28,8 @@ class DataManagerActor(fileDao: DataFileDAO) extends InstrumentedActor {
 
     case DeleteData(fileName) =>
       sender ! { if (fileDao.deleteFile(fileName)) Deleted else Error }
+    case DeleteAllData =>
+      sender ! { if (fileDao.deleteAll()) Deleted else Error }
 
     case StoreData(aName, aBytes) =>
       logger.info("Storing data in file prefix {}, {} bytes", aName, aBytes.length)

--- a/job-server/src/main/scala/spark/jobserver/io/DataFileDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/DataFileDAO.scala
@@ -2,8 +2,11 @@ package spark.jobserver.io
 
 import com.typesafe.config._
 import java.io._
+
+import org.apache.commons.io.FileUtils
 import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
+
 import scala.collection.mutable
 
 object DataFileDAO {
@@ -20,7 +23,7 @@ class DataFileDAO(config: Config) {
   private val files = mutable.HashSet.empty[String]
 
 
-  private val dataFile : File = {
+  private val dataFile: File = {
 
     val rootDir = config.getString("spark.jobserver.datadao.rootdir")
     val rootDirFile = new File(rootDir)
@@ -66,9 +69,9 @@ class DataFileDAO(config: Config) {
   }
 
   /**
-   * save the given data into a new file with the given prefix, a time stamp is appended to
-   * ensure uniqueness
-   */
+    * save the given data into a new file with the given prefix, a time stamp is appended to
+    * ensure uniqueness
+    */
   def saveFile(aNamePrefix: String, uploadTime: DateTime, aBytes: Array[Byte]): String = {
     // The order is important. Save the file first and then log it into meta data file.
     val outFile = new File(rootDir, createFileName(aNamePrefix, uploadTime) + DataFileDAO.EXTENSION)
@@ -94,6 +97,21 @@ class DataFileDAO(config: Config) {
     out.writeUTF(aInfo.appName)
     out.writeLong(aInfo.uploadTime.getMillis)
   }
+
+  def deleteAll(): Boolean = {
+    try {
+      FileUtils.deleteDirectory(new File(rootDir))
+      new File(rootDir).mkdir()
+      files.clear()
+      true
+    } catch {
+      case e: Exception => {
+        logger.error("An error occurred while deleting " + rootDir, e)
+        false
+      }
+    }
+  }
+
 
   def deleteFile(aName: String): Boolean = {
     if (aName.startsWith(rootDir) && files.contains(aName)) {


### PR DESCRIPTION
* Add support for deleting all uploaded files at once through PUT method in "data" endpoint
* Update docs

**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?
- [X] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**

The "data" API now supports a PUT method request that allows deleting all uploaded files at once.
This is in line with the "reset" functionality already available for the "context" endpoint.
Asynchronous execution is also supported. 

**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**: