### PR TITLE
feat(webapi): Add application id to route /contexts/<context>

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -22,7 +22,7 @@ import akka.pattern.gracefulStop
 import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
 import spark.jobserver.io.JobDAOActor.CleanContextJobInfos
-import spark.jobserver.JobManagerActor.{GetSparkWebUIUrl, NoSparkWebUI, SparkContextDead, SparkWebUIUrl}
+import spark.jobserver.JobManagerActor.{GetContexData, ContexData, SparkContextDead}
 
 /**
  * The AkkaClusterSupervisorActor launches Spark Contexts as external processes
@@ -116,14 +116,15 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
     case ListContexts =>
       sender ! contexts.keys.toSeq
 
-   case GetSparkWebUI(name) =>
+    case GetSparkContexData(name) =>
       contexts.get(name) match {
         case Some((actor, _)) =>
-          val future = (actor ? GetSparkWebUIUrl)(30.seconds)
+          val future = (actor ? GetContexData)(30.seconds)
           val originator = sender
           future.collect {
-            case SparkWebUIUrl(webUi) => originator ! WebUIForContext(name, Some(webUi))
-            case NoSparkWebUI => originator ! WebUIForContext(name, None)
+            case ContexData(appId, Some(webUi)) =>
+              originator ! SparkContexData(name, appId, Some(webUi))
+            case ContexData(appId, None) => originator ! SparkContexData(name, appId, None)
             case SparkContextDead =>
               logger.info("SparkContext {} is dead", name)
               originator ! NoSuchContext

--- a/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
@@ -35,7 +35,7 @@ object JobManagerActor {
 
   case object GetContextConfig
   case object SparkContextStatus
-  case object GetSparkWebUIUrl
+  case object GetContexData
 
   case class DeleteData(name: String)
 
@@ -44,10 +44,9 @@ object JobManagerActor {
   case class Initialized(contextName: String, resultActor: ActorRef)
   case class InitError(t: Throwable)
   case class JobLoadingError(err: Throwable)
-  case class SparkWebUIUrl(url: String)
+  case class ContexData(appId: String, url: Option[String])
   case object SparkContextAlive
   case object SparkContextDead
-  case object NoSparkWebUI
 
 
 
@@ -232,16 +231,17 @@ class JobManagerActor(daoActor: ActorRef)
       }
     }
 
-    case GetSparkWebUIUrl => {
+    case GetContexData => {
       if (jobContext.sparkContext == null) {
         sender ! SparkContextDead
       } else {
         try {
+          val appId = jobContext.sparkContext.applicationId;
           val webUiUrl = jobContext.sparkContext.uiWebUrl
           val msg = if (webUiUrl.isDefined) {
-            SparkWebUIUrl(webUiUrl.get)
+            ContexData(appId, Some(webUiUrl.get))
           } else {
-            NoSparkWebUI
+            ContexData(appId, None)
           }
           sender ! msg
         } catch {

--- a/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
@@ -5,7 +5,7 @@ import akka.pattern.ask
 import akka.util.Timeout
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import spark.jobserver.JobManagerActor.{GetSparkWebUIUrl, NoSparkWebUI, SparkWebUIUrl}
+import spark.jobserver.JobManagerActor.{GetContexData, ContexData}
 import spark.jobserver.JobManagerActor.{SparkContextAlive, SparkContextDead, SparkContextStatus}
 import spark.jobserver.util.SparkJobUtils
 
@@ -27,7 +27,7 @@ object ContextSupervisor {
   case class GetContext(name: String) // returns JobManager, JobResultActor
   case class GetResultActor(name: String)  // returns JobResultActor
   case class StopContext(name: String)
-  case class GetSparkWebUI(name: String)
+  case class GetSparkContexData(name: String)
 
   // Errors/Responses
   case object ContextInitialized
@@ -36,7 +36,7 @@ object ContextSupervisor {
   case object ContextAlreadyExists
   case object NoSuchContext
   case object ContextStopped
-  case class WebUIForContext(name: String, url: Option[String])
+  case class SparkContexData(name: String, appId: String, url: Option[String])
 }
 
 /**
@@ -96,14 +96,15 @@ class LocalContextSupervisorActor(dao: ActorRef, dataManagerActor: ActorRef) ext
     case ListContexts =>
       sender ! contexts.keys.toSeq
 
-    case GetSparkWebUI(name) =>
+    case GetSparkContexData(name) =>
       contexts.get(name) match {
         case Some((actor, _)) =>
-          val future = (actor ? GetSparkWebUIUrl)(contextTimeout.seconds)
+          val future = (actor ? GetContexData)(contextTimeout.seconds)
           val originator = sender
           future.collect {
-            case SparkWebUIUrl(webUi) => originator ! WebUIForContext(name, Some(webUi))
-            case NoSparkWebUI => originator ! WebUIForContext(name, None)
+            case ContexData(appId, Some(webUi)) =>
+              originator ! SparkContexData(name, appId, Some(webUi))
+            case ContexData(appId, None) => originator ! SparkContexData(name, appId, None)
             case SparkContextDead =>
               logger.info("SparkContext {} is dead", name)
               originator ! NoSuchContext

--- a/job-server/src/main/scala/spark/jobserver/WebApi.scala
+++ b/job-server/src/main/scala/spark/jobserver/WebApi.scala
@@ -349,13 +349,13 @@ class WebApi(system: ActorSystem,
     authenticate(authenticator) { authInfo =>
       (get & path(Segment)) { (contextName) =>
         respondWithMediaType(MediaTypes.`application/json`) { ctx =>
-          val future = supervisor ? GetSparkWebUI(contextName)
+          val future = supervisor ? GetSparkContexData(contextName)
           future.map {
-            case WebUIForContext(name, Some(url)) =>
-              ctx.complete(200, Map("context" -> contextName, "url" -> url))
-            case WebUIForContext(name, None) => ctx.complete(200, Map("context" -> contextName))
+            case SparkContexData(name, appId, Some(url)) =>
+              ctx.complete(200, Map("context" -> contextName, "applicationId" -> appId, "url" -> url))
+            case SparkContexData(name, appId, None) =>
+              ctx.complete(200, Map("context" -> contextName, "applicationId" -> appId))
             case NoSuchContext => notFound(ctx, s"can't find context with name $contextName")
-
           }.recover {
             case e: Exception => ctx.complete(500, errMap(e, "ERROR"))
           }

--- a/job-server/src/test/scala/spark/jobserver/WebApiMainRoutesSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiMainRoutesSpec.scala
@@ -502,16 +502,19 @@ class WebApiMainRoutesSpec extends WebApiSpec {
       }
     }
 
-    it("should return the sparkWebUi url if we get a context/id") {
+    it("should return context information if context/id is called (with context UI url)") {
       Get("/contexts/context1") ~> sealRoute(routes) ~> check {
         status should be (OK)
-        responseAs[Map[String, String]] should be (Map("context" -> "context1", "url" -> "http://spark:4040"))
+        responseAs[Map[String, String]] should be (Map(
+            "context" -> "context1",
+            "applicationId" -> "local-1337",
+            "url" -> "http://spark:4040"))
       }
     }
-    it("should return the context name if even no URL can be found") {
+    it("should return context information if context/id is called (without context UI url)") {
       Get("/contexts/context2") ~> sealRoute(routes) ~> check {
         status should be (OK)
-        responseAs[Map[String, String]] should be (Map("context" -> "context2"))
+        responseAs[Map[String, String]] should be (Map("context" -> "context2", "applicationId" -> "local-1337"))
       }
     }
   }

--- a/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
@@ -200,8 +200,8 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
       case StoreJobConfig(_, _) => sender ! JobConfigStored
       case KillJob(jobId) => sender ! JobKilled(jobId, DateTime.now())
 
-      case GetSparkWebUI("context1") => sender ! WebUIForContext("context1", Some("http://spark:4040"))
-      case GetSparkWebUI("context2") => sender ! WebUIForContext("context1", None)
+      case GetSparkContexData("context1") => sender ! SparkContexData("context1", "local-1337", Some("http://spark:4040"))
+      case GetSparkContexData("context2") => sender ! SparkContexData("context2", "local-1337", None)
     }
   }
 


### PR DESCRIPTION
PR #869[1] introduced a new route for getting context information. This
change adds the field "applicationId" to this context information.

Refactoring:
Before classes like GetSparkWebUIUrl, NoSparkWebUI, SparkWebUIUrl, ..
were used to expose the context information. But now not only the
context UI url is exposed, so the names of these classes were changed to
more generic names.

[1] #869 feat(webapi): add route for getting context info

Change-Id: If04c2591fae40d1d872d2236c8b9dbef13bf28e9

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**New behavior :**
See commit message

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1013)
<!-- Reviewable:end -->
