### PR TITLE
feat(jobenv): Remote data file cache

### DIFF
--- a/job-server-api/src/main/scala/spark/jobserver/api/SparkJobBase.scala
+++ b/job-server-api/src/main/scala/spark/jobserver/api/SparkJobBase.scala
@@ -1,5 +1,7 @@
 package spark.jobserver.api
 
+import java.io.{File, IOException}
+
 import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.spark.SparkContext
 import org.apache.spark.api.java.JavaSparkContext
@@ -12,6 +14,21 @@ trait JobEnvironment {
   def namedObjects: NamedObjects
 
   def contextConfig: Config
+}
+
+/**
+ * This trait provides data file access on local and cluster deployments of job manager.
+ */
+trait DataFileCache {
+  /**
+   * Returns data file if exists on this host or a temporary copy if job server and manager
+   * running on different hosts (cluster deployment).
+   *
+   * @param dataFile full path of data file on job server returned by web API
+   * @return data file or temporary copy cluster deployments
+   */
+  @throws(classOf[IOException])
+  def getDataFile(dataFile: String): File
 }
 
 trait ValidationProblem

--- a/job-server-extras/src/test/scala/spark/jobserver/JavaSessionSpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/JavaSessionSpec.scala
@@ -59,7 +59,7 @@ class JavaSessionSpec extends ExtrasJobSpecBase(JavaSessionSpec.getNewSystem) {
 
   describe("Java Session Jobs") {
     it("should be able to create a Hive table, then query it using separate Spark-SQL jobs") {
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(30 seconds, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()

--- a/job-server-extras/src/test/scala/spark/jobserver/JavaStreamingSpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/JavaStreamingSpec.scala
@@ -32,7 +32,7 @@ class JavaStreamingSpec extends ExtrasJobSpecBase(JavaStreamingSpec.getNewSystem
 
   describe("Running Java based Streaming Jobs") {
     it("Should return Correct results") {
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(10 seconds, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()

--- a/job-server-extras/src/test/scala/spark/jobserver/NamedObjectsJobSpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/NamedObjectsJobSpec.scala
@@ -16,7 +16,7 @@ class NamedObjectsJobSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
       daoActor))
     supervisor = TestProbe().ref
 
-    manager ! JobManagerActor.Initialize(None)
+    manager ! JobManagerActor.Initialize(None, emptyActor)
 
     expectMsgClass(10.seconds, classOf[JobManagerActor.Initialized])
 

--- a/job-server-extras/src/test/scala/spark/jobserver/SessionJobSpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/SessionJobSpec.scala
@@ -53,7 +53,7 @@ class SessionJobSpec extends ExtrasJobSpecBase(SessionJobSpec.getNewSystem) {
 
   describe("Spark Session Jobs") {
     it("should be able to create a Hive table, then query it using separate Spark-SQL jobs") {
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(30 seconds, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()

--- a/job-server-extras/src/test/scala/spark/jobserver/StreamingJobSpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/StreamingJobSpec.scala
@@ -38,7 +38,7 @@ class StreamingJobSpec extends JobSpecBase(StreamingJobSpec.getNewSystem) {
 
   describe("Spark Streaming Jobs") {
     it("should be able to process data using Streaming jobs") {
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(10 seconds, classOf[JobManagerActor.Initialized])
       uploadTestJar()
       manager ! JobManagerActor.StartJob("demo", streamingJob, emptyConfig, asyncEvents ++ errorEvents)

--- a/job-server-extras/src/test/scala/spark/jobserver/python/PythonJobManagerSpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/python/PythonJobManagerSpec.scala
@@ -29,7 +29,7 @@ class PythonJobManagerSpec extends ExtrasJobSpecBase(PythonJobManagerSpec.getNew
         withFallback(PythonSparkContextFactorySpec.config)
       manager = system.actorOf(JobManagerActor.props(pyContextConfig, daoActor))
 
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(30 seconds, classOf[JobManagerActor.Initialized])
 
       uploadTestEgg("python-demo")

--- a/job-server-tests/src/main/scala/spark/jobserver/RemoteDataFileJob.scala
+++ b/job-server-tests/src/main/scala/spark/jobserver/RemoteDataFileJob.scala
@@ -1,0 +1,25 @@
+package spark.jobserver
+
+import com.typesafe.config.Config
+import org.apache.spark.SparkContext
+import org.scalactic._
+import spark.jobserver.api.{SparkJob => NewSparkJob, _}
+
+/**
+  * Remote file cache test job (cluster mode support).
+  */
+object RemoteDataFileJob extends NewSparkJob {
+  type JobData = String
+  type JobOutput = String
+
+  def runJob(sc: SparkContext, runtime: JobEnvironment, testFile: JobData): JobOutput = {
+    runtime.asInstanceOf[DataFileCache].getDataFile(testFile).getAbsolutePath
+  }
+
+  def validate(sc: SparkContext, runtime: JobEnvironment, config: Config):
+  JobData Or Every[ValidationProblem] = {
+    Good(config.getString("testFile"))
+  }
+}
+
+

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -41,7 +41,9 @@ import spark.jobserver.io.JobDAOActor.CleanContextJobInfos
  *   }
  * }}}
  */
-class AkkaClusterSupervisorActor(daoActor: ActorRef) extends InstrumentedActor {
+class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
+    extends InstrumentedActor {
+
   import ContextSupervisor._
   import scala.collection.JavaConverters._
   import scala.concurrent.duration._
@@ -191,7 +193,7 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef) extends InstrumentedActor {
 
     val resultActor = if (isAdHoc) globalResultActor else context.actorOf(Props(classOf[JobResultActor]))
     (ref ? JobManagerActor.Initialize(
-      Some(resultActor)))(Timeout(timeoutSecs.second)).onComplete {
+      Some(resultActor), dataManagerActor))(Timeout(timeoutSecs.second)).onComplete {
       case Failure(e: Exception) =>
         logger.info("Failed to send initialize message to context " + ref, e)
         cluster.down(ref.path.address)

--- a/job-server/src/main/scala/spark/jobserver/DataManagerActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/DataManagerActor.scala
@@ -1,21 +1,26 @@
 package spark.jobserver
 
+import akka.actor.{ActorRef, Props}
 import spark.jobserver.io.DataFileDAO
-import spark.jobserver.util.JarUtils
 import org.joda.time.DateTime
 import spark.jobserver.common.akka.InstrumentedActor
+import scala.collection.mutable
 
 object DataManagerActor {
   // Messages to DataManager actor
   case class StoreData(name: String, bytes: Array[Byte])
+  case class RetrieveData(name: String, jobManager: ActorRef)
   case class DeleteData(name: String)
   case class DeleteAllData()
   case object ListData
 
   // Responses
   case class Stored(name: String)
+  case class Data(bytes: Array[Byte])
   case object Deleted
-  case object Error
+  case class Error(msg: String)
+
+  def props(fileDao: DataFileDAO): Props = Props(classOf[DataManagerActor], fileDao)
 }
 
 /**
@@ -23,18 +28,54 @@ object DataManagerActor {
  */
 class DataManagerActor(fileDao: DataFileDAO) extends InstrumentedActor {
   import DataManagerActor._
+
+  // Actors with a cached copy by filename
+  private val remoteCaches = mutable.HashMap.empty[String, mutable.HashSet[ActorRef]]
+
   override def wrappedReceive: Receive = {
     case ListData => sender ! fileDao.listFiles
 
     case DeleteData(fileName) =>
-      sender ! { if (fileDao.deleteFile(fileName)) Deleted else Error }
+      sender ! {
+        if (fileDao.deleteFile(fileName)) {
+          remoteCaches.remove(fileName).map { actors =>
+            actors.map { _ ! JobManagerActor.DeleteData(fileName) }
+          }
+          Deleted
+        } else {
+          Error(s"Unknown file: $fileName")
+        }
+      }
+
     case DeleteAllData =>
-      sender ! { if (fileDao.deleteAll()) Deleted else Error }
+      sender ! {
+        if (fileDao.deleteAll()) {
+          remoteCaches.keySet.map { fileName =>
+            remoteCaches.remove(fileName).map { actors =>
+              actors.map { _ ! JobManagerActor.DeleteData(fileName) }
+            }
+          }
+          Deleted
+        } else {
+          Error("Unable to delete all data")
+        }
+      }
 
     case StoreData(aName, aBytes) =>
       logger.info("Storing data in file prefix {}, {} bytes", aName, aBytes.length)
       val uploadTime = DateTime.now()
       val fName = fileDao.saveFile(aName, uploadTime, aBytes)
+      remoteCaches(fName) = mutable.HashSet.empty[ActorRef]
       sender ! Stored(fName)
+
+    case RetrieveData(fileName, jobManager) =>
+      logger.info("Sending data file {} to {}", fileName, jobManager.path: Any)
+      try {
+        sender ! Data(fileDao.readFile(fileName))
+        remoteCaches(fileName) += jobManager
+      } catch {
+        case e: Exception =>
+          sender ! Error(s"Failed to read file $fileName: $e")
+      }
   }
 }

--- a/job-server/src/main/scala/spark/jobserver/JobServer.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobServer.scala
@@ -68,8 +68,7 @@ object JobServer {
       }
       val jobDAO = ctor.newInstance(config).asInstanceOf[JobDAO]
       val daoActor = system.actorOf(Props(classOf[JobDAOActor], jobDAO), "dao-manager")
-      val dataManager = system.actorOf(Props(classOf[DataManagerActor],
-          new DataFileDAO(config)), "data-manager")
+      val dataManager = system.actorOf(DataManagerActor.props(new DataFileDAO(config)), "data-manager")
       val binManager = system.actorOf(Props(classOf[BinaryManager], daoActor), "binary-manager")
       val supervisor =
         system.actorOf(Props(
@@ -78,7 +77,7 @@ object JobServer {
           } else {
             classOf[LocalContextSupervisorActor]
           },
-          daoActor), "context-supervisor")
+          daoActor, dataManager), "context-supervisor")
       val jobInfo = system.actorOf(Props(classOf[JobInfoActor], jobDAO, supervisor), "job-info")
 
       // Add initial job JARs, if specified in configuration.

--- a/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
@@ -72,7 +72,7 @@ object ContextSupervisor {
  *   }
  * }}}
  */
-class LocalContextSupervisorActor(dao: ActorRef) extends InstrumentedActor {
+class LocalContextSupervisorActor(dao: ActorRef, dataManagerActor: ActorRef) extends InstrumentedActor {
   import ContextSupervisor._
   import scala.collection.JavaConverters._
   import scala.concurrent.duration._
@@ -201,7 +201,7 @@ class LocalContextSupervisorActor(dao: ActorRef) extends InstrumentedActor {
                        ).withFallback(contextConfig)
     val ref = context.actorOf(JobManagerActor.props(mergedConfig, dao), name)
     (ref ? JobManagerActor.Initialize(
-      resultActorRef))(Timeout(timeoutSecs.second)).onComplete {
+      resultActorRef, dataManagerActor))(Timeout(timeoutSecs.second)).onComplete {
       case Failure(e: Exception) =>
         logger.error("Exception after sending Initialize to JobManagerActor", e)
         // Make sure we try to shut down the context in case it gets created anyways

--- a/job-server/src/main/scala/spark/jobserver/io/DataFileDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/DataFileDAO.scala
@@ -2,6 +2,7 @@ package spark.jobserver.io
 
 import com.typesafe.config._
 import java.io._
+import java.nio.file.Files
 
 import org.apache.commons.io.FileUtils
 import org.joda.time.DateTime
@@ -98,6 +99,16 @@ class DataFileDAO(config: Config) {
     out.writeLong(aInfo.uploadTime.getMillis)
   }
 
+  def readFile(aName: String): Array[Byte] = {
+    if (aName.startsWith(rootDir) && files.contains(aName)) {
+      // only read the file if it is known to this class,
+      // otherwise this could be abused
+      Files.readAllBytes(new File(aName).toPath)
+    } else {
+      throw new IOException("Unknown file: " + aName)
+    }
+  }
+
   def deleteAll(): Boolean = {
     try {
       FileUtils.deleteDirectory(new File(rootDir))
@@ -111,7 +122,6 @@ class DataFileDAO(config: Config) {
       }
     }
   }
-
 
   def deleteFile(aName: String): Boolean = {
     if (aName.startsWith(rootDir) && files.contains(aName)) {

--- a/job-server/src/main/scala/spark/jobserver/io/RemoteFileCache.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/RemoteFileCache.scala
@@ -1,0 +1,58 @@
+package spark.jobserver.io
+
+import java.io.{File, IOException}
+import java.nio.file.{Files, Paths, StandardOpenOption}
+
+import akka.actor.{ActorRef, ActorSystem, Props}
+import akka.pattern.ask
+import akka.util.Timeout
+import org.slf4j.LoggerFactory
+import spark.jobserver.common.akka.InstrumentedActor
+import spark.jobserver.DataManagerActor.{Data, DeleteData, Error, RetrieveData}
+import scala.collection.mutable
+import scala.util.{Success, Failure}
+import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.duration._
+
+/**
+ * Requests data files from data manager if local files are not existing and caches them as local tmp file.
+ */
+class RemoteFileCache(jobManager: ActorRef, dataManager: ActorRef) {
+  private val logger = LoggerFactory.getLogger(getClass)
+  private val cachedFiles = mutable.HashMap.empty[String, File]
+  implicit val askTimeout: Timeout = Timeout(60 seconds)
+
+  @throws(classOf[IOException])
+  def getDataFile(filename: String): File = {
+    val filePath = Paths.get(filename)
+
+    if (Files exists filePath) {
+      filePath.toFile
+
+    } else if (cachedFiles contains filename) {
+      cachedFiles(filename)
+
+    } else {
+      logger.info("Local data file not found, fetching file from remote actor: {}", filename)
+
+      Await.result((dataManager ? RetrieveData(filename, jobManager)), askTimeout.duration) match {
+        case Data(data) =>
+          val tmpFile = File.createTempFile("remote-file-cache-", ".dat")
+          Files.write(tmpFile.toPath, data, StandardOpenOption.SYNC)
+          cachedFiles += (filename -> tmpFile)
+
+        case Error(msg) =>
+          throw new IOException(msg)
+      }
+
+      cachedFiles(filename)
+    }
+  }
+
+  def deleteDataFile(name: String) {
+    cachedFiles.remove(name).map { file =>
+      logger.info("Removing local copy of {}", name)
+      file.delete
+    }
+  }
+}

--- a/job-server/src/test/scala/spark/jobserver/DataManagerActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/DataManagerActorSpec.scala
@@ -1,9 +1,9 @@
 package spark.jobserver
 
 import akka.actor.{ActorRef, ActorSystem, Props}
-import akka.testkit.{ImplicitSender, TestKit}
+import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
-import java.nio.file.Files
+import java.nio.file.{Files, Paths}
 
 import spark.jobserver.common.akka
 import spark.jobserver.common.akka.AkkaTestUtils
@@ -27,13 +27,19 @@ class DataManagerActorSpec extends TestKit(DataManagerActorSpec.system) with Imp
   override def afterAll() {
     dao.shutdown()
     AkkaTestUtils.shutdownAndWait(actor)
+    AkkaTestUtils.shutdownAndWait(brokenDaoActor)
     akka.AkkaTestUtils.shutdownAndWait(DataManagerActorSpec.system)
-    Files.delete(tmpDir.resolve(DataFileDAO.META_DATA_FILE_NAME))
+    Files.deleteIfExists(tmpDir.resolve(DataFileDAO.META_DATA_FILE_NAME))
     Files.delete(tmpDir)
   }
 
   val dao: DataFileDAO = new DataFileDAO(config)
-  val actor: ActorRef = system.actorOf(Props(classOf[DataManagerActor], dao), "data-manager")
+  val actor: ActorRef = system.actorOf(DataManagerActor.props(dao), "data-manager")
+
+  val brokenDAO: DataFileDAO = new DataFileDAO(config) {
+    override def deleteAll(): Boolean = false
+  }
+  val brokenDaoActor: ActorRef = system.actorOf(DataManagerActor.props(brokenDAO), "broken-dao-data-manager")
 
   describe("DataManagerActor") {
     it("should store, list and delete tmp data file") {
@@ -77,5 +83,77 @@ class DataManagerActorSpec extends TestKit(DataManagerActorSpec.system) with Imp
       dao.listFiles should equal(Set())
     }
 
+    it("should store and delete all files") {
+      actor ! StoreData("test-file-1", bytes)
+      val firstFileName = expectMsgPF() { case Stored(name) => name }
+      val firstFile = Paths.get(firstFileName)
+      Files.exists(firstFile) should be (true)
+
+      actor ! StoreData("test-file-2", bytes)
+      val secondFileName = expectMsgPF() { case Stored(name) => name }
+      val secondFile = Paths.get(secondFileName)
+      Files.exists(secondFile) should be (true)
+
+      actor ! DeleteAllData
+      expectMsg(Deleted)
+      Files.exists(firstFile) should be (false)
+      Files.exists(secondFile) should be (false)
+    }
+
+    it("should provide files and notify job manager on delete") {
+      val fileName = System.currentTimeMillis + "tmpFile"
+
+      actor ! StoreData(fileName, bytes)
+      val storedFileName = expectMsgPF() {
+        case Stored(name) => name
+      }
+
+      val dummyJobManager = TestProbe()
+      actor ! RetrieveData(storedFileName, dummyJobManager.ref)
+      val retrievedData = expectMsgPF() {
+        case Data(data) => data
+      }
+      retrievedData should equal (bytes)
+
+      actor ! DeleteData(storedFileName)
+      expectMsg(Deleted)
+      dummyJobManager.expectMsg(JobManagerActor.DeleteData(storedFileName))
+    }
+
+    it("removes remote cached files on delete all") {
+      val fileName = System.currentTimeMillis + "tmpFile"
+
+      actor ! StoreData(fileName, bytes)
+      val storedFileName = expectMsgPF() {
+        case Stored(name) => name
+      }
+
+      val dummyJobManager = TestProbe()
+      actor ! RetrieveData(storedFileName, dummyJobManager.ref)
+      val retrievedData = expectMsgPF() {
+        case Data(data) => data
+      }
+      retrievedData should equal (bytes)
+
+      actor ! DeleteAllData
+      expectMsg(Deleted)
+      dummyJobManager.expectMsg(JobManagerActor.DeleteData(storedFileName))
+    }
+
+    it("should fail to read unknown files") {
+      val dummyJobManager = TestProbe()
+      actor ! RetrieveData("unknown-file", dummyJobManager.ref)
+      expectMsgClass(classOf[Error])
+    }
+
+    it("should fail to delete unknown files") {
+      actor ! DeleteData("unknown-file")
+      expectMsgClass(classOf[Error])
+    }
+
+    it("should handle errors in delete all") {
+      brokenDaoActor ! DeleteAllData
+      expectMsgClass(classOf[Error])
+    }
   }
 }

--- a/job-server/src/test/scala/spark/jobserver/JavaJobSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JavaJobSpec.scala
@@ -56,7 +56,7 @@ class JavaJobSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
 
   describe("Running Java Jobs") {
     it("Should run a java job") {
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
       uploadTestJar()
       manager ! JobManagerActor.StartJob("demo", javaJob, config, syncEvents ++ errorEvents)
@@ -65,7 +65,7 @@ class JavaJobSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
       }
     }
     it("Should fail running this java job"){
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
       uploadTestJar()
       manager ! JobManagerActor.StartJob("demo", failedJob, config, errorEvents)

--- a/job-server/src/test/scala/spark/jobserver/JobInfoActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobInfoActorSpec.scala
@@ -33,11 +33,13 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
   var actor: ActorRef = _
   var dao: JobDAO = _
   var daoActor: ActorRef = _
+  var dataManager: ActorRef = _
 
   before {
     dao = new InMemoryDAO
     daoActor = system.actorOf(JobDAOActor.props(dao))
-    val supervisor = system.actorOf(Props(classOf[LocalContextSupervisorActor], daoActor))
+    dataManager = system.actorOf(Props.empty)
+    val supervisor = system.actorOf(Props(classOf[LocalContextSupervisorActor], daoActor, dataManager))
     actor = system.actorOf(Props(classOf[JobInfoActor], dao, supervisor))
   }
 

--- a/job-server/src/test/scala/spark/jobserver/JobManagerActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobManagerActorSpec.scala
@@ -1,8 +1,15 @@
 package spark.jobserver
 
+import java.io.File
+import java.nio.file.{Files, StandardOpenOption}
+
+import com.typesafe.config.ConfigFactory
 import spark.jobserver.CommonMessages.{JobErroredOut, JobResult}
+import spark.jobserver.DataManagerActor.RetrieveData
 import spark.jobserver.common.akka.AkkaTestUtils
 import spark.jobserver.io.JobDAOActor
+
+import scala.concurrent.Await
 
 class JobManagerActorSpec extends JobManagerSpec {
   import scala.concurrent.duration._
@@ -21,7 +28,7 @@ class JobManagerActorSpec extends JobManagerSpec {
 
   describe("starting jobs") {
     it("jobs should be able to cache RDDs and retrieve them through getPersistentRDDs") {
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -36,8 +43,8 @@ class JobManagerActorSpec extends JobManagerSpec {
       sum2 should equal (sum)
     }
 
-    it ("jobs should be able to cache and retrieve RDDs by name") {
-      manager ! JobManagerActor.Initialize(None)
+    it("jobs should be able to cache and retrieve RDDs by name") {
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -47,6 +54,80 @@ class JobManagerActorSpec extends JobManagerSpec {
         case JobResult(_, sum: Int) => sum should equal (1 + 4 + 9 + 16 + 25)
         case JobErroredOut(_, _, error: Throwable) => throw error
       }
+    }
+  }
+
+  describe("remote file cache") {
+    it("should support local copy, fetch from remote and cache file") {
+      val testData = "test-data".getBytes
+      val dataFileActor = TestProbe()
+
+      manager ! JobManagerActor.Initialize(None, dataFileActor.ref)
+      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+      uploadTestJar()
+
+      // use already existing file
+      val existingFile = File.createTempFile("test-existing-file-", ".dat")
+      Files.write(existingFile.toPath, testData, StandardOpenOption.SYNC)
+      manager ! JobManagerActor.StartJob("demo", classPrefix + "RemoteDataFileJob",
+        ConfigFactory.parseString(s"testFile = ${existingFile.getAbsolutePath}"),
+        errorEvents ++ syncEvents)
+      dataFileActor.expectNoMsg()
+      val existingFileResult = expectMsgPF() {
+        case JobResult(_, fileName: String) => fileName
+        case JobErroredOut(_, _, error: Throwable) => throw error
+      }
+      existingFileResult should equal (existingFile.getAbsolutePath)
+
+      // downloads new file from data file manager
+      val jobConfig = ConfigFactory.parseString("testFile = test-file")
+      manager ! JobManagerActor.StartJob("demo", classPrefix + "RemoteDataFileJob", jobConfig,
+        errorEvents ++ syncEvents)
+      dataFileActor.expectMsgPF() {
+        case RetrieveData(fileName, jobManager) => {
+          fileName should equal ("test-file")
+          jobManager should equal (manager)
+        }
+      }
+      dataFileActor.reply(DataManagerActor.Data("test-data".getBytes))
+      val cachedFile = expectMsgPF() {
+        case JobResult(_, fileName: String) => fileName
+        case JobErroredOut(_, _, error: Throwable) => throw error
+      }
+      val cachedFilePath = new File(cachedFile).toPath
+      Files.exists(cachedFilePath) should equal (true)
+      Files.readAllBytes(cachedFilePath) should equal ("test-data".getBytes)
+
+      // uses cached version in second run
+      manager ! JobManagerActor.StartJob("demo", classPrefix + "RemoteDataFileJob", jobConfig,
+        errorEvents ++ syncEvents)
+      dataFileActor.expectNoMsg() // already cached
+      val secondResult = expectMsgPF() {
+        case JobResult(_, fileName: String) => fileName
+        case JobErroredOut(_, _, error: Throwable) => throw error
+      }
+      cachedFile should equal (secondResult)
+
+      manager ! JobManagerActor.DeleteData("test-file") // cleanup
+    }
+
+    it("should fail if remote data file does not exists") {
+      val testData = "test-data".getBytes
+      val dataFileActor = TestProbe()
+
+      manager ! JobManagerActor.Initialize(None, dataFileActor.ref)
+      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+      uploadTestJar()
+
+      val jobConfig = ConfigFactory.parseString("testFile = test-file")
+      manager ! JobManagerActor.StartJob("demo", classPrefix + "RemoteDataFileJob", jobConfig,
+        errorEvents ++ syncEvents)
+
+      // return error from file manager
+      dataFileActor.expectMsgClass(classOf[RetrieveData])
+      dataFileActor.reply(DataManagerActor.Error("test"))
+
+      expectMsgClass(classOf[JobErroredOut])
     }
   }
 }

--- a/job-server/src/test/scala/spark/jobserver/JobManagerSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobManagerSpec.scala
@@ -31,7 +31,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
   describe("error conditions") {
     it("should return errors if appName does not match") {
       uploadTestJar()
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
       manager ! JobManagerActor.StartJob("demo2", wordCountClass, emptyConfig, Set.empty[Class[_]])
       expectMsg(startJobWait, CommonMessages.NoSuchApplication)
@@ -39,7 +39,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
 
     it("should return error message if classPath does not match") {
       uploadTestJar()
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
       manager ! JobManagerActor.StartJob("demo", "no.such.class", emptyConfig, Set.empty[Class[_]])
       expectMsg(startJobWait, CommonMessages.NoSuchClass)
@@ -47,14 +47,14 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
 
     it("should error out if loading garbage jar") {
       uploadBinary(dao, "../README.md", "notajar", BinaryType.Jar)
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
       manager ! JobManagerActor.StartJob("notajar", "no.such.class", emptyConfig, Set.empty[Class[_]])
       expectMsg(startJobWait, CommonMessages.NoSuchClass)
     }
 
     it("should error out if job validation fails") {
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -64,7 +64,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
     }
 
     it("should error out if new API job validation fails") {
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -76,7 +76,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
 
   describe("starting jobs") {
     it("should start job and return result successfully (all events)") {
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -87,7 +87,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
     }
 
     it("should start job and return result before job finish event") {
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -99,7 +99,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
     }
 
     it("should start job more than one time and return result successfully (all events)") {
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -116,7 +116,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
     }
 
     it("should start job and return results (sync route)") {
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -128,7 +128,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
     }
 
     it("should start NewAPI job and return results (sync route)") {
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -140,7 +140,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
     }
 
     it("should start job and return JobStarted (async)") {
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -150,7 +150,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
     }
 
     it("should return error if job throws an error") {
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -161,7 +161,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
 
     it("job should get jobConfig passed in to StartJob message") {
       val jobConfig = ConfigFactory.parseString("foo.bar.baz = 3")
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -174,7 +174,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
     }
 
     it("should properly serialize case classes and other job jar classes") {
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -192,7 +192,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
       val jobSleepTimeMillis = 2000L
       val jobConfig = ConfigFactory.parseString("sleep.time.millis = " + jobSleepTimeMillis)
 
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -224,7 +224,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
     }
 
     it("should start a job that's an object rather than class") {
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -236,7 +236,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
     }
 
     it("should be able to cancel running job") {
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -252,7 +252,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
     }
 
     it("should fail a job that requires job jar dependencies but doesn't provide the jar"){
-      manager ! JobManagerActor.Initialize(None)
+      manager ! JobManagerActor.Initialize(None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()

--- a/job-server/src/test/scala/spark/jobserver/JobSpecBase.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobSpecBase.scala
@@ -1,6 +1,6 @@
 package spark.jobserver
 
-import akka.actor.{ActorRef, ActorSystem}
+import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.testkit.ImplicitSender
 import akka.testkit.TestKit
 import com.typesafe.config.{Config, ConfigFactory}
@@ -61,6 +61,7 @@ abstract class JobSpecBaseBase(system: ActorSystem) extends TestKit(system) with
 with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
   var dao: JobDAO = _
   var daoActor: ActorRef = _
+  val emptyActor = system.actorOf(Props.empty)
   var manager: ActorRef = _
   def testJar: java.io.File
   def testEgg: java.io.File

--- a/job-server/src/test/scala/spark/jobserver/LocalContextSupervisorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/LocalContextSupervisorSpec.scala
@@ -60,6 +60,7 @@ class LocalContextSupervisorSpec extends TestKit(LocalContextSupervisorSpec.syst
 
   var supervisor: ActorRef = _
   var daoProbe: TestProbe = _
+  var dataManager: ActorRef = _
 
   val contextConfig = LocalContextSupervisorSpec.config.getConfig("spark.context-settings")
 
@@ -68,7 +69,8 @@ class LocalContextSupervisorSpec extends TestKit(LocalContextSupervisorSpec.syst
 
   before {
     daoProbe = TestProbe()
-    supervisor = system.actorOf(Props(classOf[LocalContextSupervisorActor], daoProbe.ref))
+    dataManager = system.actorOf(Props.empty)
+    supervisor = system.actorOf(Props(classOf[LocalContextSupervisorActor], daoProbe.ref, dataManager))
   }
 
   after {


### PR DESCRIPTION
**Current behavior :**
Files uploaded via Data API (`/data`) are stored on the host running the REST frontend and can't simple accessed by driver instances on other hosts in the cluster.

**New behavior :**
Files can now accessed via `JobEnvironment` and are transferred via akka:
```scala
  def runJob(sc: SparkContext, runtime: JobEnvironment, input: JobData): JobOutput = {
    runtime match {
      case remote: DataFileCache => remote.getDataFile("...")
      case local => Files.read.. // job does not support remote files
    }
```
Local copies are removed on jvm/context shutdown and on file delete against the REST API.

**BREAKING CHANGES**
No public interfaces changed. Jobs compiled against older job server version should work without any changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/924)
<!-- Reviewable:end -->
