### PR TITLE
feat(jobserver): Remove extra states from contextInitInfos

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -23,6 +23,7 @@ import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
 import spark.jobserver.JobManagerActor.{GetContexData, ContexData, SparkContextDead}
 import spark.jobserver.io.{JobDAOActor, ContextInfo, ContextStatus}
+import spark.jobserver.util.{InternalServerErrorException, NoCallbackFoundException}
 
 object AkkaClusterSupervisorActor {
   val MANAGER_ACTOR_PREFIX = "jobManager-"
@@ -55,12 +56,7 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
 
   import context.dispatcher
 
-  //actor name -> (context isadhoc, success callback, failure callback)
-  //TODO: try to pass this state to the jobManager at start instead of having to track
-  //extra state.  What happens if the WebApi process dies before the forked process
-  //starts up?  Then it never gets initialized, and this state disappears.
-  private val contextInitInfos = mutable.HashMap.empty[String,
-                                                      (Config, Boolean, ActorRef => Unit, Throwable => Unit)]
+  protected val contextInitInfos = mutable.HashMap.empty[String, (ActorRef => Unit, Throwable => Unit)]
 
   // actor name -> ResultActor ref
   private val resultActorRefs = mutable.HashMap.empty[String, ActorRef]
@@ -120,14 +116,38 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
         val actorName = actorRef.path.name
         if (actorName.startsWith("jobManager")) {
           logger.info("Received identify response, attempting to initialize context at {}", memberActors)
-          (for { (contextConfig, isAdHoc, successFunc, failureFunc) <- contextInitInfos.remove(actorName) }
-           yield {
-             initContext(contextConfig, actorName,
-                         actorRef, contextInitTimeout)(isAdHoc, successFunc, failureFunc)
-           }).getOrElse({
-            logger.warn("No initialization or callback found for jobManager actor {}", actorRef.path)
-            actorRef ! PoisonPill
-          })
+
+          val contextId = actorName.replace(AkkaClusterSupervisorActor.MANAGER_ACTOR_PREFIX, "")
+          val contextFromDAO =
+            getDataFromDAO[JobDAOActor.ContextResponse](JobDAOActor.GetContextInfo(contextId))
+          val callbacks = contextInitInfos.remove(actorName)
+          (contextFromDAO, callbacks) match {
+            case (Some(JobDAOActor.ContextResponse(Some(contextInfo))),
+                Some((successCallback, failureCallback))) =>
+              val contextConfig = ConfigFactory.parseString(contextInfo.config)
+              val isAdhoc = contextConfig.getBoolean("is-adhoc")
+              initContext(contextConfig, actorName,
+                     actorRef, contextInitTimeout)(isAdhoc, successCallback, failureCallback)
+            case (Some(JobDAOActor.ContextResponse(None)), _) =>
+              logger.error(
+                 s"No such contextId ${contextId} was found in DB. Cannot initialize actor ${actorName}")
+              actorRef ! PoisonPill
+            case (Some(JobDAOActor.ContextResponse(Some(contextInfo))), None) =>
+              val exception = NoCallbackFoundException(contextInfo.id, actorRef.path.toSerializationFormat)
+              logger.error(exception.getMessage, exception)
+              actorRef ! PoisonPill // Since no watch was added, Terminated will not be fired
+              daoActor ! JobDAOActor.SaveContextInfo(contextInfo.copy(
+                  state = ContextStatus.Error, endTime = Some(DateTime.now()), error = Some(exception)))
+            case (None, Some((_, failureCallback))) =>
+              val exception = InternalServerErrorException(contextId)
+              logger.error(exception.getMessage, exception)
+              actorRef ! PoisonPill
+              failureCallback(exception)
+            case (None, None) =>
+              val errorMessage = s"Failed to create context ($contextId) due to internal error"
+              logger.error(errorMessage)
+              actorRef ! PoisonPill
+          }
         }
       }
 
@@ -351,7 +371,7 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
         failureFunc(e)
         daoActor ! JobDAOActor.SaveContextInfo(contextInfo(ContextStatus.Error, Some(e)))
       case (true, _) =>
-        contextInitInfos(contextActorName) = (mergedContextConfig, isAdHoc, successFunc, failureFunc)
+        contextInitInfos(contextActorName) = (successFunc, failureFunc)
         daoActor ! JobDAOActor.SaveContextInfo(contextInfo(ContextStatus.Started, None))
     }
   }

--- a/job-server/src/main/scala/spark/jobserver/util/CustomException.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/CustomException.scala
@@ -3,3 +3,9 @@ package spark.jobserver.util
 case class NoSuchBinaryException(private val appName: String) extends Exception {
   private val message = s"can't find binary: $appName in database";
 }
+
+final case class InternalServerErrorException(id: String) extends
+  Exception(s"Failed to create context ($id) due to internal error")
+
+final case class NoCallbackFoundException(id: String, actorPath: String) extends
+  Exception(s"Callback methods not found for actor with id=$id, path=$actorPath")

--- a/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
@@ -6,7 +6,7 @@ import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import akka.testkit._
 
 import spark.jobserver.common.akka.AkkaTestUtils
-import spark.jobserver.io.{JobDAO, JobDAOActor}
+import spark.jobserver.io.{JobDAO, JobDAOActor, ContextInfo, ContextStatus}
 import ContextSupervisor._
 
 import scala.collection.JavaConverters._
@@ -15,7 +15,8 @@ import scala.collection.mutable.ArrayBuffer
 import scala.util.Try
 import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
 import org.scalatest.{Matchers, FunSpec, BeforeAndAfter, BeforeAndAfterAll, FunSpecLike}
