### PR TITLE
fix(jobserver): return 404 for deletion of non existing binary

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/WebApi.scala
+++ b/job-server/src/main/scala/spark/jobserver/WebApi.scala
@@ -267,6 +267,7 @@ class WebApi(system: ActorSystem,
           respondWithMediaType(MediaTypes.`application/json`) { ctx =>
             future.map {
               case BinaryDeleted => ctx.complete(StatusCodes.OK)
+              case NoSuchBinary => notFound(ctx, s"can't find binary with name $appName")
             }.recover {
               case e: Exception => ctx.complete(500, errMap(e, "ERROR"))
             }
@@ -353,7 +354,7 @@ class WebApi(system: ActorSystem,
             case WebUIForContext(name, Some(url)) =>
               ctx.complete(200, Map("context" -> contextName, "url" -> url))
             case WebUIForContext(name, None) => ctx.complete(200, Map("context" -> contextName))
-            case NoSuchContext => ctx.complete(404, s"can't find context with name $contextName")
+            case NoSuchContext => notFound(ctx, s"can't find context with name $contextName")
 
           }.recover {
             case e: Exception => ctx.complete(500, errMap(e, "ERROR"))

--- a/job-server/src/main/scala/spark/jobserver/io/JobSqlDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobSqlDAO.scala
@@ -21,6 +21,7 @@ import slick.driver.JdbcProfile
 import slick.lifted.ProvenShape.proveShapeOf
 import spark.jobserver.JobManagerActor.ContextTerminatedException
 import spray.http.ErrorInfo
+import spark.jobserver.util.NoSuchBinaryException
 
 class JobSqlDAO(config: Config) extends JobDAO with FileCacher {
   val slickDriverClass = config.getString("spark.jobserver.sqldao.slick-driver")
@@ -159,7 +160,7 @@ class JobSqlDAO(config: Config) extends JobDAO with FileCacher {
     */
   override def deleteBinary(appName: String): Unit = {
     if (Await.result(deleteBinaryInfo(appName), 60 seconds) == 0) {
-      throw new SlickException(s"Failed to delete binary: $appName from database")
+      throw new NoSuchBinaryException(appName)
     }
     cleanCacheBinaries(appName)
   }

--- a/job-server/src/main/scala/spark/jobserver/util/CustomException.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/CustomException.scala
@@ -1,0 +1,5 @@
+package spark.jobserver.util
+
+case class NoSuchBinaryException(private val appName: String) extends Exception {
+  private val message = s"can't find binary: $appName in database";
+}

--- a/job-server/src/test/scala/spark/jobserver/WebApiMainRoutesSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiMainRoutesSpec.scala
@@ -104,6 +104,12 @@ class WebApiMainRoutesSpec extends WebApiSpec {
         status should be (OK)
       }
     }
+
+    it("should respond with 404 Not Found if binary was not found during deletion") {
+      Delete("/binaries/badbinary") ~> sealRoute(routes) ~> check {
+        status should be (NotFound)
+      }
+    }
   }
 
   describe("list jobs") {

--- a/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
@@ -20,6 +20,7 @@ import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success}
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.Duration
+import spark.jobserver.util.NoSuchBinaryException
 
 // Tests web response codes and formatting
 // Does NOT test underlying Supervisor / JarManager functionality
@@ -136,6 +137,7 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
       case StoreBinary("daofail", _, _) => sender ! BinaryStorageFailure(new Exception("DAO failed to store"))
       case StoreBinary(_, _, _)         => sender ! BinaryStored
 
+      case DeleteBinary("badbinary") => sender ! NoSuchBinary
       case DeleteBinary(_) => sender ! BinaryDeleted
 
       case DataManagerActor.StoreData("errorfileToRemove", _) => sender ! DataManagerActor.Error


### PR DESCRIPTION
* Return 404 in case of deletion of non existing binary
* Add test for this case

**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
If someone tries to delete non existing binary, exception is thrown.
This behavior differs from the behavior of contexts and jobs in the same situation, they return 404


**New behavior :**
Return 404 in case of deletion of non existing binary


**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/979)
<!-- Reviewable:end -->
