### PR TITLE
feat(jobserver): Enable/disable jar caching on upload

### DIFF
--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -31,7 +31,7 @@ spark {
 
     # Cache binary on upload.
     # If set to false, the binary will be cached on job start only.
-    cache-on-upload = true;
+    cache-on-upload = true
 
     filedao {
       rootdir = /tmp/spark-jobserver/filedao/data

--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -29,6 +29,10 @@ spark {
     #   test = /path/to/my/test.jar
     # }
 
+    # Cache binary on upload.
+    # If set to false, the binary will be cached on job start only.
+    cache-on-upload = true;
+
     filedao {
       rootdir = /tmp/spark-jobserver/filedao/data
     }

--- a/job-server/src/main/scala/spark/jobserver/io/JobSqlDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobSqlDAO.scala
@@ -10,7 +10,6 @@ import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.DurationInt
 import scala.reflect.runtime.universe
-import scala.util.Try
 
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
@@ -138,7 +137,7 @@ class JobSqlDAO(config: Config) extends JobDAO with FileCacher {
                           binaryType: BinaryType,
                           uploadTime: DateTime,
                           binBytes: Array[Byte]) {
-    val cacheOnUploadEnabled = Try(config.getBoolean("spark.jobserver.cache-on-upload")).getOrElse(true)
+    val cacheOnUploadEnabled = config.getBoolean("spark.jobserver.cache-on-upload")
     if (cacheOnUploadEnabled) {
       // The order is important. Save the jar file first and then log it into database.
       cacheBinary(appName, binaryType, uploadTime, binBytes)

--- a/job-server/src/test/resources/local.test.jobsqldao.conf
+++ b/job-server/src/test/resources/local.test.jobsqldao.conf
@@ -3,6 +3,8 @@
 spark.jobserver {
   jobdao = spark.jobserver.io.JobSqlDAO
 
+  cache-on-upload = true
+
   cassandra {
     hosts = ["localhost:9142"]
     chunk-size-in-kb = 8

--- a/job-server/src/test/resources/local.test.jobsqldao_dbcp.conf
+++ b/job-server/src/test/resources/local.test.jobsqldao_dbcp.conf
@@ -3,6 +3,8 @@
 spark.jobserver {
   jobdao = spark.jobserver.io.JobSqlDAO
 
+  cache-on-upload = true
+
   sqldao {
     rootdir = /tmp/spark-job-server-test/sqldao/data
     # https://coderwall.com/p/a2vnxg

--- a/job-server/src/test/scala/spark/jobserver/io/JobSqlDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/JobSqlDAOSpec.scala
@@ -122,6 +122,25 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
       apps(jarInfo.appName) should equal ((BinaryType.Jar, jarInfo.uploadTime))
     }
 
+    it("should be able to save one jar and get it back without creating a cache") {
+      val configNoCache = config.withValue("spark.jobserver.cache-on-upload", ConfigValueFactory.fromAnyRef(false))
+      val daoNoCache = new JobSqlDAO(configNoCache)
+      // check the pre-condition
+      jarFile.exists() should equal (false)
+
+      // save
+      daoNoCache.saveBinary(jarInfo.appName, BinaryType.Jar, jarInfo.uploadTime, jarBytes)
+
+      // read it back
+      val apps: Map[String, (BinaryType, DateTime)] =
+        Await.result(daoNoCache.getApps, timeout).filter(_._2._1 == BinaryType.Jar)
+
+      // test
+      jarFile.exists() should equal (false)
+      apps.keySet should equal (Set(jarInfo.appName))
+      apps(jarInfo.appName) should equal ((BinaryType.Jar, jarInfo.uploadTime))
+    }
+
     it("should be able to retrieve the jar file") {
       // check the pre-condition
       jarFile.exists() should equal (false)
@@ -388,6 +407,7 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
       apps.keys should not contain (jarInfo.appName)
     }
   }
+
 }
 
 class JobSqlDAODBCPSpec extends JobSqlDAOSpec {


### PR DESCRIPTION
Currently as soon as the jar is upload using /binaries
endpoint, it is cached on filesystem. On a high usage
SJS, disk is important and a trend has been seen where
users upload jars but don't start jobs. This change
gives the option to admin to cache jars on job start
only.

The property "spark.jobserver.cache-on-upload" is
configurable and can have the value true/false.

**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** As soon as the jar is upload using /binaries
endpoint, it is cached on filesystem.



**New behavior :** If the property "spark.jobserver.cache-on-upload" is set to false, jar will be only cached on job start.



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/950)
<!-- Reviewable:end -->