-
+import org.joda.time.DateTime
+import scala.concurrent.Await
 
 object AkkaClusterSupervisorActorSpec {
   // All the Actors System should have the same name otherwise they cannot form a cluster
@@ -67,6 +68,10 @@ object AkkaClusterSupervisorActorSpec {
   val system = ActorSystem(ACTOR_SYSTEM_NAME, config)
 }
 
+object StubbedAkkaClusterSupervisorActor {
+  case class AddContextToContextInitInfos(contextName: String)
+}
+
 class StubbedAkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef, managerProbe: TestProbe)
         extends AkkaClusterSupervisorActor(daoActor, dataManagerActor) {
 
@@ -80,17 +85,26 @@ class StubbedAkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: Ac
     (cluster, stubbedJobManagerRef)
   }
 
-    override protected def launchDriver(name: String, contextConfig: Config, contextActorName: String): (Boolean, String) = {
-      // Create probe and cluster and join back the master
-      Try(contextConfig.getBoolean("driver.fail")).getOrElse(false) match {
-        case true => (false, "")
-        case false =>
-          val managerActorAndCluster = createSlaveClusterWithJobManager(contextActorName, contextConfig)
-          managerActorAndCluster._1.join(selfAddress)
-          (true, "")
-      }
+  override protected def launchDriver(name: String, contextConfig: Config, contextActorName: String): (Boolean, String) = {
+    // Create probe and cluster and join back the master
+    Try(contextConfig.getBoolean("driver.fail")).getOrElse(false) match {
+      case true => (false, "")
+      case false =>
+        val managerActorAndCluster = createSlaveClusterWithJobManager(contextActorName, contextConfig)
+        managerActorAndCluster._1.join(selfAddress)
+        (true, "")
     }
   }
+
+  override def wrappedReceive: Receive = {
+    super.wrappedReceive orElse(stubbedWrappedReceive)
+  }
+
+  def stubbedWrappedReceive: Receive = {
+    case StubbedAkkaClusterSupervisorActor.AddContextToContextInitInfos(name) =>
+      contextInitInfos(name) = ({ref=>}, {ref=>})
+  }
+}
 
 class StubbedJobManagerActor(contextConfig: Config) extends Actor {
   def receive = {
@@ -121,7 +135,6 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
   // This is needed to help tests pass on some MBPs when working from home
   System.setProperty("spark.driver.host", "localhost")
 
-
   override def beforeAll() {
     dao = new InMemoryDAO
     daoActor = system.actorOf(JobDAOActor.props(dao))
@@ -145,6 +158,7 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
       case contexts: Seq[_] => contexts.foreach(stopContext(_))
       case _ =>
     }
+    daoActor = system.actorOf(JobDAOActor.props(dao))
   }
 
   describe("Context create tests") {
@@ -233,6 +247,54 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
 
       supervisor ! ListContexts
       expectMsgAnyOf(Seq("test-context6", "test-context7"), Seq("test-context7", "test-context6"))
+    }
+
+    it("should kill context JVM if nothing was found in the DB and no callback was available") {
+      val managerProbe = TestProbe("jobManager-dummy")
+      val deathWatch = TestProbe()
+      deathWatch.watch(managerProbe.ref)
+
+      supervisor ! ActorIdentity(1, Some(managerProbe.ref))
+
+      deathWatch.expectTerminated(managerProbe.ref)
+    }
+
+    it("should kill context JVM if context was found in DB but no callback was available") {
+      val managerProbe = TestProbe(AkkaClusterSupervisorActor.MANAGER_ACTOR_PREFIX + "dummy")
+      val contextId = managerProbe.ref.path.name.replace(AkkaClusterSupervisorActor.MANAGER_ACTOR_PREFIX, "")
+      val deathWatch = TestProbe()
+      deathWatch.watch(managerProbe.ref)
+      val dummyContext = ContextInfo(contextId, "contextName", "", None,
+          DateTime.now(), None, ContextStatus.Started, None)
+      dao.saveContextInfo(dummyContext)
+
+      supervisor ! ActorIdentity(1, Some(managerProbe.ref))
+
+      deathWatch.expectTerminated(managerProbe.ref)
+    }
+
+    it("should kill context JVM if DB call had an exception but callbacks are available") {
+      val managerProbe = TestProbe("jobManager-dummy")
+      val contextActorName = managerProbe.ref.path.name
+      val deathWatch = TestProbe()
+      deathWatch.watch(managerProbe.ref)
+
+      supervisor ! StubbedAkkaClusterSupervisorActor.AddContextToContextInitInfos(contextActorName)
+      daoActor ! PoisonPill // Simulate DAO failure
+      supervisor ! ActorIdentity(1, Some(managerProbe.ref))
+
+      deathWatch.expectTerminated(managerProbe.ref)
+    }
+
+    it("should kill context JVM if DB call had an exception and callbacks are not available") {
+      val managerProbe = TestProbe("jobManager-dummy")
+      val deathWatch = TestProbe()
+      deathWatch.watch(managerProbe.ref)
+
+      daoActor ! PoisonPill // Simulate DAO failure
+      supervisor ! ActorIdentity(1, Some(managerProbe.ref))
+
+      deathWatch.expectTerminated(managerProbe.ref)
     }
   }
 


### PR DESCRIPTION
Since, we have a DB table for context now, we don't
need to put the context config and is-adhoc flag in
the hashmap anymore. Now, we pull this information from
DB.

This hashmap also contains the success and failure
callbacks. It doesn't make sense to put them in DB
because they are just temporary. If somehow the master
crashes, the user who is waiting for the response
won't get the response anyway.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1055)
<!-- Reviewable:end -->
