### PR TITLE
Add cluster support and transfer context conf via akka

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ spark-jobserver provides a RESTful interface for submitting and managing [Apache
 This repo contains the complete Spark job server project, including unit tests and deploy scripts.
 It was originally started at [Ooyala](http://www.ooyala.com), but this is now the main development repo.
 
-Other useful links: [Troubleshooting Tips](doc/troubleshooting.md), [Yarn tips](doc/yarn.md), [Mesos tips](doc/mesos.md), [JMX tips](doc/jmx.md).
+Other useful links: [Troubleshooting](doc/troubleshooting.md), [cluster](doc/cluster.md), [YARN client](doc/yarn.md), [YARN on EMR](doc/EMR.md), [Mesos](doc/mesos.md), [JMX tips](doc/jmx.md).
 
 Also see [Chinese docs / 中文](doc/chinese/job-server.md).
 
@@ -100,7 +100,7 @@ Spark Job Server is now included in Datastax Enterprise 4.8!
 - Kill running jobs via stop context and delete job
 - Separate jar uploading step for faster job startup
 - Asynchronous and synchronous job API.  Synchronous API is great for low latency jobs!
-- Works with Standalone Spark as well as Mesos and yarn-client
+- Works with Standalone Spark as well on [cluster](doc/cluster.md), [Mesos](doc/mesos.md), YARN [client](doc/yarn.md) and [on EMR](doc/EMR.md))
 - Job and jar info is persisted via a pluggable DAO interface
 - Named Objects (such as RDDs or DataFrames) to cache and retrieve RDDs or DataFrames by name, improving object sharing and reuse among jobs.
 - Supports Scala 2.10 and 2.11
@@ -554,6 +554,8 @@ curl -k --basic --user 'user:pw' https://localhost:8090/contexts
 
 ## Deployment
 
+See also running on [cluster](doc/cluster.md), [YARN client](doc/yarn.md), on [EMR](doc/EMR.md) and running on [Mesos](doc/mesos.md).
+
 ### Manual steps
 
 1. Copy `config/local.sh.template` to `<environment>.sh` and edit as appropriate.  NOTE: be sure to set SPARK_VERSION if you need to compile against a different version.
@@ -891,8 +893,6 @@ To add to the underlying Hadoop configuration in a Spark context, add the hadoop
     }
 
 For the exact context configuration parameters, see JobManagerActor docs as well as application.conf.
-
-Also see the [yarn doc](doc/yarn.md) for more tips.
 
 ### Other configuration settings
 

