### PR TITLE
fix(job-server): JobSQLDAO: Move blobs to a separate table (#876)

### DIFF
--- a/job-server/src/main/scala/db/h2/migration/V0_7_4/V0_7_4__Migrate_Blobs.scala
+++ b/job-server/src/main/scala/db/h2/migration/V0_7_4/V0_7_4__Migrate_Blobs.scala
@@ -1,0 +1,63 @@
+package db.h2.migration.V0_7_4
+
+import java.sql.Connection
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.TimeoutException
+import scala.concurrent.duration.DurationInt
+
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration
+import org.slf4j.LoggerFactory
+
+import javax.sql.rowset.serial.SerialBlob
+import slick.dbio.DBIO
+import slick.driver.H2Driver.api.actionBasedSQLInterpolation
+import slick.jdbc.GetResult
+import slick.jdbc.PositionedParameters
+import slick.jdbc.SetParameter
+import spark.jobserver.slick.unmanaged.UnmanagedDatabase
+import java.sql.Blob
+
+class V0_7_4__Migrate_Blobs extends JdbcMigration {
+  private val Timeout = 10 minutes
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private case class BinaryContent(id: Int, binary: Blob)
+
+  private def logErrors = PartialFunction[Throwable, Unit] {
+    case e: Throwable => logger.error(e.getMessage, e)
+  }
+
+  private def insertBlob(db: UnmanagedDatabase, b: BinaryContent): Unit = {
+    implicit object SetSerialBlob extends SetParameter[SerialBlob] {
+      def apply(v: SerialBlob, pp: PositionedParameters) {
+        pp.setBlob(v)
+      }
+    }
+    val blob = new SerialBlob(b.binary.getBytes(1, b.binary.length().toInt))
+    val insertBlob = sqlu"""INSERT INTO BINARIES_CONTENTS ("BIN_ID", "BINARY") VALUES (${b.id}, ${blob})"""
+    Await.ready(db.run(insertBlob).recover{logErrors}, Timeout)
+  }
+
+  def migrate(c: Connection): Unit = {
+    val createContentsTable = sqlu"""CREATE TABLE BINARIES_CONTENTS (
+      BIN_ID  BIGINT  NOT NULL PRIMARY KEY,
+      BINARY  BLOB
+    );"""
+    implicit val getBinaryResult = GetResult[BinaryContent](r => BinaryContent(r.nextInt(), r.nextBlob()))
+    val getBinaryContents = sql"""SELECT BIN_ID, BINARY FROM BINARIES""".as[BinaryContent]
+    val dropColumn = sqlu"""ALTER TABLE BINARIES DROP COLUMN BINARY"""
+
+    val db = new UnmanagedDatabase(c)
+    c.setAutoCommit(false)
+    Await.ready(
+        for {
+          _ <- db.run(createContentsTable)
+          _ <- db.stream(getBinaryContents).foreach(b => insertBlob(db, b))
+          _ <- db.run(dropColumn)
+        } yield Unit, Timeout
+    ).recover{logErrors}
+    c.commit()
+  }
+}

--- a/job-server/src/main/scala/db/mysql/migration/V0_7_4/V0_7_4__Migrate_Blobs.scala
+++ b/job-server/src/main/scala/db/mysql/migration/V0_7_4/V0_7_4__Migrate_Blobs.scala
@@ -1,0 +1,62 @@
+package db.mysql.migration.V0_7_4
+
+import java.sql.Connection
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.DurationInt
+
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration
+import org.slf4j.LoggerFactory
+
+import javax.sql.rowset.serial.SerialBlob
+import slick.dbio.DBIO
+import slick.driver.MySQLDriver.api.actionBasedSQLInterpolation
+import slick.jdbc.GetResult
+import slick.jdbc.PositionedParameters
+import slick.jdbc.SetParameter
+import spark.jobserver.slick.unmanaged.UnmanagedDatabase
+import java.sql.Blob
+
+class V0_7_4__Migrate_Blobs extends JdbcMigration {
+  private val Timeout = 10 minutes
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private case class BinaryContent(id: Int, binary: Blob)
+
+  private def logErrors = PartialFunction[Throwable, Unit] {
+    case e: Throwable => logger.error(e.getMessage, e)
+  }
+
+  private def insertBlob(db: UnmanagedDatabase, b: BinaryContent): Unit = {
+    implicit object SetSerialBlob extends SetParameter[SerialBlob] {
+      def apply(v: SerialBlob, pp: PositionedParameters) {
+        pp.setBlob(v)
+      }
+    }
+    val blob = new SerialBlob(b.binary.getBytes(1, b.binary.length().toInt))
+    val insertBlob = sqlu"""INSERT INTO `BINARIES_CONTENTS` (`BIN_ID`, `BINARY`) VALUES (${b.id}, ${blob})"""
+    Await.ready(db.run(insertBlob).recover{logErrors}, Timeout)
+  }
+
+  def migrate(c: Connection): Unit = {
+    val createContentsTable = sqlu"""CREATE TABLE `BINARIES_CONTENTS` (
+      `BIN_ID`  SERIAL  NOT NULL PRIMARY KEY,
+      `BINARY`  LONGBLOB
+    );"""
+    implicit val getBinaryResult = GetResult[BinaryContent](r => BinaryContent(r.nextInt(), r.nextBlob()))
+    val getBinaryContents = sql"""SELECT `BIN_ID`, `BINARY` FROM `BINARIES`""".as[BinaryContent]
+    val dropColumn = sqlu"""ALTER TABLE `BINARIES` DROP COLUMN `BINARY`"""
+
+    val db = new UnmanagedDatabase(c)
+    c.setAutoCommit(false)
+    Await.ready(
+        for {
+          _ <- db.run(createContentsTable)
+          _ <- db.stream(getBinaryContents).foreach(b => insertBlob(db, b))
+          _ <- db.run(dropColumn)
+        } yield Unit, Timeout
+    ).recover{logErrors}
+    c.commit()
+  }
+}

--- a/job-server/src/main/scala/db/postgresql/migration/V0_7_4/V0_7_4__Migrate_Blobs.scala
+++ b/job-server/src/main/scala/db/postgresql/migration/V0_7_4/V0_7_4__Migrate_Blobs.scala
@@ -1,0 +1,66 @@
+package db.postgresql.migration.V0_7_4
+
+import java.sql.Connection
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.TimeoutException
+import scala.concurrent.duration.DurationInt
+
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration
+import org.slf4j.LoggerFactory
+
+import javax.sql.rowset.serial.SerialBlob
+import slick.dbio.DBIO
+import slick.driver.PostgresDriver.api.actionBasedSQLInterpolation
+import slick.jdbc.GetResult
+import slick.jdbc.PositionedParameters
+import slick.jdbc.SetParameter
+import spark.jobserver.slick.unmanaged.UnmanagedDatabase
+import java.sql.Blob
+
+class V0_7_4__Migrate_Blobs extends JdbcMigration {
+  private val Timeout = 10 minutes
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private case class BinaryContent(id: Int, binary: Blob)
+
+  private def logErrors = PartialFunction[Throwable, Unit] {
+    case e: Throwable => logger.error(e.getMessage, e)
+  }
+
+  private def insertBlob(db: UnmanagedDatabase, b: BinaryContent): Unit = {
+    implicit object SetSerialBlob extends SetParameter[SerialBlob] {
+      def apply(v: SerialBlob, pp: PositionedParameters) {
+        pp.setBlob(v)
+      }
+    }
+    val blob = new SerialBlob(b.binary.getBytes(1, b.binary.length().toInt))
+    val insertBlob = sqlu"""INSERT INTO "BINARIES_CONTENTS" ("BIN_ID", "BINARY") VALUES (${b.id}, ${blob})"""
+    Await.ready(db.run(insertBlob).recover{logErrors}, Timeout)
+  }
+
+  def migrate(c: Connection): Unit = {
+    val createContentsTable = sqlu"""CREATE TABLE "BINARIES_CONTENTS" (
+      "BIN_ID"  SERIAL  NOT NULL PRIMARY KEY,
+      "BINARY"  OID
+    );"""
+    val cleanupTrigger = sqlu"""CREATE TRIGGER t_binary BEFORE UPDATE OR DELETE ON "BINARIES_CONTENTS"
+                        FOR EACH ROW EXECUTE PROCEDURE lo_manage("BINARY")"""
+    implicit val getBinaryResult = GetResult[BinaryContent](r => BinaryContent(r.nextInt(), r.nextBlob()))
+    val getBinaryContents = sql"""SELECT "BIN_ID", "BINARY" FROM "BINARIES"""".as[BinaryContent]
+    val dropColumn = sqlu"""ALTER TABLE "BINARIES" DROP COLUMN "BINARY""""
+
+    val db = new UnmanagedDatabase(c)
+    c.setAutoCommit(false);
+    Await.ready(
+        for {
+          _ <- db.run(createContentsTable)
+          _ <- db.run(cleanupTrigger)
+          _ <- db.stream(getBinaryContents).foreach(b => insertBlob(db, b))
+          _ <- db.run(dropColumn)
+        } yield Unit, Timeout
+    ).recover{logErrors}
+    c.commit()
+  }
+}

--- a/job-server/src/main/scala/spark/jobserver/io/JobDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobDAO.scala
@@ -89,6 +89,7 @@ trait JobDAO {
     * @param appName
     */
   def deleteBinary(appName: String)
+
   /**
    * Return all applications name and their last upload times.
    *
@@ -175,8 +176,7 @@ trait JobDAO {
    * Returns the last upload time for a given app name.
    * @return Some(lastUploadedTime) if the app exists and the list of times is nonempty, None otherwise
    */
-  def getLastUploadTimeAndType(appName: String): Option[(DateTime, BinaryType)] =
-    Await.result(getApps, 60 seconds).get(appName).map(t => (t._2, t._1))
+  def getLastUploadTimeAndType(appName: String): Option[(DateTime, BinaryType)]
 
   /**
     * Fetch submited jar or egg content for remote driver and JobManagerActor to cache in local

--- a/job-server/src/main/scala/spark/jobserver/io/JobFileDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobFileDAO.scala
@@ -1,15 +1,15 @@
 package spark.jobserver.io
 
-import com.typesafe.config._
 import java.io._
 import java.nio.file.{Files, Paths}
 
+import com.typesafe.config._
 import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
 
 import scala.collection.mutable
-import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 /**
   * NB This class does NOT support persisting binary types
@@ -221,6 +221,10 @@ class JobFileDAO(config: Config) extends JobDAO {
 
   override def getJobConfig(jobId: String): Future[Option[Config]] = Future {
     configs.get(jobId)
+  }
+
+  override def getLastUploadTimeAndType(appName: String): Option[(DateTime, BinaryType)] = {
+    apps(appName).headOption.map(uploadTime => (uploadTime, BinaryType.Jar))
   }
 
   private def writeJobConfig(out: DataOutputStream, jobId: String, jobConfig: Config) {

--- a/job-server/src/main/scala/spark/jobserver/io/JobSqlDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobSqlDAO.scala
@@ -26,6 +26,12 @@ import javax.sql.rowset.serial.SerialBlob
 import slick.driver.JdbcProfile
 import slick.lifted.ProvenShape.proveShapeOf
 import spark.jobserver.JobManagerActor.ContextTerminatedException
+import slick.driver.JdbcProfile
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+import scala.reflect.runtime.universe
 
 class JobSqlDAO(config: Config) extends JobDAO with FileCacher {
   val slickDriverClass = config.getString("spark.jobserver.sqldao.slick-driver")
@@ -46,16 +52,22 @@ class JobSqlDAO(config: Config) extends JobDAO with FileCacher {
 
   // Definition of the tables
   //scalastyle:off
-  class Binaries(tag: Tag) extends Table[(Int, String, String, Timestamp, Blob)](tag, "BINARIES") {
+  class Binaries(tag: Tag) extends Table[(Int, String, String, Timestamp)](tag, "BINARIES") {
     def binId = column[Int]("BIN_ID", O.PrimaryKey, O.AutoInc)
     def appName = column[String]("APP_NAME")
     def binaryType = column[String]("BINARY_TYPE")
     def uploadTime = column[Timestamp]("UPLOAD_TIME")
+    def * = (binId, appName, binaryType, uploadTime)
+  }
+
+  class BinariesContents(tag: Tag) extends Table[(Int, Blob)](tag, "BINARIES_CONTENTS") {
+    def binId = column[Int]("BIN_ID", O.PrimaryKey)
     def binary = column[Blob]("BINARY")
-    def * = (binId, appName, binaryType, uploadTime, binary)
+    def * = (binId, binary)
   }
 
   val binaries = TableQuery[Binaries]
+  val binariesContents = TableQuery[BinariesContents]
 
   // Explicitly avoiding to label 'jarId' as a foreign key to avoid dealing with
   // referential integrity constraint violations.
@@ -173,14 +185,24 @@ class JobSqlDAO(config: Config) extends JobDAO with FileCacher {
     }
   }
 
+  override def getLastUploadTimeAndType(appName: String): Option[(DateTime, BinaryType)] = {
+    val query = binaries.filter(_.appName === appName)
+      .sortBy(_.uploadTime.desc)
+      .map(b => (b.uploadTime, b.binaryType)).result
+      .map{_.headOption.map(b => (convertDateSqlToJoda(b._1), BinaryType.fromString(b._2)))}
+
+    // Await.result(...) - same as it was in the base JobDAO version. Feel free to optimize this.
+    Await.result(db.run(query), 60 seconds)
+  }
+
   // Insert JarInfo and its jar into db and return the primary key associated with that row
   private def insertBinaryInfo(binInfo: BinaryInfo, binBytes: Array[Byte]): Future[Int] = {
-    db.run((binaries.map(j => j.*) += (
-      -1,
-      binInfo.appName,
-      binInfo.binaryType.name,
-      convertDateJodaToSql(binInfo.uploadTime),
-      new SerialBlob(binBytes))).transactionally)
+    val dbAction = (for {
+      binId <- binaries.returning(binaries.map(_.binId)) +=
+        (-1, binInfo.appName, binInfo.binaryType.name, convertDateJodaToSql(binInfo.uploadTime))
+      _ <- binariesContents.map(bc => bc.*) += (binId, new SerialBlob(binBytes))
+    } yield binId).transactionally
+    db.run(dbAction)
   }
 
   private def deleteBinaryInfo(appName: String): Future[Int] = {
@@ -206,10 +228,14 @@ class JobSqlDAO(config: Config) extends JobDAO with FileCacher {
                           binaryType: BinaryType,
                           uploadTime: DateTime): Future[Array[Byte]] = {
     val dateTime = convertDateJodaToSql(uploadTime)
-    val query = binaries.filter { bin =>
-      bin.appName === appName && bin.uploadTime === dateTime && bin.binaryType === binaryType.name
-    }.map(_.binary).result
-    db.run(query.head.map { b => b.getBytes(1, b.length.toInt) }.transactionally)
+    val query = for {
+      b <- binaries.filter { bin =>
+        bin.appName === appName && bin.uploadTime === dateTime && bin.binaryType === binaryType.name
+      }
+      bc <- binariesContents if b.binId === bc.binId
+    } yield bc.binary
+    val dbAction = query.result
+    db.run(dbAction.head.map { b => b.getBytes(1, b.length.toInt) }.transactionally)
   }
 
   private def queryBinaryId(appName: String, binaryType: BinaryType, uploadTime: DateTime): Future[Int] = {

--- a/job-server/src/test/scala/spark/jobserver/io/FlywayMigrationSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/FlywayMigrationSpec.scala
@@ -1,6 +1,6 @@
 package spark.jobserver.io
 
-import java.sql.{ResultSet, DriverManager, Connection}
+import java.sql.{Connection, DriverManager, ResultSet}
 
 import org.flywaydb.core.Flyway
 import org.scalatest.{FunSpec, Matchers}
@@ -48,7 +48,8 @@ class FlywayMigrationSpec extends FunSpec with Matchers {
     val h2Pass = ""
     val h2Driver = "org.h2.Driver"
 
-    it("should migrate from JAR schema to more generic BINARY schema") {
+    it("should migrate from JAR schema to more generic BINARY schema " +
+      "and move raw binaries into BINARIES_CONTENTS") {
       val flyway = new Flyway()
       flyway.setDataSource(h2Url, h2User, h2Pass)
       flyway.setLocations("db/h2/migration/V0_7_0")
@@ -57,8 +58,8 @@ class FlywayMigrationSpec extends FunSpec with Matchers {
       val statement = sqlConn.createStatement()
       statement.addBatch(
         """INSERT INTO JARS VALUES
-          |(1, 'ABC', '2012-01-01', 'DEADBEEF'),
-          |(2, 'DEF', '2012-02-01', 'BEADFACE');
+          |(1, 'ABC', '2012-01-01', X'deadbeef'),
+          |(2, 'DEF', '2012-02-01', X'beadface');
         """.stripMargin)
       statement.addBatch(
         """INSERT INTO JOBS VALUES
@@ -74,17 +75,26 @@ class FlywayMigrationSpec extends FunSpec with Matchers {
       sqlConn.commit()
       flyway.setLocations("db/h2/migration")
       flyway.migrate()
+
       val descBinaries = sqlConn.createStatement().executeQuery("SHOW COLUMNS FROM BINARIES")
       val descBinariesIt = ResultSetIterator(descBinaries){ r: ResultSet =>
         r.getString("FIELD")
       }
-      descBinariesIt.toList should be (List("BIN_ID", "APP_NAME", "UPLOAD_TIME", "BINARY_TYPE", "BINARY"))
+      descBinariesIt.toList should be (List("BIN_ID", "APP_NAME", "UPLOAD_TIME", "BINARY_TYPE"))
+
+      val descBinariesContents = sqlConn.createStatement().executeQuery("SHOW COLUMNS FROM BINARIES_CONTENTS")
+      val descBinariesContentsIt = ResultSetIterator(descBinariesContents){ r: ResultSet =>
+        r.getString("FIELD")
+      }
+      descBinariesContentsIt.toList should be (List("BIN_ID", "BINARY"))
+
       val descJobs = sqlConn.createStatement().executeQuery("SHOW COLUMNS FROM JOBS")
       val descJobsIt = ResultSetIterator(descJobs){ r: ResultSet =>
         r.getString("FIELD")
       }
       descJobsIt.toList should be (List(
         "JOB_ID", "CONTEXT_NAME", "BIN_ID", "CLASSPATH", "START_TIME", "END_TIME", "ERROR"))
+
       val descConfigs = sqlConn.createStatement().executeQuery("SHOW COLUMNS FROM CONFIGS")
       val descConfigsIt = ResultSetIterator(descConfigs){ r: ResultSet =>
         r.getString("FIELD")
@@ -98,10 +108,20 @@ class FlywayMigrationSpec extends FunSpec with Matchers {
           r.getString("APP_NAME"),
           r.getString("BINARY_TYPE"))
       }
-
       migratedBinariesIt.toList should be (List(
         (1, "ABC", "Jar"),
         (2, "DEF", "Jar")
+      ))
+
+      val migratedBinariesContents =
+        sqlConn.createStatement().executeQuery("SELECT BIN_ID, BINARY FROM BINARIES_CONTENTS")
+      val migratedBinariesContentsIt = ResultSetIterator(migratedBinariesContents){ r: ResultSet =>
+        (r.getInt("BIN_ID"),
+          r.getString("BINARY"))
+      }
+      migratedBinariesContentsIt.toList should be (List(
+        (1, "deadbeef"),
+        (2, "beadface")
       ))
     }
   }
@@ -121,7 +141,8 @@ class FlywayMigrationSpec extends FunSpec with Matchers {
     val pgPass = "pass"
     val pgDriver = "org.postgresql.Driver"
 
-    ignore("should migrate from JAR schema to more generic BINARY schema") {
+    ignore("should migrate from JAR schema to more generic BINARY schema " +
+      "and move raw binaries into BINARIES_CONTENTS") {
       val flyway = new Flyway()
       flyway.setDataSource(pgUrl, pgUser, pgPass)
       flyway.clean()
@@ -131,8 +152,8 @@ class FlywayMigrationSpec extends FunSpec with Matchers {
       val statement = sqlConn.createStatement()
       statement.addBatch(
         """INSERT INTO "JARS" VALUES
-          |(1, 'ABC', '2012-01-01', 'DEADBEEF'),
-          |(2, 'DEF', '2012-02-01', 'BEADFACE');
+          |(1, 'ABC', '2012-01-01', X'deadbeef'),
+          |(2, 'DEF', '2012-02-01', X'beadface');
         """.stripMargin)
       statement.addBatch(
         """INSERT INTO "JOBS" VALUES
@@ -178,6 +199,17 @@ class FlywayMigrationSpec extends FunSpec with Matchers {
       migratedBinariesIt.toList should be (List(
         (1, "ABC", "Jar"),
         (2, "DEF", "Jar")
+      ))
+
+      val migratedBinariesContents =
+        sqlConn.createStatement().executeQuery("SELECT \"BIN_ID\", \"BINARY\" FROM \"BINARIES_CONTENTS\"")
+      val migratedBinariesContentsIt = ResultSetIterator(migratedBinariesContents){ r: ResultSet =>
+        (r.getInt("BIN_ID"),
+          r.getString("BINARY"))
+      }
+      migratedBinariesContentsIt.toList should be (List(
+        (1, "deadbeef"),
+        (2, "beadface")
       ))
     }
   }

--- a/job-server/src/test/scala/spark/jobserver/io/JobDAOActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/JobDAOActorSpec.scala
@@ -5,11 +5,13 @@ import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import com.typesafe.config.Config
 import org.joda.time.DateTime
 import org.scalatest.{BeforeAndAfterAll, FunSpecLike, Matchers}
+import spark.jobserver.common.akka.AkkaTestUtils
 import spark.jobserver.io.JobDAOActor._
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
+
 import spark.jobserver.common.akka.AkkaTestUtils
 
 object JobDAOActorSpec {
@@ -20,7 +22,6 @@ object JobDAOActorSpec {
   val cleanupProbe = TestProbe()(system)
 
   object DummyDao extends JobDAO{
-
     val jarContent = Array.empty[Byte]
 
     override def saveBinary(appName: String, binaryType: BinaryType,
@@ -62,6 +63,8 @@ object JobDAOActorSpec {
     override def getJobConfigs: Future[Map[String, Config]] = ???
 
     override def getJobConfig(jobId: String): Future[Option[Config]] = ???
+
+    override def getLastUploadTimeAndType(appName: String): Option[(DateTime, BinaryType)] = ???
 
     override def deleteBinary(appName: String): Unit = {
       appName match {


### PR DESCRIPTION
* Separate the BINARIES table into BINARIES and BINARIES_CONTENTS, so
that only the BINARIES_CONTENTS table contains the "BINARY" (Blob)
column. Both tables can be joined on the same BIN_ID.

* Optimize the JobDAO.getLastUploadTimeAndType(...) method - make it
abstract and implement an optimized version in the JobFileDAO and
JobSqlDAO.

This is the result of rebasing pull request #886 onto current master and
reimplementing the migration in JDBC migration since blob columns cannot
be migrated using a SQL script.

**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ? not needed

**Current behavior :** 
Uploaded jars are stored in blob column "BINARY" in table "BINARIES".

**New behavior :**
Uploaded jars are stored in blob column "BINARY" in separate table "BINARIES_CONTENTS" which only contains BIN_ID (primary key) and the blob column.

**BREAKING CHANGES**
No breaking changes

**Other information**:
Existing blobs are migrated from BINARIES to BINARIES_CONTENTS