### PR TITLE
fix(job-server): fix for 916,917: logging for manager_start.sh

### DIFF
--- a/bin/manager_start.sh
+++ b/bin/manager_start.sh
@@ -49,3 +49,4 @@ else
 fi
 
 eval $cmd
+

--- a/bin/manager_start.sh
+++ b/bin/manager_start.sh
@@ -48,5 +48,4 @@ else
   $appdir/spark-job-server.jar $2 $3 $4 $conffile'
 fi
 
-eval $cmd > /dev/null 2>&1 &
-# exec java -cp $CLASSPATH $GC_OPTS $JAVA_OPTS $LOGGING_OPTS $CONFIG_OVERRIDES $MAIN $1 $2 $conffile 2>&1 &
+eval $cmd

--- a/job-server/config/docker.conf
+++ b/job-server/config/docker.conf
@@ -65,7 +65,6 @@ spark {
 
 deploy {
   manager-start-cmd = "app/manager_start.sh"
-  wait-for-manager-start = false
 }
 
 # Note that you can use this file to define settings not only for job server,

--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -243,7 +243,4 @@ shiro {
 
 deploy {
   manager-start-cmd = "./manager_start.sh"
-  # If true, wait for the process which starts contexts in a forked JVM to exit. Set to false
-  # if this process needs to remain in the foreground, e.g. when running in Docker.
-  wait-for-manager-start = true
 }

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -20,6 +20,7 @@ import spark.jobserver.common.akka.InstrumentedActor
 import scala.concurrent.Await
 import akka.pattern.gracefulStop
 import org.joda.time.DateTime
+import org.slf4j.LoggerFactory
 import spark.jobserver.io.JobDAOActor.CleanContextJobInfos
 
 /**
@@ -236,28 +237,11 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef) extends InstrumentedActor {
       cmdString = cmdString + s" ${contextConfig.getString(SparkJobUtils.SPARK_PROXY_USER_PARAM)}"
     }
 
-    val pb = Process(cmdString)
-    val pio = new ProcessIO(_ => (),
-                        stdout => scala.io.Source.fromInputStream(stdout)
-                          .getLines.foreach(println),
-                        stderr => scala.io.Source.fromInputStream(stderr).getLines().foreach(println))
-    logger.info("Starting to execute sub process {}", pb)
-    val processStart = Try {
-      val process = pb.run(pio)
-      if (waitForManagerStart) {
-        val exitVal = process.exitValue()
-        if (exitVal != 0) {
-          throw new IOException("Failed to launch context process, got exit code " + exitVal)
-        }
-      }
-    }
+    val contextLogger = LoggerFactory.getLogger("manager_start")
+    val process = Process(cmdString.split(" "))
+    process.run(ProcessLogger(out => contextLogger.info(out), err => contextLogger.warn(err)))
 
-    if (processStart.isSuccess) {
-      contextInitInfos(contextActorName) = (isAdHoc, successFunc, failureFunc)
-    } else {
-      failureFunc(processStart.failed.get)
-    }
-
+    contextInitInfos(contextActorName) = (isAdHoc, successFunc, failureFunc)
   }
 
   private def createContextDir(name: String,

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -1,6 +1,5 @@
 package spark.jobserver
 
-import java.io.IOException
 import java.nio.file.{Files, Paths}
 import java.nio.charset.Charset
 import java.util.concurrent.TimeUnit
@@ -38,7 +37,6 @@ import spark.jobserver.io.JobDAOActor.CleanContextJobInfos
  * {{{
  *   deploy {
  *     manager-start-cmd = "./manager_start.sh"
- *     wait-for-manager-start = true
  *   }
  * }}}
  */
@@ -53,7 +51,6 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef) extends InstrumentedActor {
                                                 TimeUnit.SECONDS)
   val contextDeletionTimeout = SparkJobUtils.getContextDeletionTimeout(config)
   val managerStartCommand = config.getString("deploy.manager-start-cmd")
-  val waitForManagerStart = config.getBoolean("deploy.wait-for-manager-start")
   import context.dispatcher
 
   //actor name -> (context isadhoc, success callback, failure callback)


### PR DESCRIPTION
* Add logging when starting context through manager_start.sh
* manager_start.sh process is now fully asynchronous
* spark-submit logs routed to main application logs

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/918)
<!-- Reviewable:end -->
