### PR TITLE
feat(jobserver): Add JMX metric for job cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ spark-jobserver provides a RESTful interface for submitting and managing [Apache
 This repo contains the complete Spark job server project, including unit tests and deploy scripts.
 It was originally started at [Ooyala](http://www.ooyala.com), but this is now the main development repo.
 
-Other useful links: [Troubleshooting Tips](doc/troubleshooting.md), [Yarn tips](doc/yarn.md), [Mesos tips](doc/mesos.md).
+Other useful links: [Troubleshooting Tips](doc/troubleshooting.md), [Yarn tips](doc/yarn.md), [Mesos tips](doc/mesos.md), [JMX tips](doc/jmx.md).
 
 Also see [Chinese docs / 中文](doc/chinese/job-server.md).
 

--- a/doc/jmx.md
+++ b/doc/jmx.md
@@ -1,0 +1,12 @@
+#### JMX
+To read JMX metrics, you can use [jconsole](http://docs.oracle.com/javase/7/docs/technotes/guides/management/jconsole.html) if you have an option of GUI. Otherwise you can use a cli utility named `jmxcli`. Here are the steps
+
+- `wget https://github.com/downloads/vladimirvivien/jmx-cli/jmxcli-0.1.2-bin.zip`
+- `unzip jmxcli-0.1.2-bin.zip -d <folder>`
+- `cd <folder>`
+- execute `java -jar cli.jar`
+- Do `ps` to list all the JVMs
+- Connect with JVM using `connect pid:<pid_id>`
+- Use `list` to see all the possible mbeans
+- To get the current value of a metric use for example
+```exec bean:"\"spark.jobserver\":name=\"job-cache-size\",type=\"JobCacheImpl\"" get:Value```


### PR DESCRIPTION
A helpful metric to see the current job cache size.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
N/A


**New behavior :**
A new job-cache metric is exposed



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/944)
<!-- Reviewable:end -->
