### PR TITLE
test(jobserver): Add testcases for AkkaClusterSupervisor

### DIFF
--- a/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
@@ -1,0 +1,289 @@
+package spark.jobserver
+
+import akka.actor._
+import akka.cluster.Cluster
+import akka.testkit.{ImplicitSender, TestKit, TestProbe}
+import akka.testkit._
+
+import spark.jobserver.common.akka.AkkaTestUtils
+import spark.jobserver.io.{JobDAO, JobDAOActor}
+import ContextSupervisor._
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+import scala.collection.mutable.ArrayBuffer
+import scala.util.Try
+import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
+import org.scalatest.{Matchers, FunSpec, BeforeAndAfter, BeforeAndAfterAll, FunSpecLike}
+
+
+object AkkaClusterSupervisorActorSpec {
+  // All the Actors System should have the same name otherwise they cannot form a cluster
+  val ACTOR_SYSTEM_NAME = "test"
+
+  val config = ConfigFactory.parseString("""
+    akka {
+      # Disable all akka output to console
+      log-dead-letters = 0
+      loglevel = "OFF" # Other options INFO, OFF, DEBUG, WARNING
+      stdout-loglevel = "OFF"
+      log-dead-letters-during-shutdown = off
+      cluster.log-info = off
+      actor {
+        provider = "akka.cluster.ClusterActorRefProvider"
+        warn-about-java-serializer-usage = off
+      }
+      remote.netty.tcp.hostname = "127.0.0.1"
+    }
+    spark {
+      master = "local[4]"
+      temp-contexts {
+        num-cpu-cores = 4           # Number of cores to allocate.  Required.
+        memory-per-node = 512m      # Executor memory per node, -Xmx style eg 512m, 1G, etc.
+      }
+      jobserver.job-result-cache-size = 100
+      jobserver.context-creation-timeout = 5 s
+      context-per-jvm = true
+      contexts {
+        config-context {
+          num-cpu-cores = 4
+          memory-per-node = 512m
+        }
+      }
+      context-settings {
+        num-cpu-cores = 2
+        memory-per-node = 512m
+        context-init-timeout = 2 s
+        context-factory = spark.jobserver.context.DefaultSparkContextFactory
+        passthrough {
+          spark.driver.allowMultipleContexts = true
+          spark.ui.enabled = false
+        }
+      }
+    }
+    """)
+
+  val system = ActorSystem(ACTOR_SYSTEM_NAME, config)
+}
+
+class StubbedAkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef, managerProbe: TestProbe)
+        extends AkkaClusterSupervisorActor(daoActor, dataManagerActor) {
+
+  def createSlaveClusterWithJobManager(contextName: String, contextConfig: Config): (Cluster, ActorRef) = {
+    val managerConfig = ConfigFactory.parseString("akka.cluster.roles=[manager],akka.remote.netty.tcp.port=0").withFallback(config)
+    val managerSystem = ActorSystem(AkkaClusterSupervisorActorSpec.ACTOR_SYSTEM_NAME, managerConfig)
+
+    val stubbedJobManagerRef = managerSystem.actorOf(Props(classOf[StubbedJobManagerActor], contextConfig), contextName)
+    val cluster = Cluster(managerSystem)
+    managerProbe.watch(stubbedJobManagerRef)
+    (cluster, stubbedJobManagerRef)
+  }
+
+    override protected def launchDriver(name: String, contextConfig: Config, contextActorName: String): Boolean = {
+      // Create probe and cluster and join back the master
+      Try(contextConfig.getBoolean("driver.fail")).getOrElse(false) match {
+        case true => false
+        case false =>
+          val managerActorAndCluster = createSlaveClusterWithJobManager(contextActorName, contextConfig)
+          managerActorAndCluster._1.join(selfAddress)
+          true
+      }
+    }
+  }
+
+class StubbedJobManagerActor(contextConfig: Config) extends Actor {
+  def receive = {
+    case JobManagerActor.Initialize(contextConfig,_,_) =>
+      val resultActor = context.system.actorOf(Props(classOf[JobResultActor]))
+      sender() ! JobManagerActor.Initialized(contextConfig.getString("context.name"), resultActor)
+    case JobManagerActor.GetContexData =>
+      val appId = Try(contextConfig.getString("manager.context.appId")).getOrElse("")
+      val webUiUrl = Try(contextConfig.getString("manager.context.webUiUrl")).getOrElse("")
+      (appId, webUiUrl) match {
+        case ("", "") => sender() ! JobManagerActor.SparkContextDead
+        case (_, "") => sender() ! JobManagerActor.ContexData(appId, None)
+        case (_, _) => sender() ! JobManagerActor.ContexData(appId, Some(webUiUrl))
+      }
+  }
+}
+
+class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorSpec.system) with ImplicitSender
+      with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
+
+  val contextInitTimeout = 10.seconds.dilated
+  var supervisor: ActorRef = _
+  var dao: JobDAO = _
+  var daoActor: ActorRef = _
+  var managerProbe = TestProbe()
+  val contextConfig = AkkaClusterSupervisorActorSpec.config.getConfig("spark.context-settings")
+
+  // This is needed to help tests pass on some MBPs when working from home
+  System.setProperty("spark.driver.host", "localhost")
+
+
+  override def beforeAll() {
+    dao = new InMemoryDAO
+    daoActor = system.actorOf(JobDAOActor.props(dao))
+    supervisor = system.actorOf(Props(classOf[StubbedAkkaClusterSupervisorActor], daoActor, TestProbe().ref, managerProbe), "supervisor")
+  }
+
+  override def afterAll() = {
+     AkkaTestUtils.shutdownAndWait(AkkaClusterSupervisorActorSpec.system)
+  }
+
+  after {
+    // Cleanup all the context to have a fresh start for next testcase
+    def stopContext(contextName: Any) {
+      supervisor ! StopContext(contextName.toString())
+      expectMsg(3.seconds.dilated, ContextStopped)
+      managerProbe.expectMsgClass(classOf[Terminated])
+    }
+
+    supervisor ! ListContexts
+    expectMsgPF(3.seconds.dilated) {
+      case contexts: ArrayBuffer[_] => contexts.foreach(stopContext(_))
+      case _ =>
+    }
+  }
+
+  describe("Context create tests") {
+    it("should be able to start a context") {
+      supervisor ! AddContext("test-context", contextConfig)
+      expectMsg(contextInitTimeout, ContextInitialized)
+    }
+
+    it("should return valid managerActorRef and resultActorRef if context exists") {
+      supervisor ! AddContext("test-context", contextConfig)
+      expectMsg(contextInitTimeout, ContextInitialized)
+
+      supervisor ! GetContext("test-context")
+      val isValid = expectMsgPF(2.seconds.dilated) {
+        case (jobManagerActor: ActorRef, resultActor: ActorRef) => true
+        case _ => false
+      }
+
+      isValid should be (true)
+    }
+
+    it("should not create context in case of error") {
+      val wrongConfig = ConfigFactory.parseString("driver.fail=true").withFallback(contextConfig)
+      supervisor ! AddContext("test-context", wrongConfig)
+      expectMsgClass(classOf[ContextInitError])
+
+      supervisor ! ListContexts
+      expectMsg(Seq.empty[String])
+    }
+
+    it("should not start two contexts with the same name") {
+      supervisor ! AddContext("test-context", contextConfig)
+      expectMsg(contextInitTimeout, ContextInitialized)
+
+      supervisor ! AddContext("test-context", contextConfig)
+      expectMsg(contextInitTimeout, ContextAlreadyExists)
+    }
+
+    it("should be able to add contexts from config") {
+      supervisor ! AddContextsFromConfig
+      Thread.sleep(contextInitTimeout.toMillis) // AddContextsFromConfig does not return any message
+
+      supervisor ! ListContexts
+      expectMsg(Seq("config-context"))
+    }
+
+    it("should be able to start adhoc context and list it") {
+      import spark.jobserver.util.SparkJobUtils
+      supervisor ! StartAdHocContext("test-adhoc-classpath", ConfigFactory.parseString(""))
+
+      val isValid = expectMsgPF(contextInitTimeout, "manager and result actors") {
+        case (manager: ActorRef, resultActor: ActorRef) =>
+          manager.path.name.startsWith("jobManager-")
+      }
+
+      isValid should be (true)
+
+      supervisor ! ListContexts
+      val hasContext = expectMsgPF(3.seconds.dilated) {
+        case contexts: ArrayBuffer[_] =>
+          contexts.head.toString().endsWith("test-adhoc-classpath")
+        case _ => false
+      }
+      hasContext should be (true)
+    }
+
+    it("should be able to stop a running context") {
+      supervisor ! AddContext("test-context", contextConfig)
+      expectMsg(contextInitTimeout, ContextInitialized)
+
+      supervisor ! StopContext("test-context")
+      expectMsg(ContextStopped)
+    }
+
+    it("context stop should be able to handle case when no context is present") {
+      supervisor ! StopContext("test-context")
+      expectMsg(NoSuchContext)
+    }
+
+    it("should be able to start multiple contexts") {
+      supervisor ! AddContext("test-context", contextConfig)
+      expectMsg(contextInitTimeout, ContextInitialized)
+
+      supervisor ! AddContext("test-context2", contextConfig)
+      expectMsg(contextInitTimeout, ContextInitialized)
+
+      supervisor ! ListContexts
+      expectMsgAnyOf(ArrayBuffer("test-context", "test-context2"), ArrayBuffer("test-context2", "test-context"))
+    }
+  }
+
+  describe("Other context operations tests") {
+    it("should list empty context at startup") {
+       supervisor ! ListContexts
+       expectMsg(Seq.empty[String])
+    }
+
+    it("should return NoSuchContext if context is not available while processing GetContext") {
+       supervisor ! GetContext("dummy-name")
+       expectMsg(NoSuchContext)
+    }
+
+    it("should be able to list all the started contexts") {
+      supervisor ! AddContext("test-context", contextConfig)
+      expectMsg(contextInitTimeout, ContextInitialized)
+
+      supervisor ! ListContexts
+      expectMsg(Seq("test-context"))
+    }
+
+    it("should return valid result actor") {
+      supervisor ! AddContext("test-context", contextConfig)
+      expectMsg(contextInitTimeout, ContextInitialized)
+
+      supervisor ! GetResultActor("test-context")
+      expectMsgClass(classOf[ActorRef])
+    }
+
+    it("should return NoSuchContext if context is not available for GetSparkContextInfo") {
+      supervisor ! GetSparkContexData("dummy-name")
+      expectMsg(NoSuchContext)
+    }
+
+    it("should return valid appId and webUiUrl if context is running") {
+      val configWithContextInfo = ConfigFactory.parseString("manager.context.webUiUrl=dummy-url,manager.context.appId=appId-dummy")
+                .withFallback(contextConfig)
+      supervisor ! AddContext("test-context", configWithContextInfo)
+      expectMsg(contextInitTimeout, ContextInitialized)
+
+      supervisor ! GetSparkContexData("test-context")
+      expectMsg(SparkContexData("test-context", "appId-dummy", Some("dummy-url")))
+    }
+
+    it("should return NoSuchContext if the context is dead") {
+      supervisor ! AddContext("test-context", contextConfig)
+      expectMsg(contextInitTimeout, ContextInitialized)
+
+      supervisor ! GetSparkContexData("test-context")
+      // JobManagerActor Stub by default return NoSuchContext
+      expectMsg(NoSuchContext)
+    }
+  }
+}


### PR DESCRIPTION
Steps:
- Create one akka cluster for master at port 2552
- Create slave akka cluster at random port
- Create a fake jobmanager actor
- Override launchDriver method and instead of
creating a new JVM, create a cluster and JobManagerActor
in the same process. This newly created actor is
used for communication with master

Since, creating a cluster is expensive, we create the
cluter only once and reuse it for each testcase.
All the contexts that we create during a testcase, we
remove them in after{} block afterwards. This makes
sure that each testcase has a clean start.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
There are no testcases for AkkaClusterSupervisor


**New behavior :**
Testcases added


**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1029)
<!-- Reviewable:end -->
