### PR TITLE
refactor(jobserver): Remove redundant caching code

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/io/JobCassandraDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobCassandraDAO.scala
@@ -3,7 +3,6 @@ package spark.jobserver.io
 import java.io.File
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer
-import java.nio.file.{Files, Paths}
 import java.util.UUID
 
 import scala.collection.convert.WrapAsJava
@@ -409,17 +408,5 @@ class JobCassandraDAO(config: Config) extends JobDAO with FileCacher {
       addColumn(ErrorStackTrace, DataType.text)
 
     session.execute(runningJobsView)
-  }
-
-  override def getBinaryContent(appName: String, binaryType: BinaryType,
-                                uploadTime: DateTime): Array[Byte] = {
-    val jarFile = new File(rootDir, createBinaryName(appName, binaryType, uploadTime))
-    if (!jarFile.exists()) {
-      val binBytes = fetchBinary(appName, binaryType, uploadTime)
-      cacheBinary(appName, binaryType, uploadTime, binBytes)
-      binBytes
-    } else {
-      Files.readAllBytes(Paths.get(jarFile.getAbsolutePath))
-    }
   }
 }

--- a/job-server/src/main/scala/spark/jobserver/io/JobDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobDAO.scala
@@ -184,14 +184,4 @@ trait JobDAO {
    * @return Some(lastUploadedTime) if the app exists and the list of times is nonempty, None otherwise
    */
   def getLastUploadTimeAndType(appName: String): Option[(DateTime, BinaryType)]
-
-  /**
-    * Fetch submited jar or egg content for remote driver and JobManagerActor to cache in local
-    * @param appName
-    * @param uploadTime
-    * @return
-    */
-  def getBinaryContent(appName: String,
-                       binaryType: BinaryType,
-                       uploadTime: DateTime): Array[Byte]
 }

