### PR TITLE
misc(build): disable assembly in job-server module

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,7 +582,7 @@ See also running on [cluster](doc/cluster.md), [YARN client](doc/yarn.md), on [E
 
 The `server_start.sh` script uses `spark-submit` under the hood and may be passed any of the standard extra arguments from `spark-submit`.
 
-NOTE: by default the assembly jar from `job-server-extras`, which includes support for SQLContext and HiveContext, is used.  If you face issues with all the extra dependencies, consider modifying the install scripts to invoke `sbt job-server/assembly` instead, which doesn't include the extra dependencies.
+NOTE: Under the hood, the deploy scripts generate an assembly jar from the `job-server-extras` project.  Generating assemblies from other projects may not include all the necessary components for job execution.
 
 ### Context per JVM
 

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val akkaApp = Project(id = "akka-app", base = file("akka-app"))
 lazy val jobServer = Project(id = "job-server", base = file("job-server"))
   .settings(commonSettings)
   .settings(revolverSettings)
-  .settings(Assembly.settings)
+  .settings(assembly := null.asInstanceOf[File])
   .settings(
     description := "Spark as a Service: a RESTful job server for Apache Spark",
     libraryDependencies ++= sparkDeps ++ slickDeps ++ cassandraDeps ++ securityDeps ++ coreTestDeps,
@@ -31,7 +31,6 @@ lazy val jobServer = Project(id = "job-server", base = file("job-server"))
     fullClasspath in Compile <<= (fullClasspath in Compile).map { classpath =>
       extraJarPaths ++ classpath
     },
-    test in assembly := {},
     fork in Test := true
   )
   .settings(publishSettings)


### PR DESCRIPTION
Assembly in job-server module without extras doesn't make much sense; that will not allow most jobs to run.  Explicitly disable the assembly to limit user errors, and clarify as such in the README.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
See #957 for example and many others.  Right now if someone does `sbt assembly` of all modules then an assembly from both job-server and job-server-extras is generated, leading to confusion. Furthermore the `job-server` assembly sometimes errors out.

**New behavior :**
Assembly jar from `job-server` module is no longer built.

**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/959)
<!-- Reviewable:end -->
