### PR TITLE
feat(jobserver): Pass cxt config to manager start

### DIFF
--- a/bin/manager_start.sh
+++ b/bin/manager_start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Script to start the job manager
-# args: <master> <deployMode> <akkaAdress> <actorName> <workDir> [<proxyUser>]
+# args: <master> <deployMode> <akkaAdress> <actorName> <workDir> <contextConfig> [<proxyUser>]
 set -e
 
 get_abs_script_path() {
@@ -50,8 +50,8 @@ else
   GC_OPTS="$GC_OPTS -Xloggc:$5/gc.out"
 fi
 
-if [ -n "$6" ]; then
-  SPARK_SUBMIT_OPTIONS="$SPARK_SUBMIT_OPTIONS --proxy-user $6"
+if [ -n "$7" ]; then
+  SPARK_SUBMIT_OPTIONS="$SPARK_SUBMIT_OPTIONS --proxy-user $7"
 fi
 
 if [ -n "$JOBSERVER_KEYTAB" ]; then

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -241,7 +241,9 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
       Map("is-adhoc" -> isAdHoc.toString, "context.name" -> name).asJava
     ).withFallback(contextConfig)
 
-    var managerArgs = Seq(master, deployMode, selfAddress.toString, contextActorName, contextDir.toString)
+    val conStr = mergedContextConfig.root.render(ConfigRenderOptions.concise())
+    var managerArgs = Seq(master, deployMode, selfAddress.toString,
+      contextActorName, contextDir.toString, conStr)
     // extract spark.proxy.user from contextConfig, if available and pass it to manager start command
     if (contextConfig.hasPath(SparkJobUtils.SPARK_PROXY_USER_PARAM)) {
       managerArgs = managerArgs :+ contextConfig.getString(SparkJobUtils.SPARK_PROXY_USER_PARAM)


### PR DESCRIPTION
This feature adds back something that was changed in the refactoring
around starting up in cluster mode, namely, it gives you access to the
entire context configuration.

The reason for this change is that it allows for more flexibility in
scheduling your driver.

For example, in yarn or mesos mode, we might not need a very large SJS
instance in terms of memory, but would like a large driver for some
contexts. Currently, there is no way to get information at runtime about
the context to create. By passing this configuration, the manager_start
script can inspect the config, extract values, and pass the appropriate
options (such as `--driver-memory` and `--driver-cores`) to
spark-submit.

This is implemented such that it comes before the optional proxy-user
argument. This fixes the default manager_start.sh command but could be a
slightly breaking change to any customized manager_start.sh scripts that
make use of proxy-user.

The other option is to put it after the optional proxy-user command, but
that might be a bit more clunky. Feedback appreciated!

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ? (no applicable tests)
- [x] Docs have been added / updated (for bug fixes / features) ? (no applicable docs)

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
No context-config is passed to the manager_start script, which doesn't allow for some run-time configuration of launched drivers 


**New behavior :**
context-config is passed as a json string as the 6th argument to manager_start.sh. This allows for runtime configuration of driver settings based on the context options passed by the user



**BREAKING CHANGES**

This contains a minor breaking change to custom manager_start scripts. If the user is using the default manager_start script, this change won't impact them. 

**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/988)
<!-- Reviewable:end -->
