### PR TITLE
fix(webapi): add missing context deletion timeout

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/WebApi.scala
+++ b/job-server/src/main/scala/spark/jobserver/WebApi.scala
@@ -134,6 +134,7 @@ class WebApi(system: ActorSystem,
       .fold(100 * 1024)(config.getBytes(_).toInt)
 
   val contextTimeout = SparkJobUtils.getContextCreationTimeout(config)
+  val contextDeletionTimeout = SparkJobUtils.getContextDeletionTimeout(config)
   val bindAddress = config.getString("spark.jobserver.bind-address")
 
   val logger = LoggerFactory.getLogger(getClass)
@@ -405,7 +406,7 @@ class WebApi(system: ActorSystem,
           //  and currently running jobs will be lost.  Use with care!
           path(Segment) { (contextName) =>
             val (cName, _) = determineProxyUser(config, authInfo, contextName)
-            val future = supervisor ? StopContext(cName)
+            val future = (supervisor ? StopContext(cName))(contextDeletionTimeout.seconds)
             respondWithMediaType(MediaTypes.`application/json`) { ctx =>
               future.map {
                 case ContextStopped => ctx.complete(StatusCodes.OK, successMap("Context stopped"))


### PR DESCRIPTION
Add explicit deletion timeout for StopContext message.
In #727 there was a contextDeletionTimeout added which determines how
long we wait for a context to stop. WebApi does not respect this timeout
though, implicit timeout for StopContext message is much shorter than
actual contextDeletionTimeout. Fix by adding explicit timeout for
StopContext message.

**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
WebApi timeouts for StopContext message sooner that actual stop-context timeout 
(contextDeletionTimeout)


**New behavior :**
WebApi timeouts StopContext after contextDeletionTimeout

**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/951)
<!-- Reviewable:end -->