--- a/job-server/src/main/scala/spark/jobserver/io/JobDAOActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobDAOActor.scala
@@ -28,9 +28,6 @@ object JobDAOActor {
   case class GetBinaryPath(appName: String,
                            binaryType: BinaryType,
                            uploadTime: DateTime) extends JobDAORequest
-  case class GetBinaryContent(appName: String,
-                              binaryType: BinaryType,
-                              uploadTime: DateTime) extends JobDAORequest
 
   case class SaveJobInfo(jobInfo: JobInfo) extends JobDAORequest
   case class GetJobInfos(limit: Int) extends JobDAORequest
@@ -45,7 +42,6 @@ object JobDAOActor {
   sealed trait JobDAOResponse
   case class Apps(apps: Map[String, (BinaryType, DateTime)]) extends JobDAOResponse
   case class BinaryPath(binPath: String) extends JobDAOResponse
-  case class BinaryContent(content: Array[Byte]) extends JobDAOResponse
   case class JobInfos(jobInfos: Seq[JobInfo]) extends JobDAOResponse
   case class JobConfig(jobConfig: Option[Config]) extends JobDAOResponse
   case class LastUploadTimeAndType(uploadTimeAndType: Option[(DateTime, BinaryType)]) extends JobDAOResponse
@@ -91,9 +87,6 @@ class JobDAOActor(dao: JobDAO) extends InstrumentedActor {
 
     case GetLastUploadTimeAndType(appName) =>
       sender() ! LastUploadTimeAndType(dao.getLastUploadTimeAndType(appName))
-
-    case GetBinaryContent(appName, binaryType, uploadTime) =>
-      sender() ! BinaryContent(dao.getBinaryContent(appName, binaryType, uploadTime))
 
     case CleanContextJobInfos(contextName, endTime) =>
       dao.cleanRunningJobInfosForContext(contextName, endTime)

--- a/job-server/src/main/scala/spark/jobserver/io/JobFileDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobFileDAO.scala
@@ -1,7 +1,6 @@
 package spark.jobserver.io
 
 import java.io._
-import java.nio.file.{Files, Paths}
 
 import com.typesafe.config._
 import org.joda.time.DateTime
@@ -237,11 +236,6 @@ class JobFileDAO(config: Config) extends JobDAO {
     in.readUTF,
     ConfigFactory.parseString(in.readUTF)
   )
-
-  override def getBinaryContent(appName: String, binaryType: BinaryType,
-                                uploadTime: DateTime): Array[Byte] = {
-    Files.readAllBytes(Paths.get(retrieveBinaryFile(appName, binaryType, uploadTime)))
-  }
 
   /**
     * Delete a jar.

--- a/job-server/src/main/scala/spark/jobserver/io/JobSqlDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobSqlDAO.scala
@@ -1,7 +1,6 @@
 package spark.jobserver.io
 
 import java.io.File
-import java.nio.file.{Files, Paths}
 import java.sql.{Blob, Timestamp}
 import javax.sql.DataSource
 import javax.sql.rowset.serial.SerialBlob
@@ -372,25 +371,6 @@ class JobSqlDAO(config: Config) extends JobDAO with FileCacher {
     }
     for (r <- db.run(joinQuery.result)) yield {
       r.map(jobInfoFromRow).headOption
-    }
-  }
-
-  /**
-    * Fetch submited jar or egg content for remote driver and JobManagerActor to cache in local
-    *
-    * @param appName
-    * @param uploadTime
-    * @return
-    */
-  override def getBinaryContent(appName: String, binaryType: BinaryType,
-                                uploadTime: DateTime): Array[Byte] = {
-    val jarFile = new File(rootDir, createBinaryName(appName, binaryType, uploadTime))
-    if (!jarFile.exists()) {
-      val binBytes = Await.result(fetchBinary(appName, binaryType, uploadTime), 60.seconds)
-      cacheBinary(appName, binaryType, uploadTime, binBytes)
-      binBytes
-    } else {
-      Files.readAllBytes(Paths.get(jarFile.getAbsolutePath))
     }
   }
 }

--- a/job-server/src/test/scala/spark/jobserver/InMemoryDAO.scala
+++ b/job-server/src/test/scala/spark/jobserver/InMemoryDAO.scala
@@ -86,12 +86,7 @@ class InMemoryDAO extends JobDAO {
     Await.result(getApps, 60 seconds).get(appName).map(t => (t._2, t._1))
   }
 
-  override def getBinaryContent(appName: String, binaryType: BinaryType,
-                                uploadTime: DateTime): Array[Byte] = {
-    binaries((appName, binaryType, uploadTime))
-  }
-
-  override def deleteBinary(appName: String): Unit = {
+override def deleteBinary(appName: String): Unit = {
     binaries = binaries.filter { case ((name, _, _), _) => appName != name }
   }
 }

--- a/job-server/src/test/scala/spark/jobserver/io/JobCassandraDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/JobCassandraDAOSpec.scala
@@ -137,19 +137,6 @@ class JobCassandraDAOSpec extends TestJarFinder with FunSpecLike with Matchers w
       jarFile.length() should equal (retrieved.length())
       Files.toByteArray(jarFile) should equal(Files.toByteArray(retrieved))
     }
-
-    it("should retrieve the jar binary content for remote job manager") {
-      // chack the pre-condition
-      jarFile.exists() should equal (false)
-
-      // retrieve the jar content
-      val jarBinaryContent: Array[Byte] = dao.getBinaryContent(jarInfo.appName, jarInfo.binaryType, jarInfo.uploadTime)
-
-      // test
-      jarFile.exists() should equal (true)
-      jarBinaryContent.length should equal (jarBytes.length)
-      jarBinaryContent should equal(jarBytes)
-    }
   }
 
   describe("saveJobConfig() tests") {

--- a/job-server/src/test/scala/spark/jobserver/io/JobDAOActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/JobDAOActorSpec.scala
@@ -22,7 +22,6 @@ object JobDAOActorSpec {
   val cleanupProbe = TestProbe()(system)
 
   object DummyDao extends JobDAO{
-    val jarContent = Array.empty[Byte]
 
     override def saveBinary(appName: String, binaryType: BinaryType,
                             uploadTime: DateTime, binaryBytes: Array[Byte]): Unit = {
@@ -37,14 +36,6 @@ object JobDAOActorSpec {
         "app1" -> (BinaryType.Jar, dt),
         "app2" -> (BinaryType.Egg, dtplus1)
       ))
-
-    override def getBinaryContent(appName: String, binaryType: BinaryType,
-                                  uploadTime: DateTime): Array[Byte] = {
-      appName match {
-        case "failOnThis" => throw new Exception("get binary content failure")
-        case _ => jarContent
-      }
-    }
 
     override def retrieveBinaryFile(appName: String,
                                     binaryType: BinaryType, uploadTime: DateTime): String = ???
@@ -126,11 +117,6 @@ class JobDAOActorSpec extends TestKit(JobDAOActorSpec.system) with ImplicitSende
     it("should get JobInfos") {
       daoActor ! GetJobInfos(1)
       expectMsg(JobInfos(Seq()))
-    }
-
-    it("should get binary content") {
-      daoActor ! GetBinaryContent("succeed", BinaryType.Jar, DateTime.now)
-      expectMsg(BinaryContent(DummyDao.jarContent))
     }
 
     it("should request jobs cleanup") {

--- a/job-server/src/test/scala/spark/jobserver/io/JobSqlDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/JobSqlDAOSpec.scala
@@ -133,18 +133,6 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
       jarFile.exists() should equal (true)
       jarFilePath should equal (jarFile.getAbsolutePath)
     }
-
-    it("should retrieve the jar binary content for remote job manager") {
-      // chack the pre-condition
-      jarFile.exists() should equal (false)
-
-      // retrieve the jar content
-      val jarBinaryContent: Array[Byte] = dao.getBinaryContent(jarInfo.appName, BinaryType.Jar, jarInfo.uploadTime)
-
-      // test
-      jarFile.exists() should equal (true)
-      jarBinaryContent should equal (jarBytes)
-    }
   }
 
   describe("save and get Python eggs") {


### PR DESCRIPTION
Mesos cluster change[1] introduced this redundant
caching and can be safely removed. Now, FileCacher
is the only class responsible for caching jars. The
discussion regarding the consent of stakeholders is
here [2].

Also removing all the instances of GetBinaryContent
because it was only used by redundant change.

This change was tested with client and cluster mode.

[1] https://github.com/spark-jobserver/spark-jobserver/pull/681/files
[2] https://github.com/spark-jobserver/spark-jobserver/commit/9084053cf6b09e02ce8c148af7745f8182cc0755#commitcomment-25033986

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/949)
<!-- Reviewable:end -->