--- a/bin/manager_start.sh
+++ b/bin/manager_start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Script to start the job manager
-# args: <work dir for context> <cluster address> [proxy_user]
+# args: <master> <deployMode> <akkaAdress> <actorName> <workDir> [<proxyUser>]
 set -e
 
 get_abs_script_path() {
@@ -13,12 +13,8 @@ get_abs_script_path
 
 . $appdir/setenv.sh
 
-# Override logging options to provide per-context logging
-LOGGING_OPTS="-Dlog4j.configuration=file:$appdir/log4j-server.properties
-              -DLOG_DIR=$2"
-
 GC_OPTS="-XX:+UseConcMarkSweepGC
-         -verbose:gc -XX:+PrintGCTimeStamps -Xloggc:$appdir/gc.out
+         -verbose:gc -XX:+PrintGCTimeStamps
          -XX:MaxPermSize=512m
          -XX:+CMSClassUnloadingEnabled "
 
@@ -27,26 +23,46 @@ JAVA_OPTS="-XX:MaxDirectMemorySize=$MAX_DIRECT_MEMORY
 
 MAIN="spark.jobserver.JobManager"
 
-MESOS_OPTS=""
-if [ $1 == "mesos-cluster" ]; then
-    MESOS_OPTS="--master $MESOS_SPARK_DISPATCHER --deploy-mode cluster"
-    appdir=$REMOTE_JOBSERVER_DIR
-fi
+# copy files via spark-submit and read them from current (container) dir
+if [ $2 = "cluster" -a -z "$REMOTE_JOBSERVER_DIR" ]; then
+  SPARK_SUBMIT_OPTIONS="$SPARK_SUBMIT_OPTIONS
+    --master $1 --deploy-mode cluster
+    --conf spark.yarn.submit.waitAppCompletion=false
+    --files $appdir/log4j-cluster.properties,$conffile"
+  JAR_FILE="$appdir/spark-job-server.jar"
+  CONF_FILE=$(basename $conffile)
+  LOGGING_OPTS="-Dlog4j.configuration=log4j-cluster.properties"
 
-if [ ! -z $5 ]; then
-  cmd='$SPARK_HOME/bin/spark-submit --class $MAIN --driver-memory $JOBSERVER_MEMORY
-  --conf "spark.executor.extraJavaOptions=$LOGGING_OPTS"
-  --proxy-user $5
-  $MESOS_OPTS
-  --driver-java-options "$GC_OPTS $JAVA_OPTS $LOGGING_OPTS $CONFIG_OVERRIDES"
-  $appdir/spark-job-server.jar $2 $3 $4 $conffile'
+# use files in REMOTE_JOBSERVER_DIR
+elif [ $2 == "cluster" ]; then
+  SPARK_SUBMIT_OPTIONS="$SPARK_SUBMIT_OPTIONS
+    --master $1 --deploy-mode cluster
+    --conf spark.yarn.submit.waitAppCompletion=false"
+  JAR_FILE="$REMOTE_JOBSERVER_DIR/spark-job-server.jar"
+  CONF_FILE="$REMOTE_JOBSERVER_DIR/$(basename $conffile)"
+  LOGGING_OPTS="-Dlog4j.configuration=$REMOTE_JOBSERVER_DIR/log4j-cluster.properties"
+
+# client mode, use files from app dir
 else
-  cmd='$SPARK_HOME/bin/spark-submit --class $MAIN --driver-memory $JOBSERVER_MEMORY
-  --conf "spark.executor.extraJavaOptions=$LOGGING_OPTS"
-  --driver-java-options "$GC_OPTS $JAVA_OPTS $LOGGING_OPTS $CONFIG_OVERRIDES"
-  $MESOS_OPTS
-  $appdir/spark-job-server.jar $2 $3 $4 $conffile'
+  JAR_FILE="$appdir/spark-job-server.jar"
+  CONF_FILE="$conffile"
+  LOGGING_OPTS="-Dlog4j.configuration=file:$appdir/log4j-server.properties -DLOG_DIR=$5"
+  GC_OPTS="$GC_OPTS -Xloggc:$5/gc.out"
 fi
 
-eval $cmd
+if [ -n "$6" ]; then
+  SPARK_SUBMIT_OPTIONS="$SPARK_SUBMIT_OPTIONS --proxy-user $6"
+fi
+
+if [ -n "$JOBSERVER_KEYTAB" ]; then
+  SPARK_SUBMIT_OPTIONS="$SPARK_SUBMIT_OPTIONS --keytab $JOBSERVER_KEYTAB"
+fi
+
+cmd='$SPARK_HOME/bin/spark-submit --class $MAIN --driver-memory $JOBSERVER_MEMORY
+      --conf "spark.executor.extraJavaOptions=$LOGGING_OPTS"
+      $SPARK_SUBMIT_OPTIONS
+      --driver-java-options "$GC_OPTS $JAVA_OPTS $LOGGING_OPTS $CONFIG_OVERRIDES $SPARK_SUBMIT_JAVA_OPTIONS"
+      $JAR_FILE $3 $4 $CONF_FILE'
+
+eval $cmd 2>&1 > $5/spark-job-server.out
 

--- a/bin/server_package.sh
+++ b/bin/server_package.sh
@@ -51,6 +51,7 @@ pushd "${bin}/.." > /dev/null
          bin/setenv.sh
          ${CONFIG_DIR}/${ENV}.conf
          config/shiro.ini
+         config/log4j-cluster.properties
          config/log4j-server.properties"
 
   rm -rf $WORK_DIR

--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,7 @@ lazy val jobServerTestJar = Project(id = "job-server-tests", base = file("job-se
   .settings(noPublishSettings)
   .dependsOn(jobServerApi)
   .disablePlugins(SbtScalariform)
+  .disablePlugins(ScoverageSbtPlugin) // do not include in coverage report
 
 lazy val jobServerApi = Project(id = "job-server-api", base = file("job-server-api"))
   .settings(commonSettings)
@@ -274,7 +275,7 @@ lazy val commonSettings = Defaults.coreDefaultSettings ++ dirSettings ++ implici
 
 lazy val scoverageSettings = {
   // Semicolon-separated list of regexs matching classes to exclude
-  coverageExcludedPackages := ".+Benchmark.*"
+  coverageExcludedPackages := ".+Benchmark.*;.+Example.*;.+TestJob"
 }
 
 lazy val publishSettings = Seq(

--- a/doc/EMR.md
+++ b/doc/EMR.md
@@ -1,5 +1,7 @@
 ## Step by step instruction on how to run Spark Job Server on EMR 4.2.0 (Spark 1.6.0)
 
+See also running in [cluster mode](cluster.md), running [YARN in client mode](yarn.md) and running on [Mesos](Mesos.md).
+
 ### Create EMR 4.2.0 cluster
 
 Create EMR cluster using AWS EMR console or aws cli.

--- a/doc/cluster.md
+++ b/doc/cluster.md
@@ -1,0 +1,66 @@
+## Configuring Job Server for YARN cluster mode
+
+See also running [YARN in client mode](yarn.md), running [YARN on EMR](EMR.md) and running on [Mesos](mesos.md).
+
+### Job Server configuration
+
+Add the following properties in your job server config file:
+- set `spark.master` property to `yarn`, `spark://...` or `mesos://...`
+- set `spark.submit.deployMode` property to `cluster`
+- set `spark.jobserver.context-per-jvm` to `true`
+- set `akka.remote.netty.tcp.hostname` to the cluster interface of the host running the frontend
+- set `akka.remote.netty.tcp.maximum-frame-size` to support big remote jars fetch
+
+Optional / required in spark standalone mode:
+- set `REMOTE_JOBSERVER_DIR` to `hdfs://...`, `file://...` or `http://...` in your settings `xxx.sh`
+- copy `spark-job-server.jar`, your job server config and `log4j-cluster.properties` file into this location
+
+Example job server config (replace `CLUSTER-IP` with the internal IP of the host running the job server frontend):
+
+    spark {
+      # deploy in yarn cluster mode
+      master = yarn
+      submit.deployMode = cluster
+
+      jobserver {
+        context-per-jvm = true
+
+        # start a H2 DB server, reachable in your cluster
+        sqldao {
+          jdbc {
+            url = "jdbc:h2:tcp://CLUSTER-IP:9092/h2-db;AUTO_RECONNECT=TRUE"
+          }
+        }
+        startH2Server = false
+      }
+    }
+
+    # start akka on this interface, reachable from your cluster
+    akka {
+      remote.netty.tcp {
+        hostname = "CLUSTER-IP"
+
+        # This controls the maximum message size, including job results, that can be sent
+        maximum-frame-size = 100 MiB
+      }
+    }
+
+Note:
+- YARN transfers the files provided via `--files` submit option into the cluster / container. Spark standalone does not support this in cluster mode and you have to transfer them manual.
+- Instead of running a H2 DB instance you can also run a real DB reachable inside your cluster. You can't use the default (host only) H2 configuration in a cluster setup.
+- Akka binds by [default](../job-server/src/main/resources/application.conf) to the local host interface and is not reachable from the cluster. You need to configure the akka hostname to the cluster internal address.
+
+### Reading files uploaded via frontend
+
+Files uploaded via the data API (`/data`) are stored on your job server frontend host.
+Call the [DataFileCache](../job-server-api/src/main/scala/spark/jobserver/api/SparkJobBase.scala) API implemented by the job environment in your spark jobs to access them:
+
+```scala
+  object RemoteDriverExample extends NewSparkJob {
+    def runJob(sc: SparkContext, runtime: JobEnvironment, data: JobData): JobOutput =
+      runtime.getDataFile(...)
+```
+
+The job server transfers the files via akka to the host running your driver and caches them there.
+
+Note: Files uploaded via the JAR or binary API are stored and transfered via the Job DB.

--- a/doc/mesos.md
+++ b/doc/mesos.md
@@ -1,114 +1,64 @@
 ## Configuring Job Server for Mesos
 
+See also running on [cluster](cluster.md), YARN in [client mode](yarn.md) and running on [EMR](EMR.md).
+
 ### Mesos client mode
 
-Configuring job-server for Mesos cluster mode is straight forward. All you need to change is `spark.master` config to 
+Configuring job-server for Mesos client mode is straight forward. All you need to change is `spark.master` config to 
 point to Mesos master URL in job-server config file.
 
 Example config file (important settings are marked with # important):
 
     spark {
-      master =  <mesos master URL here> # important, example: mesos://mesos-master:5050
-    
-      # Default # of CPUs for jobs to use for Spark standalone cluster
-      job-number-cpus = 4
-
-      jobserver {
-        port = 8090
-        jobdao = spark.jobserver.io.JobSqlDAO
-
-        sqldao {
-          # Directory where default H2 driver stores its data. Only needed for H2.
-          rootdir = /database
-
-          # Full JDBC URL / init string.  Sorry, needs to match above.
-          # Substitutions may be used to launch job-server, but leave it out here in the default or tests won't pass
-          jdbc.url = "jdbc:h2:file:/database/h2-db"
-        }
-      }
-
-      # universal context configuration.  These settings can be overridden, see README.md
-      context-settings {
-        num-cpu-cores = 2           # Number of cores to allocate.  Required.
-        memory-per-node = 512m         # Executor memory per node, -Xmx style eg 512m, #1G, etc.
-      }
+      master = <mesos master URL here> # example: mesos://mesos-master:5050
     }
 
-### Mesos cluster Mode
+### Mesos cluster mode
 
 Configuring job-server for Mesos cluster mode is a bit tricky as compared to client mode.
 
-Here is the checklist for the changes needed for the same:
-
-- You need to start Mesos dispatcher in your cluster by running `./sbin/start-mesos-dispatcher.sh` available in 
+You need to start Mesos dispatcher in your cluster by running `./sbin/start-mesos-dispatcher.sh` available in 
 spark package. This step is not specific to job-server and as mentioned in [official spark documentation](https://spark.apache.org/docs/latest/running-on-mesos.html#cluster-mode) this is needed 
 to submit spark job in Mesos cluster mode. 
 
-- Add following config at the end of job-server's settings.sh file:
-    
-    ```
-    REMOTE_JOBSERVER_DIR=<path to job-server directory> # copy job-server directory on this location on all mesos agent nodes 
-    MESOS_SPARK_DISPATCHER=<mesos dispatcher URL> # example: mesos://mesos-dispatcher:7077
-    ```
+Add the following config to you job-server config file:
+- set `spark.master` property to messos dispatcher URL (example: `mesos://mesos-dispatcher:7077`)
+- set `spark.submit.deployMode` property to `cluster`
+- set `spark.jobserver.context-per-jvm` to `true`
+- set `akka.remote.netty.tcp.hostname` to the cluster interface of the host running the frontend
+- set `akka.remote.netty.tcp.maximum-frame-size` to support big remote jars fetch
 
-- Set `spark.jobserver.driver-mode` property to `mesos-cluster` in job-server config file.
-
-- Also override akka default configs in job-server config file to support big remote jars fetch, we have to set frame 
-size to some large value, for example:
-
-```
-akka.remote.netty.tcp {
-    # use remote IP address to form akka cluster, not 127.0.0.1. This should be the IP of of the machine where the file 
-    # resides. That means for each mesos agents (where job-server directory is copied on REMOTE_JOBSERVER_DIR path),
-    # the hostname should be the remote IP of that node.  
-    #  
-    hostname = "xxxxx" 
-    # This controls the maximum message size, including job results, that can be sent
-    maximum-frame-size = 104857600b
-}
-```
-
-- set `spark.master` to Mesos master URL (and not mesos-dispatcher URL).   
-
-- set `spark.jobserver.context-per-jvm` to `true` in job-server config file.
-
-Example config file (important settings are marked with # important):
+Example job server config (replace `CLUSTER-IP` with the internal IP of the host running the job server frontend):
 
     spark {
-      master =  <mesos master URL here> # important, example: mesos://mesos-master:5050
-    
-      # Default # of CPUs for jobs to use for Spark standalone cluster
-      job-number-cpus = 4
+      master =  <mesos dispatcher URL> # example: mesos://mesos-dispatcher:7077
+      submit.deployMode = cluster
 
       jobserver {
-        port = 8090
-        driver-mode = mesos-cluster  #important
-        context-per-jvm = true       #important
-        jobdao = spark.jobserver.io.JobSqlDAO
-        
+        context-per-jvm = true
+
+        # start a H2 DB server, reachable in your cluster
         sqldao {
-          # Directory where default H2 driver stores its data. Only needed for H2.
-          rootdir = /database
-
-          # Full JDBC URL / init string.  Sorry, needs to match above.
-          # Substitutions may be used to launch job-server, but leave it out here in the default or tests won't pass
-          jdbc.url = "jdbc:h2:file:/database/h2-db"
+          jdbc {
+            url = "jdbc:h2:tcp://CLUSTER-IP:9092/h2-db;AUTO_RECONNECT=TRUE"
+          }
         }
-      }
-
-      # universal context configuration.  These settings can be overridden, see README.md
-      context-settings {
-        num-cpu-cores = 2           # Number of cores to allocate.  Required.
-        memory-per-node = 512m         # Executor memory per node, -Xmx style eg 512m, #1G, etc.
+        startH2Server = false
       }
     }
     
-    akka.remote.netty.tcp {    
-        # use remote IP address to form akka cluster, not 127.0.0.1. This should be the IP of of the machine where the file 
-        # resides. That means for each mesos agents (where job-server directory is copied on REMOTE_JOBSERVER_DIR path),
-        # the hostname should be the remote IP of that node.  
-        #  
-        hostname = "xxxxx"    #important
+    # start akka on this interface, reachable from your cluster
+    akka {
+      remote.netty.tcp {
+        hostname = "CLUSTER-IP"
+
         # This controls the maximum message size, including job results, that can be sent
-        maximum-frame-size = 104857600b    #important
+        maximum-frame-size = 100 MiB
+      }
     }
+
+- Optional: Add following config at the end of job-server's settings.sh file:
+    
+    ```
+    REMOTE_JOBSERVER_DIR=<path to job-server directory> # copy of job-server directory on all mesos agent nodes 
+    ```

--- a/doc/yarn.md
+++ b/doc/yarn.md
@@ -1,10 +1,6 @@
-## Configuring Job Server for YARN
+## Configuring Job Server for YARN in client mode with docker
 
-(Looking for contributors for this page)
-
-(I would like to thank Jon Buffington for sharing the config tips below.... @velvia)
-
-Note:  This is for yarn with docker.  If you are looking to deploy on a yarn cluster via EMR, then this link would be more useful [EMR](https://github.com/spark-jobserver/spark-jobserver/blob/master/doc/EMR.md)
+See also running in [cluster mode](cluster.md), running [YARN on EMR](EMR.md) and running on [Mesos](mesos.md).
 
 ### Configuring the Spark-Jobserver Docker package to run in Yarn-Client Mode
 
@@ -19,11 +15,10 @@ Files we need:
 - dockerfile
 - cluster-config directory with hdfs-site.xml and yarn-site.xml (You should have these files already)
 
-Example docker.conf (important settings are marked with # important):
+Example docker.conf:
 
     spark {
-      master = "yarn-client" # important
-      master = ${?SPARK_MASTER}
+      master = yarn
     
       # Default # of CPUs for jobs to use for Spark standalone cluster
       job-number-cpus = 4

--- a/job-server-api/src/main/scala/spark/jobserver/util/SparkJobUtils.scala
+++ b/job-server-api/src/main/scala/spark/jobserver/util/SparkJobUtils.scala
@@ -130,7 +130,7 @@ object SparkJobUtils {
 
   private def getContextTimeout(config: Config, yarn : String, standalone : String): Int = {
     config.getString("spark.master") match {
-      case "yarn-client" =>
+      case "yarn" =>
         Try(config.getDuration(yarn,
               TimeUnit.MILLISECONDS).toInt / 1000).getOrElse(40)
       case _ =>

--- a/job-server-api/src/main/scala/spark/jobserver/util/SparkJobUtils.scala
+++ b/job-server-api/src/main/scala/spark/jobserver/util/SparkJobUtils.scala
@@ -82,11 +82,6 @@ object SparkJobUtils {
     // Set the Jetty port to 0 to find a random port
     conf.set("spark.ui.port", "0")
 
-    // Set spark broadcast factory in yarn-client mode
-    if (sparkMaster == "yarn-client") {
-      conf.set("spark.broadcast.factory", config.getString("spark.jobserver.yarn-broadcast-factory"))
-    }
-
     // Set number of akka threads
     // TODO: need to figure out how many extra threads spark needs, besides the job threads
     conf.set("spark.akka.threads", (getMaxRunningJobs(config) + 4).toString)

--- a/job-server-api/src/test/scala/util/SparkJobUtilsSpec.scala
+++ b/job-server-api/src/test/scala/util/SparkJobUtilsSpec.scala
@@ -46,18 +46,18 @@ class SparkJobUtilsSpec extends FunSpec with Matchers {
       SparkJobUtils.getContextCreationTimeout(config) should equal (15)
     }
 
-    it("should read contextCreationTimeout for yarn-client mode") {
+    it("should read contextCreationTimeout for yarn mode") {
       val config = ConfigFactory.parseMap(Map(
-        "spark.master" -> "yarn-client",
+        "spark.master" -> "yarn",
         "spark.jobserver.yarn-context-creation-timeout" -> 20000,
         "spark.jobserver.context-creation-timeout" -> 10000
       ).asJava)
       SparkJobUtils.getContextCreationTimeout(config) should equal (20)
     }
 
-    it("should read default contextCreationTimeout for yarn-client mode") {
+    it("should read default contextCreationTimeout for yarn mode") {
       val config = ConfigFactory.parseMap(Map(
-        "spark.master" -> "yarn-client"
+        "spark.master" -> "yarn"
       ).asJava)
       SparkJobUtils.getContextCreationTimeout(config) should equal (40)
     }
@@ -78,18 +78,18 @@ class SparkJobUtilsSpec extends FunSpec with Matchers {
       SparkJobUtils.getContextDeletionTimeout(config) should equal (15)
     }
 
-    it("should read contextDeletionTimeout for yarn-client mode") {
+    it("should read contextDeletionTimeout for yarn mode") {
       val config = ConfigFactory.parseMap(Map(
-        "spark.master" -> "yarn-client",
+        "spark.master" -> "yarn",
         "spark.jobserver.yarn-context-deletion-timeout" -> 20000,
         "spark.jobserver.context-deletion-timeout" -> 10000
       ).asJava)
       SparkJobUtils.getContextDeletionTimeout(config) should equal (20)
     }
 
-    it("should read default contextDeletionTimeout for yarn-client mode") {
+    it("should read default contextDeletionTimeout for yarn mode") {
       val config = ConfigFactory.parseMap(Map(
-        "spark.master" -> "yarn-client"
+        "spark.master" -> "yarn"
       ).asJava)
       SparkJobUtils.getContextDeletionTimeout(config) should equal (40)
     }

--- a/job-server-extras/src/main/scala/spark/jobserver/SessionTestJob.scala
+++ b/job-server-extras/src/main/scala/spark/jobserver/SessionTestJob.scala
@@ -10,7 +10,7 @@ import spark.jobserver.api.{JobEnvironment, ValidationProblem}
   * Initializes some dummy data into a table, reads it back out, and returns a count.
   * Will create Hive metastore at job-server/metastore_db if Hive isn't configured.
   */
-object SessionLoaderJob extends SparkSessionJob {
+object SessionLoaderTestJob extends SparkSessionJob {
   // The following data is stored at ./hive_test_job_addresses.txt
   // val addresses = Seq(
   //   Address("Bob", "Charles", "101 A St.", "San Jose"),

--- a/job-server-extras/src/main/scala/spark/jobserver/StreamingTestJob.scala
+++ b/job-server-extras/src/main/scala/spark/jobserver/StreamingTestJob.scala
@@ -19,7 +19,12 @@ object StreamingTestJob extends SparkStreamingJob {
     val words = lines.flatMap(_.split(" "))
     val wordCounts = words.countByValue()
     //do something
-    wordCounts.foreachRDD(rdd => println(rdd.count()))
+    wordCounts.foreachRDD(rdd =>
+      try {
+        println(rdd.count())
+      } catch {
+        case _: InterruptedException => {}
+      })
     ssc.start()
     ssc.awaitTermination()
   }

--- a/job-server-extras/src/test/scala/spark/jobserver/JavaSessionSpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/JavaSessionSpec.scala
@@ -48,18 +48,17 @@ class JavaSessionSpec extends ExtrasJobSpecBase(JavaSessionSpec.getNewSystem) {
   val queryConfig = ConfigFactory.parseString(
     """sql = "SELECT firstName, lastName FROM `default`.`test_addresses` WHERE city = 'San Jose'" """
   )
+  lazy val cfg = JavaSessionSpec.getContextConfig(false, JavaSessionSpec.contextConfig)
 
   before {
     dao = new InMemoryDAO
     daoActor = system.actorOf(JobDAOActor.props(dao))
-    manager = system.actorOf(JobManagerActor.props(
-      JavaSessionSpec.getContextConfig(false, JavaSessionSpec.contextConfig),
-      daoActor))
+    manager = system.actorOf(JobManagerActor.props(daoActor))
   }
 
   describe("Java Session Jobs") {
     it("should be able to create a Hive table, then query it using separate Spark-SQL jobs") {
-      manager ! JobManagerActor.Initialize(None, emptyActor)
+      manager ! JobManagerActor.Initialize(cfg, None, emptyActor)
       expectMsgClass(30 seconds, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()

--- a/job-server-extras/src/test/scala/spark/jobserver/JavaStreamingSpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/JavaStreamingSpec.scala
@@ -26,13 +26,13 @@ class JavaStreamingSpec extends ExtrasJobSpecBase(JavaStreamingSpec.getNewSystem
   before {
     dao = new InMemoryDAO
     daoActor = system.actorOf(JobDAOActor.props(dao))
-    manager = system.actorOf(JobManagerActor.props(cfg, daoActor))
+    manager = system.actorOf(JobManagerActor.props(daoActor))
     supervisor = TestProbe().ref
   }
 
   describe("Running Java based Streaming Jobs") {
     it("Should return Correct results") {
-      manager ! JobManagerActor.Initialize(None, emptyActor)
+      manager ! JobManagerActor.Initialize(cfg, None, emptyActor)
       expectMsgClass(10 seconds, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()

--- a/job-server-extras/src/test/scala/spark/jobserver/JavaStreamingSpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/JavaStreamingSpec.scala
@@ -1,6 +1,7 @@
 package spark.jobserver
 
 import akka.actor._
+import akka.pattern._
 import akka.testkit._
 import com.typesafe.config.ConfigFactory
 import spark.jobserver.CommonMessages._
@@ -28,6 +29,10 @@ class JavaStreamingSpec extends ExtrasJobSpecBase(JavaStreamingSpec.getNewSystem
     daoActor = system.actorOf(JobDAOActor.props(dao))
     manager = system.actorOf(JobManagerActor.props(daoActor))
     supervisor = TestProbe().ref
+  }
+
+  after {
+    Await.result(gracefulStop(manager, 5 seconds), 5 seconds) // stop context
   }
 
   describe("Running Java based Streaming Jobs") {

--- a/job-server-extras/src/test/scala/spark/jobserver/NamedObjectsJobSpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/NamedObjectsJobSpec.scala
@@ -8,15 +8,15 @@ import spark.jobserver.io.JobDAOActor
 class NamedObjectsJobSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
   import scala.concurrent.duration._
 
+  lazy val cfg = JobManagerSpec.getContextConfig(adhoc = false)
+
   override def beforeAll() {
     dao = new InMemoryDAO
     daoActor = system.actorOf(JobDAOActor.props(dao))
-    manager = system.actorOf(JobManagerActor.props(
-      JobManagerSpec.getContextConfig(adhoc = false),
-      daoActor))
+    manager = system.actorOf(JobManagerActor.props(daoActor))
     supervisor = TestProbe().ref
 
-    manager ! JobManagerActor.Initialize(None, emptyActor)
+    manager ! JobManagerActor.Initialize(cfg, None, emptyActor)
 
     expectMsgClass(10.seconds, classOf[JobManagerActor.Initialized])
 

--- a/job-server-extras/src/test/scala/spark/jobserver/NamedObjectsJobSpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/NamedObjectsJobSpec.scala
@@ -5,10 +5,10 @@ import akka.testkit.TestProbe
 import spark.jobserver.CommonMessages.JobResult
 import spark.jobserver.io.JobDAOActor
 
-class NamedObjectsJobSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
+class NamedObjectsJobSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) {
   import scala.concurrent.duration._
 
-  lazy val cfg = JobManagerSpec.getContextConfig(adhoc = false)
+  lazy val cfg = JobManagerActorSpec.getContextConfig(adhoc = false)
 
   override def beforeAll() {
     dao = new InMemoryDAO

--- a/job-server-extras/src/test/scala/spark/jobserver/SessionJobSpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/SessionJobSpec.scala
@@ -35,7 +35,7 @@ object SessionJobSpec extends JobSpecConfig {
 class SessionJobSpec extends ExtrasJobSpecBase(SessionJobSpec.getNewSystem) {
 
   val classPrefix = "spark.jobserver."
-  private val hiveLoaderClass = classPrefix + "SessionLoaderJob"
+  private val hiveLoaderClass = classPrefix + "SessionLoaderTestJob"
   private val hiveQueryClass = classPrefix + "SessionTestJob"
 
   val emptyConfig = ConfigFactory.parseString("spark.master = bar")

--- a/job-server-extras/src/test/scala/spark/jobserver/SessionJobSpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/SessionJobSpec.scala
@@ -42,18 +42,17 @@ class SessionJobSpec extends ExtrasJobSpecBase(SessionJobSpec.getNewSystem) {
   val queryConfig = ConfigFactory.parseString(
     """sql = "SELECT firstName, lastName FROM `default`.`test_addresses` WHERE city = 'San Jose'" """
   )
+  lazy val contextConfig = SessionJobSpec.getContextConfig(false, SessionJobSpec.contextConfig)
 
   before {
     dao = new InMemoryDAO
     daoActor = system.actorOf(JobDAOActor.props(dao))
-    manager = system.actorOf(JobManagerActor.props(
-      SessionJobSpec.getContextConfig(false, SessionJobSpec.contextConfig),
-      daoActor))
+    manager = system.actorOf(JobManagerActor.props(daoActor))
   }
 
   describe("Spark Session Jobs") {
     it("should be able to create a Hive table, then query it using separate Spark-SQL jobs") {
-      manager ! JobManagerActor.Initialize(None, emptyActor)
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
       expectMsgClass(30 seconds, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()

--- a/job-server-extras/src/test/scala/spark/jobserver/StreamingJobSpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/StreamingJobSpec.scala
@@ -27,18 +27,17 @@ class StreamingJobSpec extends JobSpecBase(StreamingJobSpec.getNewSystem) {
 
   val emptyConfig = ConfigFactory.parseMap(configMap.asJava)
   var jobId = ""
+  val cfg = StreamingJobSpec.getContextConfig(false, StreamingJobSpec.contextConfig)
 
   before {
     dao = new InMemoryDAO
     daoActor = system.actorOf(JobDAOActor.props(dao))
-    manager = system.actorOf(JobManagerActor.props(
-      StreamingJobSpec.getContextConfig(false, StreamingJobSpec.contextConfig),
-      daoActor))
+    manager = system.actorOf(JobManagerActor.props(daoActor))
   }
 
   describe("Spark Streaming Jobs") {
     it("should be able to process data using Streaming jobs") {
-      manager ! JobManagerActor.Initialize(None, emptyActor)
+      manager ! JobManagerActor.Initialize(cfg, None, emptyActor)
       expectMsgClass(10 seconds, classOf[JobManagerActor.Initialized])
       uploadTestJar()
       manager ! JobManagerActor.StartJob("demo", streamingJob, emptyConfig, asyncEvents ++ errorEvents)

--- a/job-server-extras/src/test/scala/spark/jobserver/StreamingJobSpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/StreamingJobSpec.scala
@@ -1,7 +1,8 @@
 package spark.jobserver
 
-import scala.concurrent.Await
+import akka.pattern._
 
+import scala.concurrent.Await
 import com.typesafe.config.ConfigFactory
 import spark.jobserver.context.StreamingContextFactory
 import spark.jobserver.io.{JobDAOActor, JobInfo}
@@ -33,6 +34,10 @@ class StreamingJobSpec extends JobSpecBase(StreamingJobSpec.getNewSystem) {
     dao = new InMemoryDAO
     daoActor = system.actorOf(JobDAOActor.props(dao))
     manager = system.actorOf(JobManagerActor.props(daoActor))
+  }
+
+  after {
+    Await.result(gracefulStop(manager, 5 seconds), 5 seconds) // stop context
   }
 
   describe("Spark Streaming Jobs") {

--- a/job-server-extras/src/test/scala/spark/jobserver/python/PythonJobManagerSpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/python/PythonJobManagerSpec.scala
@@ -27,9 +27,9 @@ class PythonJobManagerSpec extends ExtrasJobSpecBase(PythonJobManagerSpec.getNew
           |context.actorName = "python_ctx"
         """.stripMargin).
         withFallback(PythonSparkContextFactorySpec.config)
-      manager = system.actorOf(JobManagerActor.props(pyContextConfig, daoActor))
+      manager = system.actorOf(JobManagerActor.props(daoActor))
 
-      manager ! JobManagerActor.Initialize(None, emptyActor)
+      manager ! JobManagerActor.Initialize(pyContextConfig, None, emptyActor)
       expectMsgClass(30 seconds, classOf[JobManagerActor.Initialized])
 
       uploadTestEgg("python-demo")

--- a/job-server/config/docker.conf
+++ b/job-server/config/docker.conf
@@ -3,9 +3,13 @@
 #
 # Spark Cluster / Job Server configuration
 spark {
-  #
+  # spark.master will be passed to each job's JobContext
+  # local[...], yarn, mesos://... or spark://...
   master = "local[4]"
   master = ${?SPARK_MASTER}
+
+  # client or cluster deployment
+  submit.deployMode = "client"
 
   # Default # of CPUs for jobs to use for Spark standalone cluster
   job-number-cpus = 4
@@ -15,12 +19,6 @@ spark {
     jobdao = spark.jobserver.io.JobSqlDAO
 
     context-per-jvm = true
-
-    # Default client mode will start up a new JobManager int local machine
-    # You can use mesos-cluster mode with REMOTE_JOBSERVER_DIR and MESOS_SPARK_DISPATCHER
-    # environment value set in xxxx.sh file to launch JobManager in remote node
-    # Mesos will take responsibility to offer resource to the JobManager process
-    driver-mode = client
 
     sqldao {
       # Directory where default H2 driver stores its data. Only needed for H2.

--- a/job-server/config/ec2.conf.template
+++ b/job-server/config/ec2.conf.template
@@ -4,7 +4,11 @@
 # Spark Cluster / Job Server configuration
 spark {
   # spark.master will be passed to each job's JobContext
+  # local[...], yarn, mesos://... or spark://...
   master = "spark://"
+
+  # client or cluster deployment
+  submit.deployMode = "client"
 
   # Default # of CPUs for jobs to use for Spark standalone cluster
   #job-number-cpus = 1
@@ -13,12 +17,6 @@ spark {
     port = 8090
 
     context-per-jvm = false
-
-    # Default client mode will start up a new JobManager int local machine
-    # You can use mesos-cluster mode with REMOTE_JOBSERVER_DIR and MESOS_SPARK_DISPATCHER
-    # environment value set in xxxx.sh file to launch JobManager in remote node
-    # Mesos will take responsibility to offer resource to the JobManager process
-    driver-mode = client
 
     # Note: JobFileDAO is deprecated from v0.7.0 because of issues in
     # production and will be removed in future, now defaults to H2 file.

--- a/job-server/config/local.conf.template
+++ b/job-server/config/local.conf.template
@@ -4,9 +4,11 @@
 # Spark Cluster / Job Server configuration
 spark {
   # spark.master will be passed to each job's JobContext
+  # local[...], yarn, mesos://... or spark://...
   master = "local[4]"
-  # master = "mesos://vm28-hulk-pub:5050"
-  # master = "yarn-client"
+
+  # client or cluster deployment
+  submit.deployMode = "client"
 
   # Default # of CPUs for jobs to use for Spark standalone cluster
   job-number-cpus = 4
@@ -15,12 +17,6 @@ spark {
     port = 8090
 
     context-per-jvm = false
-
-    # Default client mode will start up a new JobManager int local machine
-    # You can use mesos-cluster mode with REMOTE_JOBSERVER_DIR and MESOS_SPARK_DISPATCHER
-    # environment value set in xxxx.sh file to launch JobManager in remote node
-    # Mesos will take responsibility to offer resource to the JobManager process
-    driver-mode = client
 
     # Note: JobFileDAO is deprecated from v0.7.0 because of issues in
     # production and will be removed in future, now defaults to H2 file.

--- a/job-server/config/local.sh.template
+++ b/job-server/config/local.sh.template
@@ -27,6 +27,6 @@ SPARK_EXECUTOR_URI=/home/spark/spark-1.6.0.tar.gz
 # Also optional: extra JVM args for spark-submit
 # export SPARK_SUBMIT_OPTS+="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5433"
 SCALA_VERSION=2.10.4 # or 2.11.6
-REMOTE_JOBSERVER_DIR=file://... or hdfs://...
-MESOS_SPARK_DISPATCHER=mesos://127.0.0.1:7077
 
+# optional:
+# REMOTE_JOBSERVER_DIR=file://... or hdfs://...

--- a/job-server/config/log4j-cluster.properties
+++ b/job-server/config/log4j-cluster.properties
@@ -1,0 +1,13 @@
+# Rotating log file configuration for server deploys
+
+# Root logger option
+log4j.rootCategory=INFO,console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+# log4j.appender.console.layout.ConversionPattern=%d %-5p %c - %m%n
+log4j.appender.console.layout.ConversionPattern=[%d] %-5p %.26c [%X{testName}] [%X{akkaSource}] - %m%n
+
+# Settings to quiet spark logs that are too verbose
+log4j.logger.org.apache.spark.scheduler.TaskSetManager=WARN
+log4j.logger.org.apache.spark.scheduler.DAGScheduler=WARN

--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -80,6 +80,9 @@ spark {
       }
     }
 
+    # Start embeded H2 Server (usefull in cluster deployment)
+    startH2Server = false
+
     # The ask pattern timeout for Api
     short-timeout = 3 s
 

--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -1,6 +1,11 @@
 # Settings for safe local mode development
 spark {
+  # local[...], yarn or mesos://...
   master = "local[4]"
+
+  # client or cluster deployment
+  submit.deployMode = "client"
+
   # spark web UI port
   webUrlPort = 8080
 
@@ -10,12 +15,6 @@ spark {
 
     # If true, a separate JVM is forked for each Spark context
     context-per-jvm = false
-
-    # Default client mode will start up a new JobManager int local machine
-    # You can use mesos-cluster mode with REMOTE_JOBSERVER_DIR and MESOS_SPARK_DISPATCHER
-    # environment value set in xxxx.sh file to launch JobManager in remote node
-    # Mesos will take responsibility to offer resource to the JobManager process
-    driver-mode = client
 
     # Number of job results to keep per JobResultActor/context
     job-result-cache-size = 5000
@@ -80,7 +79,7 @@ spark {
       }
     }
 
-    # Start embeded H2 Server (usefull in cluster deployment)
+    # Start embedded H2 Server (usefull in cluster deployment)
     startH2Server = false
 
     # The ask pattern timeout for Api

--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -97,11 +97,6 @@ spark {
 
     # in yarn deployment, time out for job server to wait while creating contexts
     yarn-context-creation-timeout = 40 s
-
-    # spark broadcst factory in yarn deployment
-    # Versions prior to 1.1.0, spark default broadcast factory is org.apache.spark.broadcast.HttpBroadcastFactory.
-    # Can't start multiple sparkContexts in the same JVM with HttpBroadcastFactory.
-    yarn-broadcast-factory = org.apache.spark.broadcast.TorrentBroadcastFactory
   }
 
   # predefined Spark contexts

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -59,7 +59,8 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
   //TODO: try to pass this state to the jobManager at start instead of having to track
   //extra state.  What happens if the WebApi process dies before the forked process
   //starts up?  Then it never gets initialized, and this state disappears.
-  private val contextInitInfos = mutable.HashMap.empty[String, (Boolean, ActorRef => Unit, Throwable => Unit)]
+  private val contextInitInfos = mutable.HashMap.empty[String,
+                                                      (Config, Boolean, ActorRef => Unit, Throwable => Unit)]
 
   // actor name -> (JobManagerActor ref, ResultActor ref)
   private val contexts = mutable.HashMap.empty[String, (ActorRef, ActorRef)]
@@ -95,9 +96,10 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
         val actorName = actorRef.path.name
         if (actorName.startsWith("jobManager")) {
           logger.info("Received identify response, attempting to initialize context at {}", memberActors)
-          (for { (isAdHoc, successFunc, failureFunc) <- contextInitInfos.remove(actorName) }
+          (for { (contextConfig, isAdHoc, successFunc, failureFunc) <- contextInitInfos.remove(actorName) }
            yield {
-             initContext(actorName, actorRef, contextInitTimeout)(isAdHoc, successFunc, failureFunc)
+             initContext(contextConfig, actorName,
+                         actorRef, contextInitTimeout)(isAdHoc, successFunc, failureFunc)
            }).getOrElse({
             logger.warn("No initialization or callback found for jobManager actor {}", actorRef.path)
             actorRef ! PoisonPill
@@ -183,7 +185,10 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
       cluster.down(actorRef.path.address)
   }
 
-  private def initContext(actorName: String, ref: ActorRef, timeoutSecs: Long = 1)
+  private def initContext(contextConfig: Config,
+                          actorName: String,
+                          ref: ActorRef,
+                          timeoutSecs: Long = 1)
                          (isAdHoc: Boolean,
                           successFunc: ActorRef => Unit,
                           failureFunc: Throwable => Unit): Unit = {
@@ -191,7 +196,7 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
 
     val resultActor = if (isAdHoc) globalResultActor else context.actorOf(Props(classOf[JobResultActor]))
     (ref ? JobManagerActor.Initialize(
-      Some(resultActor), dataManagerActor))(Timeout(timeoutSecs.second)).onComplete {
+      contextConfig, Some(resultActor), dataManagerActor))(Timeout(timeoutSecs.second)).onComplete {
       case Failure(e: Exception) =>
         logger.info("Failed to send initialize message to context " + ref, e)
         cluster.down(ref.path.address)
@@ -221,67 +226,32 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
 
     logger.info("Starting context with actor name {}", contextActorName)
 
-    val driverMode = Try(config.getString("spark.jobserver.driver-mode")).toOption.getOrElse("client")
-    val (workDir, contextContent) = generateContext(name, contextConfig, isAdHoc, contextActorName)
-    logger.info("Ready to create working directory {} for context {}", workDir: Any, name)
+    val master = Try(config.getString("spark.master")).toOption.getOrElse("local[4]")
+    val deployMode = Try(config.getString("spark.submit.deployMode")).toOption.getOrElse("client")
 
-    //extract spark.proxy.user from contextConfig, if available and pass it to $managerStartCommand
-    var cmdString = if (driverMode == "mesos-cluster") {
-      s"$managerStartCommand $driverMode $workDir '$contextContent' ${selfAddress.toString}"
-    } else {
-      s"$managerStartCommand $driverMode $workDir $contextContent ${selfAddress.toString}"
-    }
+    // Create a temporary dir, preferably in the LOG_DIR
+    val encodedContextName = java.net.URLEncoder.encode(name, "UTF-8")
+    val contextDir = Option(System.getProperty("LOG_DIR")).map { logDir =>
+      Files.createTempDirectory(Paths.get(logDir), s"jobserver-$encodedContextName")
+    }.getOrElse(Files.createTempDirectory("jobserver"))
+    logger.info("Created working directory {} for context {}", contextDir: Any, name)
 
+    // Now create the contextConfig merged with the values we need
+    val mergedContextConfig = ConfigFactory.parseMap(
+      Map("is-adhoc" -> isAdHoc.toString, "context.name" -> name).asJava
+    ).withFallback(contextConfig)
+
+    var managerArgs = Seq(master, deployMode, selfAddress.toString, contextActorName, contextDir.toString)
+    // extract spark.proxy.user from contextConfig, if available and pass it to manager start command
     if (contextConfig.hasPath(SparkJobUtils.SPARK_PROXY_USER_PARAM)) {
-      cmdString = cmdString + s" ${contextConfig.getString(SparkJobUtils.SPARK_PROXY_USER_PARAM)}"
+      managerArgs = managerArgs :+ contextConfig.getString(SparkJobUtils.SPARK_PROXY_USER_PARAM)
     }
 
     val contextLogger = LoggerFactory.getLogger("manager_start")
-    val process = Process(cmdString.split(" "))
+    val process = Process(managerStartCommand, managerArgs)
     process.run(ProcessLogger(out => contextLogger.info(out), err => contextLogger.warn(err)))
 
-    contextInitInfos(contextActorName) = (isAdHoc, successFunc, failureFunc)
-  }
-
-  private def createContextDir(name: String,
-                               contextConfig: Config,
-                               isAdHoc: Boolean,
-                               actorName: String): java.io.File = {
-    // Create a temporary dir, preferably in the LOG_DIR
-    val encodedContextName = java.net.URLEncoder.encode(name, "UTF-8")
-    val tmpDir = Option(System.getProperty("LOG_DIR")).map { logDir =>
-      Files.createTempDirectory(Paths.get(logDir), s"jobserver-$encodedContextName")
-    }.getOrElse(Files.createTempDirectory("jobserver"))
-    logger.info("Created working directory {} for context {}", tmpDir: Any, name)
-
-    // Now create the contextConfig merged with the values we need
-    val mergedConfig = ConfigFactory.parseMap(
-                         Map("is-adhoc" -> isAdHoc.toString,
-                             "context.name" -> name,
-                             "context.actorname" -> actorName).asJava
-                       ).withFallback(contextConfig)
-
-    // Write out the config to the temp dir
-    Files.write(tmpDir.resolve("context.conf"),
-                Seq(mergedConfig.root.render(ConfigRenderOptions.concise)).asJava,
-                Charset.forName("UTF-8"))
-
-    tmpDir.toFile
-  }
-
-  //generate remote context path and context config
-  private def generateContext(name: String,
-                              contextConfig: Config,
-                              isAdHoc: Boolean,
-                              actorName: String): (String, String) = {
-    (Option(System.getProperty("LOG_DIR")).getOrElse("/tmp/jobserver") + "/"
-      + java.net.URLEncoder.encode(name + "-" + actorName, "UTF-8"),
-      ConfigFactory.parseMap(
-        Map("is-adhoc" -> isAdHoc.toString,
-          "context.name" -> name,
-          "context.actorname" -> actorName).asJava
-      ).withFallback(contextConfig).root().render(ConfigRenderOptions.concise())
-      )
+    contextInitInfos(contextActorName) = (mergedContextConfig, isAdHoc, successFunc, failureFunc)
   }
 
   private def addContextsFromConfig(config: Config) {

--- a/job-server/src/main/scala/spark/jobserver/JobManager.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManager.scala
@@ -77,6 +77,7 @@ object JobManager {
 
   def main(args: Array[String]) {
     import scala.collection.JavaConverters._
+
     def makeManagerSystem(name: String)(config: Config): ActorSystem = {
       val configWithRole = config.withValue("akka.cluster.roles",
         ConfigValueFactory.fromIterable(List("manager").asJava))

--- a/job-server/src/main/scala/spark/jobserver/JobServer.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobServer.scala
@@ -66,6 +66,14 @@ object JobServer {
             throw new RuntimeException("H2 mem backend is not support with context-per-jvm.")
         }
       }
+
+      // start embedded H2 server
+      if (config.getBoolean("spark.jobserver.startH2Server")) {
+        val rootDir = config.getString("spark.jobserver.sqldao.rootdir")
+        val h2 = org.h2.tools.Server.createTcpServer("-tcpAllowOthers", "-baseDir", rootDir).start();
+        logger.info("Embeded H2 server started with base dir {} and URL {}", rootDir, h2.getURL: Any)
+      }
+
       val jobDAO = ctor.newInstance(config).asInstanceOf[JobDAO]
       val daoActor = system.actorOf(Props(classOf[JobDAOActor], jobDAO), "dao-manager")
       val dataManager = system.actorOf(DataManagerActor.props(new DataFileDAO(config)), "data-manager")

--- a/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
@@ -195,13 +195,11 @@ class LocalContextSupervisorActor(dao: ActorRef, dataManagerActor: ActorRef) ext
 
     val resultActorRef = if (isAdHoc) Some(globalResultActor) else None
     val mergedConfig = ConfigFactory.parseMap(
-                         Map("is-adhoc" -> isAdHoc.toString,
-                             "context.name" -> name,
-                             "context.actorname" -> name).asJava
+                         Map("is-adhoc" -> isAdHoc.toString, "context.name" -> name).asJava
                        ).withFallback(contextConfig)
-    val ref = context.actorOf(JobManagerActor.props(mergedConfig, dao), name)
+    val ref = context.actorOf(JobManagerActor.props(dao), name)
     (ref ? JobManagerActor.Initialize(
-      resultActorRef, dataManagerActor))(Timeout(timeoutSecs.second)).onComplete {
+      mergedConfig, resultActorRef, dataManagerActor))(Timeout(timeoutSecs.second)).onComplete {
       case Failure(e: Exception) =>
         logger.error("Exception after sending Initialize to JobManagerActor", e)
         // Make sure we try to shut down the context in case it gets created anyways

--- a/job-server/src/test/scala/spark/jobserver/JavaJobSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JavaJobSpec.scala
@@ -29,7 +29,6 @@ class JavaJobSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
       "context-factory" -> contextFactory,
       "spark.context-settings.test" -> "",
       "context.name" -> "ctx",
-      "context.actorname" -> "ctx",
       "is-adhoc" -> "false"
     )
     ConfigFactory.parseMap(ConfigMap.asJava).withFallback(ConfigFactory.defaultOverrides())
@@ -38,7 +37,7 @@ class JavaJobSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
   before {
     dao = new InMemoryDAO
     daoActor = system.actorOf(JobDAOActor.props(dao))
-    manager = system.actorOf(JobManagerActor.props(config, daoActor))
+    manager = system.actorOf(JobManagerActor.props(daoActor))
     supervisor = TestProbe().ref
   }
 
@@ -56,7 +55,7 @@ class JavaJobSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
 
   describe("Running Java Jobs") {
     it("Should run a java job") {
-      manager ! JobManagerActor.Initialize(None, emptyActor)
+      manager ! JobManagerActor.Initialize(config, None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
       uploadTestJar()
       manager ! JobManagerActor.StartJob("demo", javaJob, config, syncEvents ++ errorEvents)
@@ -65,7 +64,7 @@ class JavaJobSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
       }
     }
     it("Should fail running this java job"){
-      manager ! JobManagerActor.Initialize(None, emptyActor)
+      manager ! JobManagerActor.Initialize(config, None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
       uploadTestJar()
       manager ! JobManagerActor.StartJob("demo", failedJob, config, errorEvents)

--- a/job-server/src/test/scala/spark/jobserver/JavaJobSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JavaJobSpec.scala
@@ -10,7 +10,7 @@ import spark.jobserver.io.JobDAOActor
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 
-class JavaJobSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
+class JavaJobSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) {
 
   val JobResultCacheSize = Integer.valueOf(30)
   val NumCpuCores = Integer.valueOf(Runtime.getRuntime.availableProcessors())

--- a/job-server/src/test/scala/spark/jobserver/JobManagerActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobManagerActorSpec.scala
@@ -3,22 +3,40 @@ package spark.jobserver
 import java.io.File
 import java.nio.file.{Files, StandardOpenOption}
 
-import com.typesafe.config.ConfigFactory
-import spark.jobserver.CommonMessages.{JobErroredOut, JobResult}
+import com.typesafe.config.{Config, ConfigFactory}
 import spark.jobserver.DataManagerActor.RetrieveData
+import spark.jobserver.JobManagerActor.KillJob
 import spark.jobserver.common.akka.AkkaTestUtils
-import spark.jobserver.io.JobDAOActor
+import spark.jobserver.io.{BinaryType, JobDAOActor}
 
-import scala.concurrent.Await
+import scala.collection.mutable
 
-class JobManagerActorSpec extends JobManagerSpec {
-  import scala.concurrent.duration._
+object JobManagerActorSpec extends JobSpecConfig
+
+class JobManagerActorSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) {
   import akka.testkit._
+  import CommonMessages._
+  import JobManagerActorSpec.MaxJobsPerContext
+  import scala.concurrent.duration._
+
+  val classPrefix = "spark.jobserver."
+  private val wordCountClass = classPrefix + "WordCountExample"
+  private val newWordCountClass = classPrefix + "WordCountExampleNewApi"
+  private val javaJob = classPrefix + "JavaHelloWorldJob"
+  val sentence = "The lazy dog jumped over the fish"
+  val counts = sentence.split(" ").groupBy(x => x).mapValues(_.length)
+  protected val stringConfig = ConfigFactory.parseString(s"input.string = $sentence")
+  protected val emptyConfig = ConfigFactory.parseString("spark.master = bar")
+
+  val initMsgWait = 10.seconds.dilated
+  val startJobWait = 5.seconds.dilated
+
+  var contextConfig: Config = _
 
   before {
     dao = new InMemoryDAO
     daoActor = system.actorOf(JobDAOActor.props(dao))
-    contextConfig = JobManagerSpec.getContextConfig(adhoc = false)
+    contextConfig = JobManagerActorSpec.getContextConfig(adhoc = false)
     manager = system.actorOf(JobManagerActor.props(daoActor))
     supervisor = TestProbe().ref
   }
@@ -28,6 +46,198 @@ class JobManagerActorSpec extends JobManagerSpec {
   }
 
   describe("starting jobs") {
+    it("should start job and return result successfully (all events)") {
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
+      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+
+      uploadTestJar()
+      manager ! JobManagerActor.StartJob("demo", wordCountClass, stringConfig, allEvents)
+      expectMsgClass(startJobWait, classOf[JobStarted])
+      expectMsgAllClassOf(classOf[JobFinished], classOf[JobResult])
+      expectNoMsg()
+    }
+
+    it("should start job and return result before job finish event") {
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
+      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+
+      uploadTestJar()
+      manager ! JobManagerActor.StartJob("demo", wordCountClass, stringConfig, allEvents)
+      expectMsgClass(startJobWait, classOf[JobStarted])
+      expectMsgClass(classOf[JobResult])
+      expectMsgClass(classOf[JobFinished])
+      expectNoMsg()
+    }
+
+    it("should start job more than one time and return result successfully (all events)") {
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
+      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+
+      uploadTestJar()
+      manager ! JobManagerActor.StartJob("demo", wordCountClass, stringConfig, allEvents)
+      expectMsgClass(startJobWait, classOf[JobStarted])
+      expectMsgAllClassOf(classOf[JobFinished], classOf[JobResult])
+      expectNoMsg()
+
+      // should be ok to run the same more again
+      manager ! JobManagerActor.StartJob("demo", wordCountClass, stringConfig, allEvents)
+      expectMsgClass(startJobWait, classOf[JobStarted])
+      expectMsgAllClassOf(classOf[JobFinished], classOf[JobResult])
+      expectNoMsg()
+    }
+
+    it("should start job and return results (sync route)") {
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
+      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+
+      uploadTestJar()
+      manager ! JobManagerActor.StartJob("demo", wordCountClass, stringConfig, syncEvents ++ errorEvents)
+      expectMsgPF(startJobWait, "Did not get JobResult") {
+        case JobResult(_, result) => result should equal (counts)
+      }
+      expectNoMsg()
+    }
+
+    it("should start NewAPI job and return results (sync route)") {
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
+      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+
+      uploadTestJar()
+      manager ! JobManagerActor.StartJob("demo", newWordCountClass, stringConfig, syncEvents ++ errorEvents)
+      expectMsgPF(startJobWait, "Did not get JobResult") {
+        case JobResult(_, result) => result should equal (counts)
+      }
+      expectNoMsg()
+    }
+
+    it("should start job and return JobStarted (async)") {
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
+      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+
+      uploadTestJar()
+      manager ! JobManagerActor.StartJob("demo", wordCountClass, stringConfig, errorEvents ++ asyncEvents)
+      expectMsgClass(startJobWait, classOf[JobStarted])
+      expectNoMsg()
+    }
+
+    it("should return error if job throws an error") {
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
+      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+
+      uploadTestJar()
+      manager ! JobManagerActor.StartJob("demo", classPrefix + "MyErrorJob", emptyConfig, errorEvents)
+      val errorMsg = expectMsgClass(startJobWait, classOf[JobErroredOut])
+      errorMsg.err.getClass should equal (classOf[RuntimeException])
+    }
+
+    it("job should get jobConfig passed in to StartJob message") {
+      val jobConfig = ConfigFactory.parseString("foo.bar.baz = 3")
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
+      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+
+      uploadTestJar()
+      manager ! JobManagerActor.StartJob("demo", classPrefix + "ConfigCheckerJob", jobConfig,
+        syncEvents ++ errorEvents)
+      expectMsgPF(startJobWait, "Did not get JobResult") {
+        case JobResult(_, keys: Seq[_]) =>
+          keys should contain ("foo")
+      }
+    }
+
+    it("should properly serialize case classes and other job jar classes") {
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
+      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+
+      uploadTestJar()
+      manager ! JobManagerActor.StartJob("demo", classPrefix + "ZookeeperJob", stringConfig,
+        syncEvents ++ errorEvents)
+      expectMsgPF(5.seconds.dilated, "Did not get JobResult") {
+        case JobResult(_, result: Array[Product]) =>
+          result.length should equal (1)
+          result(0).getClass.getName should include ("Animal")
+      }
+      expectNoMsg()
+    }
+
+    it ("should refuse to start a job when too many jobs in the context are running") {
+      val jobSleepTimeMillis = 2000L
+      val jobConfig = ConfigFactory.parseString("sleep.time.millis = " + jobSleepTimeMillis)
+
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
+      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+
+      uploadTestJar()
+
+      val messageCounts = new mutable.HashMap[Class[_], Int].withDefaultValue(0)
+      // Try to start 3 instances of this job. 2 of them should start, and the 3rd should be denied.
+      for (i <- 0 until MaxJobsPerContext + 1) {
+        manager ! JobManagerActor.StartJob("demo", classPrefix + "SleepJob", jobConfig, allEvents)
+      }
+
+      while (messageCounts.values.sum < (MaxJobsPerContext * 3 + 1)) {
+        expectMsgPF(5.seconds.dilated, "Expected a message but didn't get one!") {
+          case started: JobStarted =>
+            messageCounts(started.getClass) += 1
+          case noSlots: NoJobSlotsAvailable =>
+            noSlots.maxJobSlots should equal (MaxJobsPerContext)
+            messageCounts(noSlots.getClass) += 1
+          case finished: JobFinished =>
+            messageCounts(finished.getClass) += 1
+          case result: JobResult =>
+            result.result should equal (jobSleepTimeMillis)
+            messageCounts(result.getClass) += 1
+        }
+      }
+      messageCounts.toMap should equal (Map(classOf[JobStarted] -> MaxJobsPerContext,
+        classOf[JobFinished] -> MaxJobsPerContext,
+        classOf[JobResult] -> MaxJobsPerContext,
+        classOf[NoJobSlotsAvailable] -> 1))
+    }
+
+    it("should start a job that's an object rather than class") {
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
+      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+
+      uploadTestJar()
+      manager ! JobManagerActor.StartJob("demo", classPrefix + "SimpleObjectJob", emptyConfig,
+        syncEvents ++ errorEvents)
+      expectMsgPF(5.seconds.dilated, "Did not get JobResult") {
+        case JobResult(_, result: Int) => result should equal (1 + 2 + 3)
+      }
+    }
+
+    it("should be able to cancel running job") {
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
+      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+
+      uploadTestJar()
+      manager ! JobManagerActor.StartJob("demo", classPrefix + "LongPiJob", stringConfig, allEvents)
+      expectMsgPF(5.seconds.dilated, "Did not get JobResult") {
+        case JobStarted(id, _) =>
+          manager ! KillJob(id)
+          // we need this twice as we send both to sender and manager, in unit tests they are the same
+          // in usage they may be different
+          expectMsgClass(classOf[JobKilled])
+          expectMsgClass(classOf[JobKilled])
+      }
+    }
+
+    it("should fail a job that requires job jar dependencies but doesn't provide the jar"){
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
+      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+
+      uploadTestJar()
+      val jobJarDepsConfigs = ConfigFactory.parseString(
+        s"""
+           |dependent-jar-uris = []
+        """.stripMargin)
+
+      manager ! JobManagerActor.StartJob("demo", classPrefix + "jobJarDependenciesJob", jobJarDepsConfigs,
+        syncEvents ++ errorEvents)
+
+      expectMsgClass(startJobWait, classOf[JobErroredOut])
+    }
+
     it("jobs should be able to cache RDDs and retrieve them through getPersistentRDDs") {
       manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
       expectMsgClass(classOf[JobManagerActor.Initialized])
@@ -55,6 +265,52 @@ class JobManagerActorSpec extends JobManagerSpec {
         case JobResult(_, sum: Int) => sum should equal (1 + 4 + 9 + 16 + 25)
         case JobErroredOut(_, _, error: Throwable) => throw error
       }
+    }
+  }
+
+  describe("error conditions") {
+    it("should return errors if appName does not match") {
+      uploadTestJar()
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
+      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+      manager ! JobManagerActor.StartJob("demo2", wordCountClass, emptyConfig, Set.empty[Class[_]])
+      expectMsg(startJobWait, CommonMessages.NoSuchApplication)
+    }
+
+    it("should return error message if classPath does not match") {
+      uploadTestJar()
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
+      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+      manager ! JobManagerActor.StartJob("demo", "no.such.class", emptyConfig, Set.empty[Class[_]])
+      expectMsg(startJobWait, CommonMessages.NoSuchClass)
+    }
+
+    it("should error out if loading garbage jar") {
+      uploadBinary(dao, "../README.md", "notajar", BinaryType.Jar)
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
+      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+      manager ! JobManagerActor.StartJob("notajar", "no.such.class", emptyConfig, Set.empty[Class[_]])
+      expectMsg(startJobWait, CommonMessages.NoSuchClass)
+    }
+
+    it("should error out if job validation fails") {
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
+      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+
+      uploadTestJar()
+      manager ! JobManagerActor.StartJob("demo", wordCountClass, emptyConfig, allEvents)
+      expectMsgClass(startJobWait, classOf[CommonMessages.JobValidationFailed])
+      expectNoMsg()
+    }
+
+    it("should error out if new API job validation fails") {
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
+      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+
+      uploadTestJar()
+      manager ! JobManagerActor.StartJob("demo", newWordCountClass, emptyConfig, allEvents)
+      expectMsgClass(startJobWait, classOf[CommonMessages.JobValidationFailed])
+      expectNoMsg()
     }
   }
 

--- a/job-server/src/test/scala/spark/jobserver/JobManagerSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobManagerSpec.scala
@@ -3,8 +3,7 @@ package spark.jobserver
 import spark.jobserver.io.BinaryType
 
 import scala.collection.mutable
-
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigFactory}
 import spark.jobserver.JobManagerActor.KillJob
 
 object JobManagerSpec extends JobSpecConfig
@@ -28,10 +27,12 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
   val initMsgWait = 10.seconds.dilated
   val startJobWait = 5.seconds.dilated
 
+  var contextConfig: Config = _
+
   describe("error conditions") {
     it("should return errors if appName does not match") {
       uploadTestJar()
-      manager ! JobManagerActor.Initialize(None, emptyActor)
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
       manager ! JobManagerActor.StartJob("demo2", wordCountClass, emptyConfig, Set.empty[Class[_]])
       expectMsg(startJobWait, CommonMessages.NoSuchApplication)
@@ -39,7 +40,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
 
     it("should return error message if classPath does not match") {
       uploadTestJar()
-      manager ! JobManagerActor.Initialize(None, emptyActor)
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
       manager ! JobManagerActor.StartJob("demo", "no.such.class", emptyConfig, Set.empty[Class[_]])
       expectMsg(startJobWait, CommonMessages.NoSuchClass)
@@ -47,14 +48,14 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
 
     it("should error out if loading garbage jar") {
       uploadBinary(dao, "../README.md", "notajar", BinaryType.Jar)
-      manager ! JobManagerActor.Initialize(None, emptyActor)
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
       manager ! JobManagerActor.StartJob("notajar", "no.such.class", emptyConfig, Set.empty[Class[_]])
       expectMsg(startJobWait, CommonMessages.NoSuchClass)
     }
 
     it("should error out if job validation fails") {
-      manager ! JobManagerActor.Initialize(None, emptyActor)
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -64,7 +65,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
     }
 
     it("should error out if new API job validation fails") {
-      manager ! JobManagerActor.Initialize(None, emptyActor)
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -76,7 +77,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
 
   describe("starting jobs") {
     it("should start job and return result successfully (all events)") {
-      manager ! JobManagerActor.Initialize(None, emptyActor)
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -87,7 +88,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
     }
 
     it("should start job and return result before job finish event") {
-      manager ! JobManagerActor.Initialize(None, emptyActor)
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -99,7 +100,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
     }
 
     it("should start job more than one time and return result successfully (all events)") {
-      manager ! JobManagerActor.Initialize(None, emptyActor)
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -116,7 +117,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
     }
 
     it("should start job and return results (sync route)") {
-      manager ! JobManagerActor.Initialize(None, emptyActor)
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -128,7 +129,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
     }
 
     it("should start NewAPI job and return results (sync route)") {
-      manager ! JobManagerActor.Initialize(None, emptyActor)
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -140,7 +141,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
     }
 
     it("should start job and return JobStarted (async)") {
-      manager ! JobManagerActor.Initialize(None, emptyActor)
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -150,7 +151,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
     }
 
     it("should return error if job throws an error") {
-      manager ! JobManagerActor.Initialize(None, emptyActor)
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -161,7 +162,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
 
     it("job should get jobConfig passed in to StartJob message") {
       val jobConfig = ConfigFactory.parseString("foo.bar.baz = 3")
-      manager ! JobManagerActor.Initialize(None, emptyActor)
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -174,7 +175,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
     }
 
     it("should properly serialize case classes and other job jar classes") {
-      manager ! JobManagerActor.Initialize(None, emptyActor)
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -192,7 +193,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
       val jobSleepTimeMillis = 2000L
       val jobConfig = ConfigFactory.parseString("sleep.time.millis = " + jobSleepTimeMillis)
 
-      manager ! JobManagerActor.Initialize(None, emptyActor)
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -224,7 +225,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
     }
 
     it("should start a job that's an object rather than class") {
-      manager ! JobManagerActor.Initialize(None, emptyActor)
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -236,7 +237,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
     }
 
     it("should be able to cancel running job") {
-      manager ! JobManagerActor.Initialize(None, emptyActor)
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()
@@ -252,7 +253,7 @@ abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
     }
 
     it("should fail a job that requires job jar dependencies but doesn't provide the jar"){
-      manager ! JobManagerActor.Initialize(None, emptyActor)
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
 
       uploadTestJar()

--- a/job-server/src/test/scala/spark/jobserver/JobManagerSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobManagerSpec.scala
@@ -1,272 +1,140 @@
 package spark.jobserver
 
-import spark.jobserver.io.BinaryType
+import java.nio.charset.Charset
+import java.nio.file.Files
 
-import scala.collection.mutable
-import com.typesafe.config.{Config, ConfigFactory}
-import spark.jobserver.JobManagerActor.KillJob
+import akka.actor.{ActorRef, ActorSystem}
+import akka.cluster.Cluster
+import akka.cluster.ClusterEvent.{InitialStateAsEvents, MemberUp}
+import akka.util.Timeout
+import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
+import spark.jobserver.common.akka.AkkaTestUtils
 
-object JobManagerSpec extends JobSpecConfig
+import scala.concurrent.Await
 
-abstract class JobManagerSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
+class JobManagerSpec extends FunSpecLike with Matchers with BeforeAndAfter {
+
+  import akka.testkit._
+  import com.typesafe.config._
+
+  import scala.collection.JavaConverters._
   import scala.concurrent.duration._
 
-  import CommonMessages._
-  import JobManagerSpec.MaxJobsPerContext
-  import akka.testkit._
+  implicit var system: ActorSystem = _
+  var cluster: Cluster = _
+  var clusterAddr: String = _
+  val configFile = Files.createTempFile("job-server-config", ".conf")
 
-  val classPrefix = "spark.jobserver."
-  private val wordCountClass = classPrefix + "WordCountExample"
-  private val newWordCountClass = classPrefix + "WordCountExampleNewApi"
-  private val javaJob = classPrefix + "JavaHelloWorldJob"
-  val sentence = "The lazy dog jumped over the fish"
-  val counts = sentence.split(" ").groupBy(x => x).mapValues(_.length)
-  protected val stringConfig = ConfigFactory.parseString(s"input.string = $sentence")
-  protected val emptyConfig = ConfigFactory.parseString("spark.master = bar")
-
-  val initMsgWait = 10.seconds.dilated
-  val startJobWait = 5.seconds.dilated
-
-  var contextConfig: Config = _
-
-  describe("error conditions") {
-    it("should return errors if appName does not match") {
-      uploadTestJar()
-      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
-      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
-      manager ! JobManagerActor.StartJob("demo2", wordCountClass, emptyConfig, Set.empty[Class[_]])
-      expectMsg(startJobWait, CommonMessages.NoSuchApplication)
-    }
-
-    it("should return error message if classPath does not match") {
-      uploadTestJar()
-      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
-      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
-      manager ! JobManagerActor.StartJob("demo", "no.such.class", emptyConfig, Set.empty[Class[_]])
-      expectMsg(startJobWait, CommonMessages.NoSuchClass)
-    }
-
-    it("should error out if loading garbage jar") {
-      uploadBinary(dao, "../README.md", "notajar", BinaryType.Jar)
-      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
-      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
-      manager ! JobManagerActor.StartJob("notajar", "no.such.class", emptyConfig, Set.empty[Class[_]])
-      expectMsg(startJobWait, CommonMessages.NoSuchClass)
-    }
-
-    it("should error out if job validation fails") {
-      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
-      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
-
-      uploadTestJar()
-      manager ! JobManagerActor.StartJob("demo", wordCountClass, emptyConfig, allEvents)
-      expectMsgClass(startJobWait, classOf[CommonMessages.JobValidationFailed])
-      expectNoMsg()
-    }
-
-    it("should error out if new API job validation fails") {
-      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
-      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
-
-      uploadTestJar()
-      manager ! JobManagerActor.StartJob("demo", newWordCountClass, emptyConfig, allEvents)
-      expectMsgClass(startJobWait, classOf[CommonMessages.JobValidationFailed])
-      expectNoMsg()
-    }
+  before {
+    system = ActorSystem("test")
+    cluster = Cluster(system)
+    clusterAddr = cluster.selfAddress.toString
   }
 
-  describe("starting jobs") {
-    it("should start job and return result successfully (all events)") {
-      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
-      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+  after {
+    AkkaTestUtils.shutdownAndWait(system)
+    Files.deleteIfExists(configFile)
+  }
 
-      uploadTestJar()
-      manager ! JobManagerActor.StartJob("demo", wordCountClass, stringConfig, allEvents)
-      expectMsgClass(startJobWait, classOf[JobStarted])
-      expectMsgAllClassOf(classOf[JobFinished], classOf[JobResult])
-      expectNoMsg()
-    }
+  def writeConfigFile(configMap: Map[String, Any]): String = {
+    val config = ConfigFactory.parseMap(configMap.asJava).withFallback(ConfigFactory.defaultOverrides())
+    Files.write(configFile,
+      Seq(config.root.render(ConfigRenderOptions.concise)).asJava,
+      Charset.forName("UTF-8"))
+    configFile.toAbsolutePath.toString
+  }
 
-    it("should start job and return result before job finish event") {
-      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
-      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+  def makeSupervisorSystem(config: Config): ActorSystem = system
+  def waitForTerminationDummy(system: ActorSystem, master: String, deployMode: String) { }
+  implicit val timeout: Timeout = 3 seconds
 
-      uploadTestJar()
-      manager ! JobManagerActor.StartJob("demo", wordCountClass, stringConfig, allEvents)
-      expectMsgClass(startJobWait, classOf[JobStarted])
-      expectMsgClass(classOf[JobResult])
-      expectMsgClass(classOf[JobFinished])
-      expectNoMsg()
-    }
+  describe("starting job manager") {
+    it ("removes akka.remote.netty.tcp.hostname from config cluster mode") {
+      val configFileName = writeConfigFile(Map(
+        "spark.submit.deployMode" -> "cluster",
+        "akka.remote.netty.tcp.hostname" -> "test"
+      ))
 
-    it("should start job more than one time and return result successfully (all events)") {
-      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
-      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
-
-      uploadTestJar()
-      manager ! JobManagerActor.StartJob("demo", wordCountClass, stringConfig, allEvents)
-      expectMsgClass(startJobWait, classOf[JobStarted])
-      expectMsgAllClassOf(classOf[JobFinished], classOf[JobResult])
-      expectNoMsg()
-
-      // should be ok to run the same more again
-      manager ! JobManagerActor.StartJob("demo", wordCountClass, stringConfig, allEvents)
-      expectMsgClass(startJobWait, classOf[JobStarted])
-      expectMsgAllClassOf(classOf[JobFinished], classOf[JobResult])
-      expectNoMsg()
-    }
-
-    it("should start job and return results (sync route)") {
-      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
-      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
-
-      uploadTestJar()
-      manager ! JobManagerActor.StartJob("demo", wordCountClass, stringConfig, syncEvents ++ errorEvents)
-      expectMsgPF(startJobWait, "Did not get JobResult") {
-        case JobResult(_, result) => result should equal (counts)
-      }
-      expectNoMsg()
-    }
-
-    it("should start NewAPI job and return results (sync route)") {
-      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
-      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
-
-      uploadTestJar()
-      manager ! JobManagerActor.StartJob("demo", newWordCountClass, stringConfig, syncEvents ++ errorEvents)
-      expectMsgPF(startJobWait, "Did not get JobResult") {
-        case JobResult(_, result) => result should equal (counts)
-      }
-      expectNoMsg()
-    }
-
-    it("should start job and return JobStarted (async)") {
-      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
-      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
-
-      uploadTestJar()
-      manager ! JobManagerActor.StartJob("demo", wordCountClass, stringConfig, errorEvents ++ asyncEvents)
-      expectMsgClass(startJobWait, classOf[JobStarted])
-      expectNoMsg()
-    }
-
-    it("should return error if job throws an error") {
-      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
-      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
-
-      uploadTestJar()
-      manager ! JobManagerActor.StartJob("demo", classPrefix + "MyErrorJob", emptyConfig, errorEvents)
-      val errorMsg = expectMsgClass(startJobWait, classOf[JobErroredOut])
-      errorMsg.err.getClass should equal (classOf[RuntimeException])
-    }
-
-    it("job should get jobConfig passed in to StartJob message") {
-      val jobConfig = ConfigFactory.parseString("foo.bar.baz = 3")
-      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
-      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
-
-      uploadTestJar()
-      manager ! JobManagerActor.StartJob("demo", classPrefix + "ConfigCheckerJob", jobConfig,
-        syncEvents ++ errorEvents)
-      expectMsgPF(startJobWait, "Did not get JobResult") {
-        case JobResult(_, keys: Seq[_]) =>
-          keys should contain ("foo")
-      }
-    }
-
-    it("should properly serialize case classes and other job jar classes") {
-      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
-      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
-
-      uploadTestJar()
-      manager ! JobManagerActor.StartJob("demo", classPrefix + "ZookeeperJob", stringConfig,
-        syncEvents ++ errorEvents)
-      expectMsgPF(5.seconds.dilated, "Did not get JobResult") {
-        case JobResult(_, result: Array[Product]) =>
-          result.length should equal (1)
-          result(0).getClass.getName should include ("Animal")
-      }
-      expectNoMsg()
-    }
-
-    it ("should refuse to start a job when too many jobs in the context are running") {
-      val jobSleepTimeMillis = 2000L
-      val jobConfig = ConfigFactory.parseString("sleep.time.millis = " + jobSleepTimeMillis)
-
-      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
-      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
-
-      uploadTestJar()
-
-      val messageCounts = new mutable.HashMap[Class[_], Int].withDefaultValue(0)
-      // Try to start 3 instances of this job. 2 of them should start, and the 3rd should be denied.
-      for (i <- 0 until MaxJobsPerContext + 1) {
-        manager ! JobManagerActor.StartJob("demo", classPrefix + "SleepJob", jobConfig, allEvents)
+      def makeSystem(config: Config): ActorSystem = {
+        config.hasPath("akka.remote.netty.tcp.hostname") should be(false)
+        system
       }
 
-      while (messageCounts.values.sum < (MaxJobsPerContext * 3 + 1)) {
-        expectMsgPF(5.seconds.dilated, "Expected a message but didn't get one!") {
-          case started: JobStarted =>
-            messageCounts(started.getClass) += 1
-          case noSlots: NoJobSlotsAvailable =>
-            noSlots.maxJobSlots should equal (MaxJobsPerContext)
-            messageCounts(noSlots.getClass) += 1
-          case finished: JobFinished =>
-            messageCounts(finished.getClass) += 1
-          case result: JobResult =>
-            result.result should equal (jobSleepTimeMillis)
-            messageCounts(result.getClass) += 1
-        }
+      JobManager.start(Seq(clusterAddr, "test-manager", configFileName).toArray,
+        makeSystem, waitForTerminationDummy)
+    }
+
+    it ("use temporary sqldao dir in cluster mode") {
+      val configFileName = writeConfigFile(Map(
+        "spark.submit.deployMode" -> "cluster",
+        "spark.jobserver.sqldao.rootdir" -> "test"
+      ))
+
+      def makeSystem(config: Config): ActorSystem = {
+        config.getString("spark.jobserver.sqldao.rootdir") shouldNot equal ("test")
+        system
       }
-      messageCounts.toMap should equal (Map(classOf[JobStarted] -> MaxJobsPerContext,
-        classOf[JobFinished] -> MaxJobsPerContext,
-        classOf[JobResult] -> MaxJobsPerContext,
-        classOf[NoJobSlotsAvailable] -> 1))
+
+      JobManager.start(Seq(clusterAddr, "test-manager", configFileName).toArray,
+        makeSystem, waitForTerminationDummy)
     }
 
-    it("should start a job that's an object rather than class") {
-      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
-      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+    it ("keeps hostname and sqldao dir in client mode") {
+      val tmpDir = Files.createTempDirectory("job-manager-sqldao").toString
+      val configFileName = writeConfigFile(Map(
+        "spark.submit.deployMode" -> "client",
+        "akka.remote.netty.tcp.hostname" -> "localhost",
+        "spark.jobserver.sqldao.rootdir" -> tmpDir
+      ))
 
-      uploadTestJar()
-      manager ! JobManagerActor.StartJob("demo", classPrefix + "SimpleObjectJob", emptyConfig,
-        syncEvents ++ errorEvents)
-      expectMsgPF(5.seconds.dilated, "Did not get JobResult") {
-        case JobResult(_, result: Int) => result should equal (1 + 2 + 3)
+      def makeSystem(config: Config): ActorSystem = {
+        config.getString("akka.remote.netty.tcp.hostname") should equal ("localhost")
+        config.getString("spark.jobserver.sqldao.rootdir") should equal (tmpDir)
+        system
       }
+
+      JobManager.start(Seq(clusterAddr, "test-manager", configFileName).toArray,
+        makeSystem, waitForTerminationDummy)
     }
 
-    it("should be able to cancel running job") {
-      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
-      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+    it ("starts dao-manager and job manager actor") {
+      val configFileName = writeConfigFile(Map(
+        "spark.submit.deployMode" -> "cluster"
+      ))
 
-      uploadTestJar()
-      manager ! JobManagerActor.StartJob("demo", classPrefix + "LongPiJob", stringConfig, allEvents)
-      expectMsgPF(5.seconds.dilated, "Did not get JobResult") {
-        case JobStarted(id, _) =>
-          manager ! KillJob(id)
-          // we need this twice as we send both to sender and manager, in unit tests they are the same
-          // in usage they may be different
-          expectMsgClass(classOf[JobKilled])
-          expectMsgClass(classOf[JobKilled])
+      JobManager.start(Seq(clusterAddr, "test-manager", configFileName).toArray,
+        makeSupervisorSystem, waitForTerminationDummy)
+
+      Await.result(system.actorSelection("/user/dao-manager-jobmanager").resolveOne, 2 seconds) shouldBe a[ActorRef]
+      Await.result(system.actorSelection("/user/test-manager").resolveOne, 2 seconds) shouldBe a[ActorRef]
+    }
+
+    it ("joins the akka cluster") {
+      val configFileName = writeConfigFile(Map(
+        "spark.submit.deployMode" -> "cluster"
+      ))
+      val testProbe = TestProbe()
+      cluster.subscribe(testProbe.ref, initialStateMode = InitialStateAsEvents, classOf[MemberUp])
+
+      JobManager.start(Seq(clusterAddr, "test-manager", configFileName).toArray,
+        makeSupervisorSystem, waitForTerminationDummy)
+
+      testProbe.expectMsgClass(classOf[MemberUp])
+    }
+
+    it ("calls wait for termination") {
+      var called = false
+      def waitForTermination(system: ActorSystem, master: String, deployMode: String) {
+        called = true
       }
+      val configFileName = writeConfigFile(Map(
+        "spark.submit.deployMode" -> "cluster"
+      ))
+
+      JobManager.start(Seq(clusterAddr, "test-manager", configFileName).toArray,
+        makeSupervisorSystem, waitForTermination)
+
+      called should be (true)
     }
-
-    it("should fail a job that requires job jar dependencies but doesn't provide the jar"){
-      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
-      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
-
-      uploadTestJar()
-      val jobJarDepsConfigs = ConfigFactory.parseString(
-        s"""
-           |dependent-jar-uris = []
-        """.stripMargin)
-
-      manager ! JobManagerActor.StartJob("demo", classPrefix + "jobJarDependenciesJob", jobJarDepsConfigs,
-        syncEvents ++ errorEvents)
-
-      expectMsgClass(startJobWait, classOf[JobErroredOut])
-    }
-
   }
 }

--- a/job-server/src/test/scala/spark/jobserver/JobServerSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobServerSpec.scala
@@ -1,0 +1,137 @@
+package spark.jobserver
+
+import java.nio.charset.Charset
+
+import akka.actor.{ActorRef, ActorSystem}
+import akka.util.Timeout
+import akka.testkit.TestKit
+import org.scalatest.{BeforeAndAfterAll, FunSpecLike, Matchers}
+import java.nio.file.Files
+
+import scala.concurrent.duration._
+import spark.jobserver.JobServer.InvalidConfiguration
+import spark.jobserver.common.akka
+
+import scala.concurrent.Await
+
+object JobServerSpec {
+  val system = ActorSystem("test")
+}
+
+class JobServerSpec extends TestKit(JobServerSpec.system) with FunSpecLike with Matchers
+  with BeforeAndAfterAll {
+
+  import com.typesafe.config._
+  import scala.collection.JavaConverters._
+
+  private val configFile = Files.createTempFile("job-server-config", ".conf")
+
+  override def afterAll() {
+    akka.AkkaTestUtils.shutdownAndWait(JobServerSpec.system)
+    Files.deleteIfExists(configFile)
+  }
+
+  def writeConfigFile(configMap: Map[String, Any]): String = {
+    val config = ConfigFactory.parseMap(configMap.asJava).withFallback(ConfigFactory.defaultOverrides())
+    Files.write(configFile,
+      Seq(config.root.render(ConfigRenderOptions.concise)).asJava,
+      Charset.forName("UTF-8"))
+    configFile.toAbsolutePath.toString
+  }
+
+  def makeSupervisorSystem(config: Config): ActorSystem = system
+  implicit val timeout: Timeout = 3 seconds
+
+  describe("Fails on invalid configuration") {
+    it("requires context-per-jvm in YARN mode") {
+      val configFileName = writeConfigFile(Map(
+        "spark.master " -> "yarn",
+        "spark.jobserver.context-per-jvm " -> false))
+
+      intercept[InvalidConfiguration] {
+        JobServer.start(Seq(configFileName).toArray, makeSupervisorSystem(_))
+      }
+    }
+
+    it("requires context-per-jvm in Mesos mode") {
+      val configFileName = writeConfigFile(Map(
+        "spark.master " -> "mesos://test:123",
+        "spark.jobserver.context-per-jvm " -> false))
+
+      intercept[InvalidConfiguration] {
+        JobServer.start(Seq(configFileName).toArray, makeSupervisorSystem(_))
+      }
+    }
+
+    it("requires context-per-jvm in cluster mode") {
+      val configFileName = writeConfigFile(Map(
+        "spark.submit.deployMode " -> "cluster",
+        "spark.jobserver.context-per-jvm " -> false))
+
+      intercept[InvalidConfiguration] {
+        JobServer.start(Seq(configFileName).toArray, makeSupervisorSystem(_))
+      }
+    }
+
+    it("does not support context-per-jvm and JobFileDAO") {
+      val configFileName = writeConfigFile(Map(
+        "spark.jobserver.context-per-jvm " -> true,
+        "spark.jobserver.jobdao" -> "spark.jobserver.io.JobFileDAO"))
+
+      intercept[InvalidConfiguration] {
+        JobServer.start(Seq(configFileName).toArray, makeSupervisorSystem(_))
+      }
+    }
+
+    it("does not support context-per-jvm and H2 in-memory DB") {
+      val configFileName = writeConfigFile(Map(
+        "spark.jobserver.context-per-jvm " -> true,
+        "spark.jobserver.jobdao" -> "spark.jobserver.io.JobSqlDAO",
+        "spark.jobserver.sqldao.jdbc.url" -> "jdbc:h2:mem"))
+
+      intercept[InvalidConfiguration] {
+        JobServer.start(Seq(configFileName).toArray, makeSupervisorSystem(_))
+      }
+    }
+
+    it("does not support cluster mode and H2 in-memory DB") {
+      val configFileName = writeConfigFile(Map(
+        "spark.submit.deployMode" -> "cluster",
+        "spark.jobserver.context-per-jvm " -> true,
+        "spark.jobserver.jobdao" -> "spark.jobserver.io.JobSqlDAO",
+        "spark.jobserver.sqldao.jdbc.url" -> "jdbc:h2:mem"))
+
+      intercept[InvalidConfiguration] {
+        JobServer.start(Seq(configFileName).toArray, makeSupervisorSystem(_))
+      }
+    }
+
+    it("does not support cluster mode and H2 file based DB") {
+      val configFileName = writeConfigFile(Map(
+        "spark.submit.deployMode" -> "cluster",
+        "spark.jobserver.context-per-jvm " -> true,
+        "spark.jobserver.jobdao" -> "spark.jobserver.io.JobSqlDAO",
+        "spark.jobserver.sqldao.jdbc.url" -> "jdbc:h2:file"))
+
+      intercept[InvalidConfiguration] {
+        JobServer.start(Seq(configFileName).toArray, makeSupervisorSystem(_))
+      }
+    }
+
+    it("starts some actors in local mode") {
+      val configFileName = writeConfigFile(Map(
+        "spark.master" -> "local[1]",
+        "spark.submit.deployMode" -> "client",
+        "spark.jobserver.context-per-jvm " -> false,
+        "spark.jobserver.sqldao.jdbc.url" -> "jdbc:h2:mem"))
+
+      JobServer.start(Seq(configFileName).toArray, makeSupervisorSystem(_))
+
+      Await.result(system.actorSelection("/user/dao-manager").resolveOne, 2 seconds) shouldBe a[ActorRef]
+      Await.result(system.actorSelection("/user/data-manager").resolveOne, 2 seconds) shouldBe a[ActorRef]
+      Await.result(system.actorSelection("/user/binary-manager").resolveOne, 2 seconds) shouldBe a[ActorRef]
+      Await.result(system.actorSelection("/user/context-supervisor").resolveOne, 2 seconds) shouldBe a[ActorRef]
+      Await.result(system.actorSelection("/user/job-info").resolveOne, 2 seconds) shouldBe a[ActorRef]
+    }
+  }
+}

--- a/job-server/src/test/scala/spark/jobserver/JobWithNamedRddsSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobWithNamedRddsSpec.scala
@@ -10,7 +10,7 @@ import org.apache.spark.rdd.RDD
 import com.typesafe.config.Config
 import spark.jobserver.common.akka.AkkaTestUtils
 
-class JobWithNamedRddsSpec extends JobSpecBase(JobManagerSpec.getNewSystem) {
+class JobWithNamedRddsSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) {
 
   val sc = new SparkContext("local[4]", getClass.getSimpleName, new SparkConf)
 


### PR DESCRIPTION
**Current behavior :** 
- Bevor #681: context config was written into a local `context.conf` file. this does not work with a job manager running on another host in the cluster (aka cluster mode)
- After #681: context config was converted into JSON and then transferred as argument (this results in problems with YARN (parsing `}}`) and has other downsides (see #915))
- Setting the spark master requires changes in job server config and `manager_start.sh` or `settings.sh`
- Cluster setup requires an external database accessible within the cluster.

**New behavior :**
*context config*
The job manager gets now initialized with cluster address and actor name as argument. After joining the cluster, the context config gets transferred via akka and the context initialized. This fixes #915.

*spark master*
The following config options can be set and will be used in `spark-submit` too:
- `spark.master` can be `local[...]`, `yarn`, `spark://...` or `mesos://...`
- `spark.submit.deployMode` can be `client` or `cluster`

*spark standalone cluster mode*
Spark does not transfer your job server config, jar and log4j config. You need to copy them on each host or adding them in e.g. HDFS and then set the following variable in your `settings.sh`: `REMOTE_JOBSERVER_DIR`
If your don't set the remote dir, files are transferred via `spark-submit --files...` (this works fine with e.g. YARN).

*embedded H2 database*
Job server can now host the database instance for you:
- set `spark.jobserver.startH2Server` to `true`
- set `spark.jobserver.sqldao.jdbc.url` to `"jdbc:h2:tcp://CLUSTER-IP:9092/h2-db;AUTO_RECONNECT=TRUE"`

*Akka interface*
To run akka in a cluster (to interact with remote job manager) add the following config:
```
akka {
  remote.netty.tcp {
    hostname = "FRONT-END-IP"
  }
}
```
This config ensures that akka binds to the right interface. The hostname option will be removed in the job manager config and the job then detects the right interface.

*Remote data files and jars*
PR #924 contains a solution to access files uploaded via the data API (`/data`). Jars and other binaries are already transferred via SQL backend.

*logging*
Same behavior as before in client mode. Cluster mode use `log4j-cluster.properties` (same config as the server options but with log output to stderr instead of a logfile). This works well with YARN and spark standalone containers.

**Other information**:
Tested on virtual cluster with YARN and spark standalone. Might be work with Mesos too.

This PR changes many files (constructor changes...). Code, test and doc changes are in its own commits to reduce the review complexity. Comments are welcome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/927)
<!-- Reviewable:end -->
