### PR TITLE
feat(jobserver): Kill zombie context JVMs

### DIFF
--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -19,6 +19,8 @@ spark {
     # Number of job results to keep per JobResultActor/context
     job-result-cache-size = 5000
 
+    kill-context-on-supervisor-down = false
+
     # Note: JobFileDAO is deprecated from v0.7.0 because of issues in
     # production and will be removed in future, now defaults to H2 file.
     jobdao = spark.jobserver.io.JobSqlDAO

--- a/job-server/src/main/scala/spark/jobserver/JobManager.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManager.scala
@@ -63,7 +63,13 @@ object JobManager {
     logger.info("Starting JobManager named " + managerName + " with config {}",
       config.getConfig("spark").root.render())
 
-    val jobManager = system.actorOf(JobManagerActor.props(daoActor), managerName)
+    val masterAddress = if (systemConfig.getBoolean("spark.jobserver.kill-context-on-supervisor-down")) {
+      clusterAddress.toString + "/user/context-supervisor"
+    } else {
+      ""
+    }
+
+    val jobManager = system.actorOf(JobManagerActor.props(daoActor, masterAddress), managerName)
 
     //Join akka cluster
     logger.info("Joining cluster at address {}", clusterAddress)

--- a/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
@@ -5,7 +5,7 @@ import java.net.{URI, URL}
 import java.util.concurrent.Executors._
 import java.util.concurrent.atomic.AtomicInteger
 
-import akka.actor.{ActorRef, PoisonPill, Props}
+import akka.actor.{ActorRef, PoisonPill, Props, ReceiveTimeout, Identify, ActorIdentity, Terminated}
 import com.typesafe.config.Config
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.{SparkConf, SparkEnv}
@@ -20,6 +20,7 @@ import spark.jobserver.util.{ContextURLClassLoader, SparkJobUtils}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
+import scala.concurrent.duration._
 import spark.jobserver.common.akka.InstrumentedActor
 
 object JobManagerActor {
@@ -52,7 +53,9 @@ object JobManagerActor {
 
 
   // Akka 2.2.x style actor props for actor creation
-  def props(daoActor: ActorRef): Props = Props(classOf[JobManagerActor], daoActor)
+  def props(daoActor: ActorRef, supervisorActorAddress: String = "",
+      initializationTimeout: FiniteDuration = 30.seconds): Props =
+      Props(classOf[JobManagerActor], daoActor, supervisorActorAddress, initializationTimeout)
 }
 
 /**
@@ -83,8 +86,8 @@ object JobManagerActor {
  *   }
  * }}}
  */
-class JobManagerActor(daoActor: ActorRef)
-  extends InstrumentedActor {
+class JobManagerActor(daoActor: ActorRef, supervisorActorAddress: String,
+    initializationTimeout: FiniteDuration) extends InstrumentedActor {
 
   import CommonMessages._
   import JobManagerActor._
@@ -123,6 +126,12 @@ class JobManagerActor(daoActor: ActorRef)
 
   private val jobServerNamedObjects = new JobServerNamedObjects(context.system)
 
+  if (!supervisorActorAddress.isEmpty()) {
+    logger.info(s"Sending identify message to supervisor at ${supervisorActorAddress}")
+    context.setReceiveTimeout(initializationTimeout)
+    context.actorSelection(supervisorActorAddress) ! Identify(1)
+  }
+
   private def getEnvironment(_jobId: String): JobEnvironment = {
     val _contextCfg = contextConfig
     new JobEnvironment with DataFileCache {
@@ -151,6 +160,30 @@ class JobManagerActor(daoActor: ActorRef)
   }
 
   def wrappedReceive: Receive = {
+    case ActorIdentity(memberActors, supervisorActorRef) =>
+      supervisorActorRef.foreach { ref =>
+        val actorName = ref.path.name
+        if (actorName == "context-supervisor") {
+          logger.info("Received supervisor's response for Identify message. Adding a watch.")
+          context.watch(ref)
+
+          logger.info("ActorIdentity message received from master, stopping the timer.")
+          context.setReceiveTimeout(Duration.Undefined) // Deactivate receive timeout
+        }
+      }
+
+    case Terminated(actorRef) =>
+      if (actorRef.path.name == "context-supervisor") {
+        logger.warn(s"Supervisor actor (${actorRef.path.address.toString}) terminated!" +
+            s" Killing myself (${self.path.address.toString})!")
+        self ! PoisonPill
+      }
+
+    case ReceiveTimeout =>
+        logger.warn("Did not receive ActorIdentity message from master." +
+           s"Killing myself (${self.path.address.toString})!")
+        self ! PoisonPill
+
     case Initialize(ctxConfig, resOpt, dataManagerActor) =>
       contextConfig = ctxConfig
       logger.info("Starting context with config:\n" + contextConfig.root.render)
@@ -269,7 +302,6 @@ class JobManagerActor(daoActor: ActorRef)
     import spark.jobserver.context._
 
     import scala.concurrent.Await
-    import scala.concurrent.duration._
 
     def failed(msg: Any): Option[Future[Any]] = {
       sender ! msg

--- a/job-server/src/test/scala/spark/jobserver/JobManagerActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobManagerActorSpec.scala
@@ -2,6 +2,7 @@ package spark.jobserver
 
 import java.io.File
 import java.nio.file.{Files, StandardOpenOption}
+import akka.actor.{Props, ActorRef}
 
 import com.typesafe.config.{Config, ConfigFactory}
 import spark.jobserver.DataManagerActor.RetrieveData
@@ -38,7 +39,6 @@ class JobManagerActorSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) 
     daoActor = system.actorOf(JobDAOActor.props(dao))
     contextConfig = JobManagerActorSpec.getContextConfig(adhoc = false)
     manager = system.actorOf(JobManagerActor.props(daoActor))
-    supervisor = TestProbe().ref
   }
 
   after {
@@ -311,6 +311,36 @@ class JobManagerActorSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) 
       manager ! JobManagerActor.StartJob("demo", newWordCountClass, emptyConfig, allEvents)
       expectMsgClass(startJobWait, classOf[CommonMessages.JobValidationFailed])
       expectNoMsg()
+    }
+
+    it("should kill itself if the master is down") {
+        val dataManager = system.actorOf(Props.empty)
+
+        supervisor = system.actorOf(
+            Props(classOf[LocalContextSupervisorActor], TestProbe().ref, dataManager), "context-supervisor")
+        val managerWithMasterAddress = system.actorOf(JobManagerActor.props(daoActor,
+            s"${supervisor.path.address.toString}${supervisor.path.toStringWithoutAddress}"))
+
+        val supervisorProbe = TestProbe()
+        supervisorProbe.watch(supervisor)
+
+        val managerProbe = TestProbe()
+        managerProbe.watch(managerWithMasterAddress)
+
+        Thread.sleep(2000) // Wait for manager actor to initialize and add a watch
+        supervisor ! akka.actor.PoisonPill
+        supervisorProbe.expectTerminated(supervisor)
+
+        managerProbe.expectTerminated(managerWithMasterAddress, 5.seconds.dilated)
+    }
+
+    it("should kill itself if response to Identify message is not received") {
+        val managerWithDummyMasterAddress = system.actorOf(JobManagerActor.props(
+            daoActor, "fake-path", 2.seconds.dilated))
+
+        val managerProbe = TestProbe()
+        managerProbe.watch(managerWithDummyMasterAddress)
+        managerProbe.expectTerminated(managerWithDummyMasterAddress, 3.seconds.dilated)
     }
   }
 


### PR DESCRIPTION
If for some reason driver JVMs loose connection with
master, driver JVMs keep on running forever without
any chance of recovering. This change adds a watch on
master. If master goes down or network break, the driver
JVMs kill themselves.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
If driver looses connection to master, it marks master node as DOWN and becomes a zombie. The process keeps on hanging until kill command is executed manually.


**New behavior :**
- If connection loses, the driver will kill itself after 30s of inactivity.
- By default, this behavior is disabled. It can be enabled by turning the config property to
`kill-context-on-supervisor-down` to true


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1019)
<!-- Reviewable:end -->
