### PR TITLE
feat(jobserver): move data from contexts hash to db

### DIFF
--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -25,7 +25,7 @@ spark {
     # production and will be removed in future, now defaults to H2 file.
     jobdao = spark.jobserver.io.JobSqlDAO
 
-    dao-timeout = 3s
+    dao-timeout = 6s
 
     # Automatically load a set of jars at startup time.  Key is the appName, value is the path/URL.
     # job-bin-paths {

--- a/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
@@ -37,6 +37,7 @@ object ContextSupervisor {
   case object NoSuchContext
   case object ContextStopped
   case class SparkContexData(name: String, appId: String, url: Option[String])
+  case object UnexpectedError
 }
 
 /**

--- a/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
@@ -155,7 +155,7 @@ class LocalContextSupervisorActor(dao: ActorRef, dataManagerActor: ActorRef) ext
         val future = (contexts(name)._1 ? SparkContextStatus) (contextTimeout.seconds)
         val originator = sender
         future.collect {
-          case SparkContextAlive => originator ! contexts(name)
+          case SparkContextAlive => originator ! contexts(name)._1
           case SparkContextDead =>
             logger.info("SparkContext {} is dead", name)
             self ! StopContext(name)

--- a/job-server/src/main/scala/spark/jobserver/WebApi.scala
+++ b/job-server/src/main/scala/spark/jobserver/WebApi.scala
@@ -716,7 +716,7 @@ class WebApi(system: ActorSystem,
       }
     val future = (supervisor ? msg)(contextTimeout.seconds)
     Await.result(future, contextTimeout.seconds) match {
-      case (manager: ActorRef, resultActor: ActorRef) => Some(manager)
+      case (manager: ActorRef) => Some(manager)
       case NoSuchContext => None
       case ContextInitError(err) => throw new RuntimeException(err)
     }

--- a/job-server/src/main/scala/spark/jobserver/WebApi.scala
+++ b/job-server/src/main/scala/spark/jobserver/WebApi.scala
@@ -356,17 +356,25 @@ class WebApi(system: ActorSystem,
             case SparkContexData(name, appId, None) =>
               ctx.complete(200, Map("context" -> contextName, "applicationId" -> appId))
             case NoSuchContext => notFound(ctx, s"can't find context with name $contextName")
+            case UnexpectedError => ctx.complete(500, errMap("UNEXPECTED ERROR OCCURRED"))
           }.recover {
             case e: Exception => ctx.complete(500, errMap(e, "ERROR"))
           }
         }
       } ~
       get { ctx =>
-        (supervisor ? ListContexts).mapTo[Seq[String]]
-          .map { contexts =>
-            ctx.complete(SparkJobUtils.removeProxyUserPrefix(
-              authInfo.toString, contexts,
-              config.getBoolean("shiro.authentication") && config.getBoolean("shiro.use-as-proxy-user"))) }
+        logger.info("GET /contexts");
+        val future = (supervisor ? ListContexts)
+        future.map {
+          case UnexpectedError => ctx.complete(500, errMap("UNEXPECTED ERROR OCCURRED"))
+          case contexts =>
+            val getContexts = SparkJobUtils.removeProxyUserPrefix(
+              authInfo.toString, contexts.asInstanceOf[Seq[String]],
+              config.getBoolean("shiro.authentication") && config.getBoolean("shiro.use-as-proxy-user"))
+            ctx.complete(getContexts)
+        }.recover {
+          case e: Exception => ctx.complete(500, errMap(e, "ERROR"))
+        }
       } ~
       post {
         /**
@@ -398,7 +406,8 @@ class WebApi(system: ActorSystem,
                     case ContextInitialized => ctx.complete(StatusCodes.OK,
                       successMap("Context initialized"))
                     case ContextAlreadyExists => badRequest(ctx, "context " + contextName + " exists")
-                    case ContextInitError(e) => ctx.complete(500, errMap(e, "CONTEXT INIT ERROR"))
+                    case ContextInitError(e) => ctx.complete(500, errMap(e, "CONTEXT INIT ERROR"));
+                    case UnexpectedError => ctx.complete(500, errMap("UNEXPECTED ERROR OCCURRED"))
                   }
                 }
               }
@@ -418,6 +427,7 @@ class WebApi(system: ActorSystem,
                 case ContextStopped => ctx.complete(StatusCodes.OK, successMap("Context stopped"))
                 case NoSuchContext => notFound(ctx, "context " + contextName + " not found")
                 case ContextStopError(e) => ctx.complete(500, errMap(e, "CONTEXT DELETE ERROR"))
+                case UnexpectedError => ctx.complete(500, errMap("UNEXPECTED ERROR OCCURRED"))
               }
             }
           }

--- a/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
@@ -142,7 +142,7 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
 
     supervisor ! ListContexts
     expectMsgPF(3.seconds.dilated) {
-      case contexts: ArrayBuffer[_] => contexts.foreach(stopContext(_))
+      case contexts: Seq[_] => contexts.foreach(stopContext(_))
       case _ =>
     }
   }
@@ -153,13 +153,13 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
       expectMsg(contextInitTimeout, ContextInitialized)
     }
 
-    it("should return valid managerActorRef and resultActorRef if context exists") {
+    it("should return valid managerActorRef if context exists") {
       supervisor ! AddContext("test-context1", contextConfig)
       expectMsg(contextInitTimeout, ContextInitialized)
 
       supervisor ! GetContext("test-context1")
       val isValid = expectMsgPF(2.seconds.dilated) {
-        case (jobManagerActor: ActorRef, resultActor: ActorRef) => true
+        case (jobManagerActor: ActorRef) => true
         case _ => false
       }
 
@@ -196,7 +196,7 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
       supervisor ! StartAdHocContext("test-adhoc-classpath", ConfigFactory.parseString(""))
 
       val isValid = expectMsgPF(contextInitTimeout, "manager and result actors") {
-        case (manager: ActorRef, resultActor: ActorRef) =>
+        case (manager: ActorRef) =>
           manager.path.name.startsWith("jobManager-")
       }
 
@@ -204,7 +204,7 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
 
       supervisor ! ListContexts
       val hasContext = expectMsgPF(3.seconds.dilated) {
-        case contexts: ArrayBuffer[_] =>
+        case contexts: Seq[_] =>
           contexts.head.toString().endsWith("test-adhoc-classpath")
         case _ => false
       }
@@ -232,7 +232,7 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
       expectMsg(contextInitTimeout, ContextInitialized)
 
       supervisor ! ListContexts
-      expectMsgAnyOf(ArrayBuffer("test-context6", "test-context7"), ArrayBuffer("test-context7", "test-context6"))
+      expectMsgAnyOf(Seq("test-context6", "test-context7"), Seq("test-context7", "test-context6"))
     }
   }
 

--- a/job-server/src/test/scala/spark/jobserver/LocalContextSupervisorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/LocalContextSupervisorSpec.scala
@@ -132,7 +132,7 @@ class LocalContextSupervisorSpec extends TestKit(LocalContextSupervisorSpec.syst
       expectMsg(ContextInitialized)
       supervisor ! GetContext("c1")
       expectMsgPF(5 seconds, "I can't find that context :'-(") {
-        case (contextActor: ActorRef, resultActor: ActorRef) =>
+        case (contextActor: ActorRef) =>
           contextActor ! GetContextConfig
           val cc = expectMsgClass(classOf[ContextConfig])
           cc.contextName shouldBe "c1"
@@ -171,7 +171,7 @@ class LocalContextSupervisorSpec extends TestKit(LocalContextSupervisorSpec.syst
       supervisor ! AddContext("c1", contextConfig)
       expectMsg(ContextInitialized)
       supervisor ! GetContext("c1")
-      val (jobManager: ActorRef, _) = expectMsgType[(_, _)]
+      val (jobManager: ActorRef) = expectMsgType[ActorRef]
 
       jobManager ! PoisonPill
       val msg = daoProbe.expectMsgType[CleanContextJobInfos]

--- a/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
@@ -164,9 +164,9 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
       case AddContext(_, _)     => sender ! ContextInitialized
 
       case GetContext("no-context") => sender ! NoSuchContext
-      case GetContext(_)            => sender ! (self, self)
+      case GetContext(_)            => sender ! (self)
 
-      case StartAdHocContext(_, _) => sender ! (self, self)
+      case StartAdHocContext(_, _) => sender ! (self)
 
       // These routes are part of JobManagerActor
       case StartJob("no-app", _, _, _)   =>  sender ! NoSuchApplication

--- a/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
@@ -11,7 +11,7 @@ import spark.jobserver.io._
 import spray.client.pipelining._
 import JobServerSprayProtocol._
 import org.scalatest.time.{Seconds, Span}
-import spray.http.{ContentType, HttpHeader, HttpHeaders, MediaTypes}
+import spray.http.{ContentType, HttpHeader, HttpHeaders, MediaTypes, HttpRequest}
 import spray.httpx.{SprayJsonSupport, UnsuccessfulResponseException}
 import spray.routing.HttpService
 import spray.testkit.ScalatestRouteTest
@@ -151,6 +151,7 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
       case ListContexts =>  sender ! Seq("context1", "context2")
       case StopContext("none") => sender ! NoSuchContext
       case StopContext("timeout-ctx") => sender ! ContextStopError(new Throwable)
+      case StopContext("unexp-err") => sender ! UnexpectedError
       case StopContext(_)      => sender ! ContextStopped
       case AddContext("one", _) => sender ! ContextAlreadyExists
       case AddContext("custom-ctx", c) =>
@@ -161,6 +162,7 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
         c.getInt("override_me") should be(3)
         sender ! ContextInitialized
       case AddContext("initError-ctx", _) => sender ! ContextInitError(new Throwable)
+      case AddContext("unexp-err", _) => sender ! UnexpectedError
       case AddContext(_, _)     => sender ! ContextInitialized
 
       case GetContext("no-context") => sender ! NoSuchContext
@@ -202,7 +204,20 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
 
       case GetSparkContexData("context1") => sender ! SparkContexData("context1", "local-1337", Some("http://spark:4040"))
       case GetSparkContexData("context2") => sender ! SparkContexData("context2", "local-1337", None)
+      case GetSparkContexData("unexp-err") => sender ! UnexpectedError
     }
+  }
+
+  private def unexpectedErrorHelpFunction(curlCommand: HttpRequest) {
+    val p = sendReceive ~> unmarshal[JobServerResponse]
+      val valid:Future[JobServerResponse] = p(curlCommand)
+      Await.ready(valid, Duration.create(1, TimeUnit.SECONDS)).value.get match {
+        case Success(_) => fail("Should return an exception")
+        case Failure(r: UnsuccessfulResponseException) =>
+          r.response.status.intValue shouldBe 500
+          r.response.status.isFailure shouldBe true
+        case Failure(_) => fail("Should return an UnsuccessfulResponseException")
+      }
   }
 
   implicit override val patienceConfig =
@@ -282,6 +297,18 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
         r.status shouldBe "SUCCESS"
         r.result shouldBe "Context reset"
       }
+    }
+
+    it ("Should return an error when unexpected error occures at adding context") {
+      unexpectedErrorHelpFunction(Post("http://127.0.0.1:9999/contexts/unexp-err"))
+    }
+
+    it ("Should return an error when unexpected error occures at deleting context") {
+      unexpectedErrorHelpFunction(Delete("http://127.0.0.1:9999/contexts/unexp-err"))
+    }
+
+    it ("Should return an error when unexpected error occures at getting context") {
+      unexpectedErrorHelpFunction(Get("http://127.0.0.1:9999/contexts/unexp-err"))
     }
   }
 }


### PR DESCRIPTION
This change is related to
https://github.com/spark-jobserver/spark-jobserver/issues/1040

* Instead of using "contexts" hash map, the data from DB is used to
get/save the actor reference and to get/save the state of the context.
* The "STARTING" state is added for the interval between the start
request and the actual start of the context.
* The reference of each JobManager actor is stored in the database. Due
to this, it is possible to reconnect to a running SJS Driver, if the SJS
Master has crashed.
This change introduces a check for running SJS Drivers on the startup
phase of SJS Master.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1047)
<!-- Reviewable:end -->
