### PR TITLE
Add YARN cluster mode and simplify cluster deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ spark-jobserver provides a RESTful interface for submitting and managing [Apache
 This repo contains the complete Spark job server project, including unit tests and deploy scripts.
 It was originally started at [Ooyala](http://www.ooyala.com), but this is now the main development repo.
 
-Other useful links: [Troubleshooting Tips](doc/troubleshooting.md), [Yarn tips](doc/yarn.md), [Mesos tips](doc/mesos.md).
+Other useful links: [Troubleshooting](doc/troubleshooting.md), [YARN client](doc/yarn.md), [YARN cluster](doc/yarn-cluster.md), [YARN on EMR](doc/EMR.md) and [Mesos](doc/mesos.md).
 
 Also see [Chinese docs / 中文](doc/chinese/job-server.md).
 
@@ -100,7 +100,7 @@ Spark Job Server is now included in Datastax Enterprise 4.8!
 - Kill running jobs via stop context and delete job
 - Separate jar uploading step for faster job startup
 - Asynchronous and synchronous job API.  Synchronous API is great for low latency jobs!
-- Works with Standalone Spark as well as Mesos and yarn-client
+- Works with Standalone Spark as well on [Mesos](doc/mesos.md) and YARN mode ([client](doc/yarn.md), [cluster](doc/yarn-cluster.md), [EMR](doc/EMR.md))
 - Job and jar info is persisted via a pluggable DAO interface
 - Named Objects (such as RDDs or DataFrames) to cache and retrieve RDDs or DataFrames by name, improving object sharing and reuse among jobs.
 - Supports Scala 2.10 and 2.11
@@ -562,6 +562,8 @@ curl -k --basic --user 'user:pw' https://localhost:8090/contexts
 
 ## Deployment
 
+See also running [YARN in client mode](doc/yarn.md), [YARN in cluster mode](doc/yarn-cluster.md), [YARN on EMR](doc/EMR.md) and running on [Mesos](doc/mesos.md).
+
 ### Manual steps
 
 1. Copy `config/local.sh.template` to `<environment>.sh` and edit as appropriate.  NOTE: be sure to set SPARK_VERSION if you need to compile against a different version.
@@ -899,8 +901,6 @@ To add to the underlying Hadoop configuration in a Spark context, add the hadoop
     }
 
 For the exact context configuration parameters, see JobManagerActor docs as well as application.conf.
-
-Also see the [yarn doc](doc/yarn.md) for more tips.
 
 ### Other configuration settings
 

--- a/bin/manager_start.sh
+++ b/bin/manager_start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Script to start the job manager
-# args: <work dir for context> <cluster address> [proxy_user]
+# args: <master> <deployMode> <workDir> <akkaAdress> [<proxyUser>]
 set -e
 
 get_abs_script_path() {
@@ -13,12 +13,8 @@ get_abs_script_path
 
 . $appdir/setenv.sh
 
-# Override logging options to provide per-context logging
-LOGGING_OPTS="-Dlog4j.configuration=file:$appdir/log4j-server.properties
-              -DLOG_DIR=$2"
-
 GC_OPTS="-XX:+UseConcMarkSweepGC
-         -verbose:gc -XX:+PrintGCTimeStamps -Xloggc:$appdir/gc.out
+         -verbose:gc -XX:+PrintGCTimeStamps
          -XX:MaxPermSize=512m
          -XX:+CMSClassUnloadingEnabled "
 
@@ -27,26 +23,34 @@ JAVA_OPTS="-XX:MaxDirectMemorySize=$MAX_DIRECT_MEMORY
 
 MAIN="spark.jobserver.JobManager"
 
-MESOS_OPTS=""
-if [ $1 == "mesos-cluster" ]; then
-    MESOS_OPTS="--master $MESOS_SPARK_DISPATCHER --deploy-mode cluster"
-    appdir=$REMOTE_JOBSERVER_DIR
+if [ $2 == "cluster" ]; then
+  SPARK_SUBMIT_OPTIONS="$SPARK_SUBMIT_OPTIONS
+    --master $1 --deploy-mode cluster
+    --files $appdir/log4j-cluster.properties,$3/context.conf,$conffile"
+  LOGGING_OPTS="-Dlog4j.configuration=log4j-cluster.properties"
+else # client mode
+  # Override logging options to provide per-context logging
+  LOGGING_OPTS="-Dlog4j.configuration=file:$appdir/log4j-server.properties -DLOG_DIR=$3"
+  GC_OPTS="$GC_OPTS -Xloggc:$3/gc.out"
 fi
 
-if [ ! -z $5 ]; then
-  cmd='$SPARK_HOME/bin/spark-submit --class $MAIN --driver-memory $JOBSERVER_MEMORY
-  --conf "spark.executor.extraJavaOptions=$LOGGING_OPTS"
-  --proxy-user $5
-  $MESOS_OPTS
-  --driver-java-options "$GC_OPTS $JAVA_OPTS $LOGGING_OPTS $CONFIG_OVERRIDES"
-  $appdir/spark-job-server.jar $2 $3 $4 $conffile'
-else
-  cmd='$SPARK_HOME/bin/spark-submit --class $MAIN --driver-memory $JOBSERVER_MEMORY
-  --conf "spark.executor.extraJavaOptions=$LOGGING_OPTS"
-  --driver-java-options "$GC_OPTS $JAVA_OPTS $LOGGING_OPTS $CONFIG_OVERRIDES"
-  $MESOS_OPTS
-  $appdir/spark-job-server.jar $2 $3 $4 $conffile'
+if [ -n "$REMOTE_JOBSERVER_DIR" ]; then
+  appdir=$REMOTE_JOBSERVER_DIR
 fi
+
+if [ -n "$5" ]; then
+  SPARK_SUBMIT_OPTIONS="$SPARK_SUBMIT_OPTIONS --proxy-user $5"
+fi
+
+if [ -n "$JOBSERVER_KEYTAB" ]; then
+  SPARK_SUBMIT_OPTIONS="$SPARK_SUBMIT_OPTIONS --keytab $JOBSERVER_KEYTAB"
+fi
+
+cmd='$SPARK_HOME/bin/spark-submit --class $MAIN --driver-memory $JOBSERVER_MEMORY
+      --conf "spark.executor.extraJavaOptions=$LOGGING_OPTS"
+      $SPARK_SUBMIT_OPTIONS
+      --driver-java-options "$GC_OPTS $JAVA_OPTS $LOGGING_OPTS $CONFIG_OVERRIDES $SPARK_SUBMIT_JAVA_OPTIONS"
+      $appdir/spark-job-server.jar $2 $3 $4 $conffile'
 
 eval $cmd > /dev/null 2>&1 &
 # exec java -cp $CLASSPATH $GC_OPTS $JAVA_OPTS $LOGGING_OPTS $CONFIG_OVERRIDES $MAIN $1 $2 $conffile 2>&1 &

--- a/bin/server_package.sh
+++ b/bin/server_package.sh
@@ -51,6 +51,7 @@ pushd "${bin}/.." > /dev/null
          bin/setenv.sh
          ${CONFIG_DIR}/${ENV}.conf
          config/shiro.ini
+         config/log4j-cluster.properties
          config/log4j-server.properties"
 
   rm -rf $WORK_DIR

--- a/doc/EMR.md
+++ b/doc/EMR.md
@@ -1,5 +1,7 @@
 ## Step by step instruction on how to run Spark Job Server on EMR 4.2.0 (Spark 1.6.0)
 
+See also running [YARN in client mode](yarn.md), running [YARN in cluster mode](yarn-cluster.md) and running on [Mesos](Mesos.md).
+
 ### Create EMR 4.2.0 cluster
 
 Create EMR cluster using AWS EMR console or aws cli.

--- a/doc/mesos.md
+++ b/doc/mesos.md
@@ -1,114 +1,64 @@
 ## Configuring Job Server for Mesos
 
+See also running [YARN in client mode](yarn.md), running [YARN in cluster mode](yarn-cluster.md) and running [YARN on EMR](EMR.md).
+
 ### Mesos client mode
 
-Configuring job-server for Mesos cluster mode is straight forward. All you need to change is `spark.master` config to 
+Configuring job-server for Mesos client mode is straight forward. All you need to change is `spark.master` config to 
 point to Mesos master URL in job-server config file.
 
 Example config file (important settings are marked with # important):
 
     spark {
-      master =  <mesos master URL here> # important, example: mesos://mesos-master:5050
-    
-      # Default # of CPUs for jobs to use for Spark standalone cluster
-      job-number-cpus = 4
-
-      jobserver {
-        port = 8090
-        jobdao = spark.jobserver.io.JobSqlDAO
-
-        sqldao {
-          # Directory where default H2 driver stores its data. Only needed for H2.
-          rootdir = /database
-
-          # Full JDBC URL / init string.  Sorry, needs to match above.
-          # Substitutions may be used to launch job-server, but leave it out here in the default or tests won't pass
-          jdbc.url = "jdbc:h2:file:/database/h2-db"
-        }
-      }
-
-      # universal context configuration.  These settings can be overridden, see README.md
-      context-settings {
-        num-cpu-cores = 2           # Number of cores to allocate.  Required.
-        memory-per-node = 512m         # Executor memory per node, -Xmx style eg 512m, #1G, etc.
-      }
+      master = <mesos master URL here> # example: mesos://mesos-master:5050
     }
 
-### Mesos cluster Mode
+### Mesos cluster mode
 
 Configuring job-server for Mesos cluster mode is a bit tricky as compared to client mode.
 
-Here is the checklist for the changes needed for the same:
-
-- You need to start Mesos dispatcher in your cluster by running `./sbin/start-mesos-dispatcher.sh` available in 
+You need to start Mesos dispatcher in your cluster by running `./sbin/start-mesos-dispatcher.sh` available in 
 spark package. This step is not specific to job-server and as mentioned in [official spark documentation](https://spark.apache.org/docs/latest/running-on-mesos.html#cluster-mode) this is needed 
 to submit spark job in Mesos cluster mode. 
 
-- Add following config at the end of job-server's settings.sh file:
-    
-    ```
-    REMOTE_JOBSERVER_DIR=<path to job-server directory> # copy job-server directory on this location on all mesos agent nodes 
-    MESOS_SPARK_DISPATCHER=<mesos dispatcher URL> # example: mesos://mesos-dispatcher:7077
-    ```
+Add the following config to you job-server config file:
+- set `spark.master` property to messos dispatcher URL (example: `mesos://mesos-dispatcher:7077`)
+- set `spark.submit.deployMode` property to `cluster`
+- set `spark.jobserver.context-per-jvm` to `true`
+- set `akka.remote.netty.tcp.hostname` to the cluster interface of the host running the frontend
+- set `akka.remote.netty.tcp.maximum-frame-size` to support big remote jars fetch
 
-- Set `spark.jobserver.driver-mode` property to `mesos-cluster` in job-server config file.
-
-- Also override akka default configs in job-server config file to support big remote jars fetch, we have to set frame 
-size to some large value, for example:
-
-```
-akka.remote.netty.tcp {
-    # use remote IP address to form akka cluster, not 127.0.0.1. This should be the IP of of the machine where the file 
-    # resides. That means for each mesos agents (where job-server directory is copied on REMOTE_JOBSERVER_DIR path),
-    # the hostname should be the remote IP of that node.  
-    #  
-    hostname = "xxxxx" 
-    # This controls the maximum message size, including job results, that can be sent
-    maximum-frame-size = 104857600b
-}
-```
-
-- set `spark.master` to Mesos master URL (and not mesos-dispatcher URL).   
-
-- set `spark.jobserver.context-per-jvm` to `true` in job-server config file.
-
-Example config file (important settings are marked with # important):
+Example job server config (replace `CLUSTER-IP` with the internal IP of the host running the job server frontend):
 
     spark {
-      master =  <mesos master URL here> # important, example: mesos://mesos-master:5050
-    
-      # Default # of CPUs for jobs to use for Spark standalone cluster
-      job-number-cpus = 4
+      master =  <mesos dispatcher URL> # example: mesos://mesos-dispatcher:7077
+      submit.deployMode = cluster
 
       jobserver {
-        port = 8090
-        driver-mode = mesos-cluster  #important
-        context-per-jvm = true       #important
-        jobdao = spark.jobserver.io.JobSqlDAO
-        
+        context-per-jvm = true
+
+        # start a H2 DB server, reachable in your cluster
         sqldao {
-          # Directory where default H2 driver stores its data. Only needed for H2.
-          rootdir = /database
-
-          # Full JDBC URL / init string.  Sorry, needs to match above.
-          # Substitutions may be used to launch job-server, but leave it out here in the default or tests won't pass
-          jdbc.url = "jdbc:h2:file:/database/h2-db"
+          jdbc {
+            url = "jdbc:h2:tcp://CLUSTER-IP:9092/h2-db;AUTO_RECONNECT=TRUE"
+          }
         }
-      }
-
-      # universal context configuration.  These settings can be overridden, see README.md
-      context-settings {
-        num-cpu-cores = 2           # Number of cores to allocate.  Required.
-        memory-per-node = 512m         # Executor memory per node, -Xmx style eg 512m, #1G, etc.
+        startH2Server = false
       }
     }
     
-    akka.remote.netty.tcp {    
-        # use remote IP address to form akka cluster, not 127.0.0.1. This should be the IP of of the machine where the file 
-        # resides. That means for each mesos agents (where job-server directory is copied on REMOTE_JOBSERVER_DIR path),
-        # the hostname should be the remote IP of that node.  
-        #  
-        hostname = "xxxxx"    #important
+    # start akka on this interface, reachable from your cluster
+    akka {
+      remote.netty.tcp {
+        hostname = "CLUSTER-IP"
+
         # This controls the maximum message size, including job results, that can be sent
-        maximum-frame-size = 104857600b    #important
+        maximum-frame-size = 100 MiB
+      }
     }
+
+- Optional: Add following config at the end of job-server's settings.sh file:
+    
+    ```
+    REMOTE_JOBSERVER_DIR=<path to job-server directory> # copy of job-server directory on all mesos agent nodes 
+    ```

--- a/doc/yarn-cluster.md
+++ b/doc/yarn-cluster.md
@@ -1,0 +1,61 @@
+## Configuring Job Server for YARN cluster mode
+
+See also running [YARN in client mode](yarn.md), running [YARN on EMR](EMR.md) and running on [Mesos](mesos.md).
+
+### Job Server configuration
+
+Add the following config to you job-server config file:
+- set `spark.master` property to `yarn`
+- set `spark.submit.deployMode` property to `cluster`
+- set `spark.jobserver.context-per-jvm` to `true`
+- set `akka.remote.netty.tcp.hostname` to the cluster interface of the host running the frontend
+- set `akka.remote.netty.tcp.maximum-frame-size` to support big remote jars fetch
+
+Example job server config (replace `CLUSTER-IP` with the internal IP of the host running the job server frontend):
+
+    spark {
+      # deploy in yarn cluster mode
+      master = yarn
+      submit.deployMode = cluster
+
+      jobserver {
+        context-per-jvm = true
+
+        # start a H2 DB server, reachable in your cluster
+        sqldao {
+          jdbc {
+            url = "jdbc:h2:tcp://CLUSTER-IP:9092/h2-db;AUTO_RECONNECT=TRUE"
+          }
+        }
+        startH2Server = false
+      }
+    }
+
+    # start akka on this interface, reachable from your cluster
+    akka {
+      remote.netty.tcp {
+        hostname = "CLUSTER-IP"
+
+        # This controls the maximum message size, including job results, that can be sent
+        maximum-frame-size = 100 MiB
+      }
+    }
+
+Note:
+- Instead of running a H2 DB instance you can also run a real DB reachable inside your cluster. You can't use the default (host only) H2 configuration in a cluster setup.
+- Akka binds by [default](../job-server/src/main/resources/application.conf) to the local host interface and is not reachable from the cluster. You need to configure the akka hostname to the cluster internal address.
+
+### Reading files uploaded via frontend
+
+Files uploaded via the data API (`/data`) are stored on your job server frontend host.
+Call the [DataFileCache](../job-server-api/src/main/scala/spark/jobserver/api/SparkJobBase.scala) API implemented by the job environment in your spark jobs to access them:
+
+```scala
+  object RemoteDriverExample extends NewSparkJob {
+    def runJob(sc: SparkContext, runtime: JobEnvironment, data: JobData): JobOutput =
+      runtime.getDataFile(...)
+```
+
+The job server transfers the files via akka to the host running your driver and caches them there.
+
+Note: Files uploaded via the JAR or binary API are stored and transfered via the Job DB.

--- a/doc/yarn.md
+++ b/doc/yarn.md
@@ -1,10 +1,6 @@
-## Configuring Job Server for YARN
+## Configuring Job Server for YARN in client mode with docker
 
-(Looking for contributors for this page)
-
-(I would like to thank Jon Buffington for sharing the config tips below.... @velvia)
-
-Note:  This is for yarn with docker.  If you are looking to deploy on a yarn cluster via EMR, then this link would be more useful [EMR](https://github.com/spark-jobserver/spark-jobserver/blob/master/doc/EMR.md)
+See also running [YARN in cluster mode](yarn-cluster.md), running [YARN on EMR](EMR.md) and running on [Mesos](mesos.md).
 
 ### Configuring the Spark-Jobserver Docker package to run in Yarn-Client Mode
 
@@ -19,11 +15,10 @@ Files we need:
 - dockerfile
 - cluster-config directory with hdfs-site.xml and yarn-site.xml (You should have these files already)
 
-Example docker.conf (important settings are marked with # important):
+Example docker.conf:
 
     spark {
-      master = "yarn-client" # important
-      master = ${?SPARK_MASTER}
+      master = yarn
     
       # Default # of CPUs for jobs to use for Spark standalone cluster
       job-number-cpus = 4

--- a/job-server-api/src/main/scala/spark/jobserver/util/SparkJobUtils.scala
+++ b/job-server-api/src/main/scala/spark/jobserver/util/SparkJobUtils.scala
@@ -130,7 +130,7 @@ object SparkJobUtils {
 
   private def getContextTimeout(config: Config, yarn : String, standalone : String): Int = {
     config.getString("spark.master") match {
-      case "yarn-client" =>
+      case "yarn" =>
         Try(config.getDuration(yarn,
               TimeUnit.MILLISECONDS).toInt / 1000).getOrElse(40)
       case _ =>

--- a/job-server-api/src/main/scala/spark/jobserver/util/SparkJobUtils.scala
+++ b/job-server-api/src/main/scala/spark/jobserver/util/SparkJobUtils.scala
@@ -82,11 +82,6 @@ object SparkJobUtils {
     // Set the Jetty port to 0 to find a random port
     conf.set("spark.ui.port", "0")
 
-    // Set spark broadcast factory in yarn-client mode
-    if (sparkMaster == "yarn-client") {
-      conf.set("spark.broadcast.factory", config.getString("spark.jobserver.yarn-broadcast-factory"))
-    }
-
     // Set number of akka threads
     // TODO: need to figure out how many extra threads spark needs, besides the job threads
     conf.set("spark.akka.threads", (getMaxRunningJobs(config) + 4).toString)

--- a/job-server-api/src/test/scala/util/SparkJobUtilsSpec.scala
+++ b/job-server-api/src/test/scala/util/SparkJobUtilsSpec.scala
@@ -46,18 +46,18 @@ class SparkJobUtilsSpec extends FunSpec with Matchers {
       SparkJobUtils.getContextCreationTimeout(config) should equal (15)
     }
 
-    it("should read contextCreationTimeout for yarn-client mode") {
+    it("should read contextCreationTimeout for yarn mode") {
       val config = ConfigFactory.parseMap(Map(
-        "spark.master" -> "yarn-client",
+        "spark.master" -> "yarn",
         "spark.jobserver.yarn-context-creation-timeout" -> 20000,
         "spark.jobserver.context-creation-timeout" -> 10000
       ).asJava)
       SparkJobUtils.getContextCreationTimeout(config) should equal (20)
     }
 
-    it("should read default contextCreationTimeout for yarn-client mode") {
+    it("should read default contextCreationTimeout for yarn mode") {
       val config = ConfigFactory.parseMap(Map(
-        "spark.master" -> "yarn-client"
+        "spark.master" -> "yarn"
       ).asJava)
       SparkJobUtils.getContextCreationTimeout(config) should equal (40)
     }
@@ -78,18 +78,18 @@ class SparkJobUtilsSpec extends FunSpec with Matchers {
       SparkJobUtils.getContextDeletionTimeout(config) should equal (15)
     }
 
-    it("should read contextDeletionTimeout for yarn-client mode") {
+    it("should read contextDeletionTimeout for yarn mode") {
       val config = ConfigFactory.parseMap(Map(
-        "spark.master" -> "yarn-client",
+        "spark.master" -> "yarn",
         "spark.jobserver.yarn-context-deletion-timeout" -> 20000,
         "spark.jobserver.context-deletion-timeout" -> 10000
       ).asJava)
       SparkJobUtils.getContextDeletionTimeout(config) should equal (20)
     }
 
-    it("should read default contextDeletionTimeout for yarn-client mode") {
+    it("should read default contextDeletionTimeout for yarn mode") {
       val config = ConfigFactory.parseMap(Map(
-        "spark.master" -> "yarn-client"
+        "spark.master" -> "yarn"
       ).asJava)
       SparkJobUtils.getContextDeletionTimeout(config) should equal (40)
     }

--- a/job-server/config/docker.conf
+++ b/job-server/config/docker.conf
@@ -16,12 +16,6 @@ spark {
 
     context-per-jvm = true
 
-    # Default client mode will start up a new JobManager int local machine
-    # You can use mesos-cluster mode with REMOTE_JOBSERVER_DIR and MESOS_SPARK_DISPATCHER
-    # environment value set in xxxx.sh file to launch JobManager in remote node
-    # Mesos will take responsibility to offer resource to the JobManager process
-    driver-mode = client
-
     sqldao {
       # Directory where default H2 driver stores its data. Only needed for H2.
       rootdir = /database

--- a/job-server/config/ec2.conf.template
+++ b/job-server/config/ec2.conf.template
@@ -14,12 +14,6 @@ spark {
 
     context-per-jvm = false
 
-    # Default client mode will start up a new JobManager int local machine
-    # You can use mesos-cluster mode with REMOTE_JOBSERVER_DIR and MESOS_SPARK_DISPATCHER
-    # environment value set in xxxx.sh file to launch JobManager in remote node
-    # Mesos will take responsibility to offer resource to the JobManager process
-    driver-mode = client
-
     # Note: JobFileDAO is deprecated from v0.7.0 because of issues in
     # production and will be removed in future, now defaults to H2 file.
     jobdao = spark.jobserver.io.JobSqlDAO

--- a/job-server/config/local.conf.template
+++ b/job-server/config/local.conf.template
@@ -16,12 +16,6 @@ spark {
 
     context-per-jvm = false
 
-    # Default client mode will start up a new JobManager int local machine
-    # You can use mesos-cluster mode with REMOTE_JOBSERVER_DIR and MESOS_SPARK_DISPATCHER
-    # environment value set in xxxx.sh file to launch JobManager in remote node
-    # Mesos will take responsibility to offer resource to the JobManager process
-    driver-mode = client
-
     # Note: JobFileDAO is deprecated from v0.7.0 because of issues in
     # production and will be removed in future, now defaults to H2 file.
     jobdao = spark.jobserver.io.JobSqlDAO

--- a/job-server/config/local.sh.template
+++ b/job-server/config/local.sh.template
@@ -27,6 +27,3 @@ SPARK_EXECUTOR_URI=/home/spark/spark-1.6.0.tar.gz
 # Also optional: extra JVM args for spark-submit
 # export SPARK_SUBMIT_OPTS+="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5433"
 SCALA_VERSION=2.10.4 # or 2.11.6
-REMOTE_JOBSERVER_DIR=file://... or hdfs://...
-MESOS_SPARK_DISPATCHER=mesos://127.0.0.1:7077
-

--- a/job-server/config/log4j-cluster.properties
+++ b/job-server/config/log4j-cluster.properties
@@ -1,0 +1,13 @@
+# Rotating log file configuration for server deploys
+
+# Root logger option
+log4j.rootCategory=INFO,console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+# log4j.appender.console.layout.ConversionPattern=%d %-5p %c - %m%n
+log4j.appender.console.layout.ConversionPattern=[%d] %-5p %.26c [%X{testName}] [%X{akkaSource}] - %m%n
+
+# Settings to quiet spark logs that are too verbose
+log4j.logger.org.apache.spark.scheduler.TaskSetManager=WARN
+log4j.logger.org.apache.spark.scheduler.DAGScheduler=WARN

--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -80,6 +80,9 @@ spark {
       }
     }
 
+    # Start embeded H2 Server (usefull in cluster deployment)
+    startH2Server = false
+
     # The ask pattern timeout for Api
     short-timeout = 3 s
 

--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -96,11 +96,6 @@ spark {
 
     # in yarn deployment, time out for job server to wait while creating contexts
     yarn-context-creation-timeout = 40 s
-
-    # spark broadcst factory in yarn deployment
-    # Versions prior to 1.1.0, spark default broadcast factory is org.apache.spark.broadcast.HttpBroadcastFactory.
-    # Can't start multiple sparkContexts in the same JVM with HttpBroadcastFactory.
-    yarn-broadcast-factory = org.apache.spark.broadcast.TorrentBroadcastFactory
   }
 
   # predefined Spark contexts

--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -1,6 +1,10 @@
 # Settings for safe local mode development
 spark {
+  # local[...], yarn or mesos://...
   master = "local[4]"
+  # client or cluster deployment
+  submit.deployMode = "client"
+
   # spark web UI port
   webUrlPort = 8080
 
@@ -10,12 +14,6 @@ spark {
 
     # If true, a separate JVM is forked for each Spark context
     context-per-jvm = false
-
-    # Default client mode will start up a new JobManager int local machine
-    # You can use mesos-cluster mode with REMOTE_JOBSERVER_DIR and MESOS_SPARK_DISPATCHER
-    # environment value set in xxxx.sh file to launch JobManager in remote node
-    # Mesos will take responsibility to offer resource to the JobManager process
-    driver-mode = client
 
     # Number of job results to keep per JobResultActor/context
     job-result-cache-size = 5000

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -221,26 +221,26 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef) extends InstrumentedActor {
 
     logger.info("Starting context with actor name {}", contextActorName)
 
-    val driverMode = Try(config.getString("spark.jobserver.driver-mode")).toOption.getOrElse("client")
-    val (workDir, contextContent) = generateContext(name, contextConfig, isAdHoc, contextActorName)
-    logger.info("Ready to create working directory {} for context {}", workDir: Any, name)
-
-    //extract spark.proxy.user from contextConfig, if available and pass it to $managerStartCommand
-    var cmdString = if (driverMode == "mesos-cluster") {
-      s"$managerStartCommand $driverMode $workDir '$contextContent' ${selfAddress.toString}"
-    } else {
-      s"$managerStartCommand $driverMode $workDir $contextContent ${selfAddress.toString}"
+    val master = Try(config.getString("spark.master")).toOption.getOrElse("local[4]")
+    val deployMode = Try(config.getString("spark.submit.deployMode")).toOption.getOrElse("client")
+    val contextDir: java.io.File = try {
+      createContextDir(name, contextConfig, isAdHoc, contextActorName)
+    } catch {
+      case e: Exception =>
+        failureFunc(e)
+        return
     }
 
+    var managerArgs = Seq(master, deployMode, contextDir.toString, selfAddress.toString)
+    // extract spark.proxy.user from contextConfig, if available and pass it to manager start command
     if (contextConfig.hasPath(SparkJobUtils.SPARK_PROXY_USER_PARAM)) {
-      cmdString = cmdString + s" ${contextConfig.getString(SparkJobUtils.SPARK_PROXY_USER_PARAM)}"
+      managerArgs = managerArgs :+ contextConfig.getString(SparkJobUtils.SPARK_PROXY_USER_PARAM)
     }
 
-    val pb = Process(cmdString)
+    val pb = Process(managerStartCommand, managerArgs)
     val pio = new ProcessIO(_ => (),
-                        stdout => scala.io.Source.fromInputStream(stdout)
-                          .getLines.foreach(println),
-                        stderr => scala.io.Source.fromInputStream(stderr).getLines().foreach(println))
+                        stdout => scala.io.Source.fromInputStream(stdout).getLines.foreach(println),
+                        stderr => scala.io.Source.fromInputStream(stderr).getLines.foreach(println))
     logger.info("Starting to execute sub process {}", pb)
     val processStart = Try {
       val process = pb.run(pio)
@@ -284,21 +284,6 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef) extends InstrumentedActor {
                 Charset.forName("UTF-8"))
 
     tmpDir.toFile
-  }
-
-  //generate remote context path and context config
-  private def generateContext(name: String,
-                              contextConfig: Config,
-                              isAdHoc: Boolean,
-                              actorName: String): (String, String) = {
-    (Option(System.getProperty("LOG_DIR")).getOrElse("/tmp/jobserver") + "/"
-      + java.net.URLEncoder.encode(name + "-" + actorName, "UTF-8"),
-      ConfigFactory.parseMap(
-        Map("is-adhoc" -> isAdHoc.toString,
-          "context.name" -> name,
-          "context.actorname" -> actorName).asJava
-      ).withFallback(contextConfig).root().render(ConfigRenderOptions.concise())
-      )
   }
 
   private def addContextsFromConfig(config: Config) {

--- a/job-server/src/main/scala/spark/jobserver/JobServer.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobServer.scala
@@ -66,6 +66,14 @@ object JobServer {
             throw new RuntimeException("H2 mem backend is not support with context-per-jvm.")
         }
       }
+
+      // start embedded H2 server
+      if (config.getBoolean("spark.jobserver.startH2Server")) {
+        val rootDir = config.getString("spark.jobserver.sqldao.rootdir")
+        val h2 = org.h2.tools.Server.createTcpServer("-tcpAllowOthers", "-baseDir", rootDir).start();
+        logger.info("Embeded H2 server started with base dir {} and URL {}", rootDir, h2.getURL: Any)
+      }
+
       val jobDAO = ctor.newInstance(config).asInstanceOf[JobDAO]
       val daoActor = system.actorOf(Props(classOf[JobDAOActor], jobDAO), "dao-manager")
       val dataManager = system.actorOf(Props(classOf[DataManagerActor],

--- a/job-server/src/main/scala/spark/jobserver/JobServer.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobServer.scala
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory
 import scala.collection.JavaConverters._
 import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
+import scala.util.Try
 
 /**
  * The Spark Job Server is a web service that allows users to submit and run Spark jobs, check status,
@@ -32,6 +33,8 @@ import scala.concurrent.duration._
 object JobServer {
   val logger = LoggerFactory.getLogger(getClass)
 
+  class InvalidConfiguration(error: String) extends RuntimeException(error)
+
   // Allow custom function to create ActorSystem.  An example of why this is useful:
   // we can have something that stores the ActorSystem so it could be shut down easily later.
   def start(args: Array[String], makeSystem: Config => ActorSystem) {
@@ -48,58 +51,75 @@ object JobServer {
     }
     logger.info("Starting JobServer with config {}", config.getConfig("spark").root.render())
     logger.info("Spray config: {}", config.getConfig("spray.can.server").root.render())
-    val port = config.getInt("spark.jobserver.port")
 
     // TODO: Hardcode for now to get going. Make it configurable later.
     val system = makeSystem(config)
-    val clazz = Class.forName(config.getString("spark.jobserver.jobdao"))
-    val ctor = clazz.getDeclaredConstructor(Class.forName("com.typesafe.config.Config"))
-    try {
-      val contextPerJvm = config.getBoolean("spark.jobserver.context-per-jvm")
-      // Check if we are using correct DB backend when context-per-jvm is enabled.
-      // JobFileDAO and H2 mem is not supported.
-      if (contextPerJvm) {
-        if (clazz.getName == "spark.jobserver.io.JobFileDAO") {
-          throw new RuntimeException("JobFileDAO is not supported with context-per-jvm, use JobSqlDAO.")
-        } else if (clazz.getName == "spark.jobserver.io.JobSqlDAO" &&
-          config.getString("spark.jobserver.sqldao.jdbc.url").startsWith("jdbc:h2:mem")) {
-            throw new RuntimeException("H2 mem backend is not support with context-per-jvm.")
-        }
-      }
+    val port = config.getInt("spark.jobserver.port")
+    val sparkMaster = config.getString("spark.master")
+    val driverMode = config.getString("spark.submit.deployMode")
+    val contextPerJvm = config.getBoolean("spark.jobserver.context-per-jvm")
+    val jobDaoClass = Class.forName(config.getString("spark.jobserver.jobdao"))
 
-      // start embedded H2 server
-      if (config.getBoolean("spark.jobserver.startH2Server")) {
-        val rootDir = config.getString("spark.jobserver.sqldao.rootdir")
-        val h2 = org.h2.tools.Server.createTcpServer("-tcpAllowOthers", "-baseDir", rootDir).start();
-        logger.info("Embeded H2 server started with base dir {} and URL {}", rootDir, h2.getURL: Any)
-      }
-
-      val jobDAO = ctor.newInstance(config).asInstanceOf[JobDAO]
-      val daoActor = system.actorOf(Props(classOf[JobDAOActor], jobDAO), "dao-manager")
-      val dataManager = system.actorOf(Props(classOf[DataManagerActor],
-          new DataFileDAO(config)), "data-manager")
-      val binManager = system.actorOf(Props(classOf[BinaryManager], daoActor), "binary-manager")
-      val supervisor =
-        system.actorOf(Props(
-          if (contextPerJvm) {
-            classOf[AkkaClusterSupervisorActor]
-          } else {
-            classOf[LocalContextSupervisorActor]
-          },
-          daoActor), "context-supervisor")
-      val jobInfo = system.actorOf(Props(classOf[JobInfoActor], jobDAO, supervisor), "job-info")
-
-      // Add initial job JARs, if specified in configuration.
-      storeInitialBinaries(config, binManager)
-
-      // Create initial contexts
-      supervisor ! ContextSupervisor.AddContextsFromConfig
-      new WebApi(system, config, port, binManager, dataManager, supervisor, jobInfo).start()
-    } catch {
-      case e: Exception =>
-        logger.error("Unable to start Spark JobServer: ", e)
-        sys.exit(1)
+    // ensure context-per-jvm is enabled
+    if (sparkMaster.startsWith("yarn") && !contextPerJvm) {
+      throw new InvalidConfiguration("YARN mode requires context-per-jvm")
+    } else if (sparkMaster.startsWith("mesos") && !contextPerJvm) {
+      throw new InvalidConfiguration("Mesos mode requires context-per-jvm")
+    } else if (driverMode == "cluster" && !contextPerJvm) {
+      throw new InvalidConfiguration("Cluster mode requires context-per-jvm")
     }
+
+    // Check if we are using correct DB backend when context-per-jvm is enabled.
+    // JobFileDAO and H2 mem is not supported.
+    if (contextPerJvm) {
+      if (jobDaoClass.getName == "spark.jobserver.io.JobFileDAO") {
+        throw new InvalidConfiguration("JobFileDAO is not supported with context-per-jvm, use JobSqlDAO.")
+      } else if (jobDaoClass.getName == "spark.jobserver.io.JobSqlDAO" &&
+        config.getString("spark.jobserver.sqldao.jdbc.url").startsWith("jdbc:h2:mem")) {
+        throw new InvalidConfiguration("H2 mem backend is not support with context-per-jvm.")
+      }
+    }
+
+    // cluster mode requires network base H2 server
+    if (driverMode == "cluster" && jobDaoClass.getName == "spark.jobserver.io.JobSqlDAO") {
+      val jdbcUrl = config.getString("spark.jobserver.sqldao.jdbc.url")
+        if (jdbcUrl.startsWith("jdbc:h2") && !jdbcUrl.startsWith("jdbc:h2:tcp")
+            && !jdbcUrl.startsWith("jdbc:h2:ssl")) {
+          throw new InvalidConfiguration(
+            """H2 backend and cluster mode is not support with file or in-memory storage,
+               use tcp or ssl server.""")
+        }
+    }
+
+    // start embedded H2 server
+    if (config.getBoolean("spark.jobserver.startH2Server")) {
+      val rootDir = config.getString("spark.jobserver.sqldao.rootdir")
+      val h2 = org.h2.tools.Server.createTcpServer("-tcpAllowOthers", "-baseDir", rootDir).start();
+      logger.info("Embeded H2 server started with base dir {} and URL {}", rootDir, h2.getURL: Any)
+    }
+
+    val ctor = jobDaoClass.getDeclaredConstructor(Class.forName("com.typesafe.config.Config"))
+    val jobDAO = ctor.newInstance(config).asInstanceOf[JobDAO]
+    val daoActor = system.actorOf(Props(classOf[JobDAOActor], jobDAO), "dao-manager")
+    val dataFileDAO = new DataFileDAO(config)
+    val dataManager = system.actorOf(Props(classOf[DataManagerActor], dataFileDAO), "data-manager")
+    val binManager = system.actorOf(Props(classOf[BinaryManager], daoActor), "binary-manager")
+    val supervisor =
+      system.actorOf(Props(
+        if (contextPerJvm) {
+          classOf[AkkaClusterSupervisorActor]
+        } else {
+          classOf[LocalContextSupervisorActor]
+        },
+        daoActor, dataManager), "context-supervisor")
+    val jobInfo = system.actorOf(Props(classOf[JobInfoActor], jobDAO, supervisor), "job-info")
+
+    // Add initial job JARs, if specified in configuration.
+    storeInitialBinaries(config, binManager)
+
+    // Create initial contexts
+    supervisor ! ContextSupervisor.AddContextsFromConfig
+    new WebApi(system, config, port, binManager, dataManager, supervisor, jobInfo).start()
   }
 
   private def parseInitialBinaryConfig(key: String, config: Config): Map[String, String] = {
@@ -165,8 +185,13 @@ object JobServer {
         ConfigValueFactory.fromIterable(List("supervisor").asJava))
       ActorSystem(name, configWithRole)
     }
-    start(args, makeSupervisorSystem("JobServer")(_))
+
+    try {
+      start(args, makeSupervisorSystem("JobServer")(_))
+    } catch {
+      case e: Exception =>
+        logger.error("Unable to start Spark JobServer: ", e)
+        sys.exit(1)
+    }
   }
-
-
 }

--- a/job-server/src/test/scala/spark/jobserver/JobServerSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobServerSpec.scala
@@ -1,0 +1,115 @@
+package spark.jobserver
+
+import java.nio.charset.Charset
+
+import akka.actor.{ActorRef, ActorSystem, Props}
+import akka.testkit.{ImplicitSender, TestKit, TestProbe}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
+import java.nio.file.{Files, Paths}
+
+import spark.jobserver.JobServer.InvalidConfiguration
+import spark.jobserver.common.akka
+
+object JobServerSpec {
+  val system = ActorSystem("test")
+}
+
+class JobServerSpec extends TestKit(JobServerSpec.system) with FunSpecLike with Matchers with BeforeAndAfterAll {
+
+  import com.typesafe.config._
+  import scala.collection.JavaConverters._
+
+  private val configFile = Files.createTempFile("job-server-config", ".conf")
+
+  override def afterAll() {
+    akka.AkkaTestUtils.shutdownAndWait(JobServerSpec.system)
+    Files.deleteIfExists(configFile)
+  }
+
+  def writeConfigFile(configMap: Map[String, Any]): String = {
+    val config = ConfigFactory.parseMap(configMap.asJava).withFallback(ConfigFactory.defaultOverrides())
+    Files.write(configFile,
+      Seq(config.root.render(ConfigRenderOptions.concise)).asJava,
+      Charset.forName("UTF-8"))
+    configFile.toAbsolutePath.toString
+  }
+
+  def makeSupervisorSystem(config: Config): ActorSystem = system
+
+  describe("Fails on invalid configuration") {
+    it("requires context-per-jvm in YARN mode") {
+      val configFileName = writeConfigFile(Map(
+        "spark.master " -> "yarn",
+        "spark.jobserver.context-per-jvm " -> false))
+
+      intercept[InvalidConfiguration] {
+        JobServer.start(Seq(configFileName).toArray, makeSupervisorSystem(_))
+      }
+    }
+
+    it("requires context-per-jvm in Mesos mode") {
+      val configFileName = writeConfigFile(Map(
+        "spark.master " -> "mesos://test:123",
+        "spark.jobserver.context-per-jvm " -> false))
+
+      intercept[InvalidConfiguration] {
+        JobServer.start(Seq(configFileName).toArray, makeSupervisorSystem(_))
+      }
+    }
+
+    it("requires context-per-jvm in cluster mode") {
+      val configFileName = writeConfigFile(Map(
+        "spark.submit.deployMode " -> "cluster",
+        "spark.jobserver.context-per-jvm " -> false))
+
+      intercept[InvalidConfiguration] {
+        JobServer.start(Seq(configFileName).toArray, makeSupervisorSystem(_))
+      }
+    }
+
+    it("does not support context-per-jvm and JobFileDAO") {
+      val configFileName = writeConfigFile(Map(
+        "spark.jobserver.context-per-jvm " -> true,
+        "spark.jobserver.jobdao" -> "spark.jobserver.io.JobFileDAO"))
+
+      intercept[InvalidConfiguration] {
+        JobServer.start(Seq(configFileName).toArray, makeSupervisorSystem(_))
+      }
+    }
+
+    it("does not support context-per-jvm and H2 in-memory DB") {
+      val configFileName = writeConfigFile(Map(
+        "spark.jobserver.context-per-jvm " -> true,
+        "spark.jobserver.jobdao" -> "spark.jobserver.io.JobSqlDAO",
+        "spark.jobserver.sqldao.jdbc.url" -> "jdbc:h2:mem"))
+
+      intercept[InvalidConfiguration] {
+        JobServer.start(Seq(configFileName).toArray, makeSupervisorSystem(_))
+      }
+    }
+
+    it("does not support cluster mode and H2 in-memory DB") {
+      val configFileName = writeConfigFile(Map(
+        "spark.submit.deployMode" -> "cluster",
+        "spark.jobserver.context-per-jvm " -> true,
+        "spark.jobserver.jobdao" -> "spark.jobserver.io.JobSqlDAO",
+        "spark.jobserver.sqldao.jdbc.url" -> "jdbc:h2:mem"))
+
+      intercept[InvalidConfiguration] {
+        JobServer.start(Seq(configFileName).toArray, makeSupervisorSystem(_))
+      }
+    }
+
+    it("does not support cluster mode and H2 file based DB") {
+      val configFileName = writeConfigFile(Map(
+        "spark.submit.deployMode" -> "cluster",
+        "spark.jobserver.context-per-jvm " -> true,
+        "spark.jobserver.jobdao" -> "spark.jobserver.io.JobSqlDAO",
+        "spark.jobserver.sqldao.jdbc.url" -> "jdbc:h2:file"))
+
+      intercept[InvalidConfiguration] {
+        JobServer.start(Seq(configFileName).toArray, makeSupervisorSystem(_))
+      }
+    }
+  }
+}


### PR DESCRIPTION
**New behavior :**

*Deploy mode and spark master in job server config*
- `spark.master` can be `local[...]`, `yarn` or `mesos://...`
- `spark.submit.deployMode` can be `client` or `cluster`

Both options are forwarded trough `manager_start.sh` to `spark-submit`. No need to edit shell variables in `settings.sh` to provide Mesos master.

*Embedded H2 server in job server config*

To launch a H2 database available to remote job manager instances in a cluster:
```
spark {
  jobserver {
    # start a H2 DB server, reachable in your cluster
    sqldao {
      jdbc {
        url = "jdbc:h2:tcp://CLUSTER-IP:9092/h2-db;AUTO_RECONNECT=TRUE"
      }
    }
    startH2Server = true
  }
}
```

*Akka interface*
To run in akka in a cluster (to interact with remote job manager) add the following config:
```
akka {
  remote.netty.tcp {
    hostname = "FRONT-END-IP"
  }
}
```
This config ensures that akka binds to right interface. The hostname gets removed in Job manager configs.

*Remote files and context config*
Some files are now transferred via `spark-submit`:
- job-server-config: default config, no need to copy this by hand to all hosts
- context.conf: each context has its own config file (this reverts #681). providing the config as JSON argument has many limitations (maximal arguments length, special charactes / white spaces and security risk). Arguments in YARN with e.g. `{{VARNAME}}` are replaced with variables at runtime and `}}` makes trouble... This might also fix #915
- log4j-cluster.properties: same config as the server options but with log output to stderr instead of a logfile. works well with YARN cluster containers.

*Remote data files and jars*
PR #924 contains a solution to access files uploaded via the data API (`/data`). Jars and other binaries are already transferred via SQL backend.

**Breaking Changes**
`spark.submit.deployMode` has to be set to `cluster` in job server config. Mesos master variable can be removed from `settings.sh`.

**Documentation**
This PR rewrites the cluster documentations in yarn/mesos docs. Im not sure if the configuration described in [Mesos](doc/mesos.md) with file based H2 database really works?!?!

**Other information**
The changes by this PR has been tested with YARN client and cluster mode. Can someone test this on a Mesos cluster?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/922)
<!-- Reviewable:end -->
