### PR TITLE
feat(jobserver): Extend zombie killing logic to add Initialize msg

### DIFF
--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -20,6 +20,7 @@ spark {
     job-result-cache-size = 5000
 
     kill-context-on-supervisor-down = false
+    manager-initialization-timeout = 40s
 
     # Note: JobFileDAO is deprecated from v0.7.0 because of issues in
     # production and will be removed in future, now defaults to H2 file.

--- a/job-server/src/main/scala/spark/jobserver/JobManager.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManager.scala
@@ -3,6 +3,7 @@ package spark.jobserver
 import java.io.{File, IOException}
 import java.nio.charset.Charset
 import java.nio.file.{Files, Paths}
+import java.util.concurrent.TimeUnit
 
 import akka.actor.{ActorSystem, Address, AddressFromURIString, Props}
 import akka.cluster.Cluster
@@ -13,6 +14,7 @@ import spark.jobserver.common.akka.actor.ProductionReaper
 import spark.jobserver.io.{JobDAO, JobDAOActor}
 import scala.collection.JavaConverters._
 import scala.util.Try
+import scala.concurrent.duration.FiniteDuration
 
 /**
  * The JobManager is the main entry point for the forked JVM process running an individual
@@ -68,7 +70,8 @@ object JobManager {
       case false => ""
     }
 
-    val jobManager = system.actorOf(JobManagerActor.props(daoActor, masterAddress), managerName)
+    val jobManager = system.actorOf(JobManagerActor.props(daoActor, masterAddress,
+        getManagerInitializationTimeout(systemConfig)), managerName)
 
     //Join akka cluster
     logger.info("Joining cluster at address {}", clusterAddress)
@@ -106,6 +109,11 @@ object JobManager {
     }
 
     start(args, makeManagerSystem("JobServer"), waitForTermination)
+  }
+
+   private def getManagerInitializationTimeout(config: Config): FiniteDuration = {
+    FiniteDuration(config.getDuration("spark.jobserver.manager-initialization-timeout",
+        TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS)
   }
 }
 

--- a/job-server/src/main/scala/spark/jobserver/JobManager.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManager.scala
@@ -63,10 +63,9 @@ object JobManager {
     logger.info("Starting JobManager named " + managerName + " with config {}",
       config.getConfig("spark").root.render())
 
-    val masterAddress = if (systemConfig.getBoolean("spark.jobserver.kill-context-on-supervisor-down")) {
-      clusterAddress.toString + "/user/context-supervisor"
-    } else {
-      ""
+    val masterAddress = systemConfig.getBoolean("spark.jobserver.kill-context-on-supervisor-down") match {
+      case true => clusterAddress.toString + "/user/context-supervisor"
+      case false => ""
     }
 
     val jobManager = system.actorOf(JobManagerActor.props(daoActor, masterAddress), managerName)

--- a/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
@@ -53,7 +53,7 @@ object JobManagerActor {
 
   // Akka 2.2.x style actor props for actor creation
   def props(daoActor: ActorRef, supervisorActorAddress: String = "",
-      initializationTimeout: FiniteDuration = 30.seconds): Props =
+      initializationTimeout: FiniteDuration = 40.seconds): Props =
       Props(classOf[JobManagerActor], daoActor, supervisorActorAddress, initializationTimeout)
 }
 
@@ -125,7 +125,7 @@ class JobManagerActor(daoActor: ActorRef, supervisorActorAddress: String,
 
   private val jobServerNamedObjects = new JobServerNamedObjects(context.system)
 
-  if (!supervisorActorAddress.isEmpty()) {
+  if (isKillingContextOnUnresponsiveSupervisorEnabled()) {
     logger.info(s"Sending identify message to supervisor at ${supervisorActorAddress}")
     context.setReceiveTimeout(initializationTimeout)
     context.actorSelection(supervisorActorAddress) ! Identify(1)
@@ -158,6 +158,10 @@ class JobManagerActor(daoActor: ActorRef, supervisorActorAddress: String,
     }
   }
 
+  private def isKillingContextOnUnresponsiveSupervisorEnabled(): Boolean = {
+    !supervisorActorAddress.isEmpty()
+  }
+
   def wrappedReceive: Receive = {
     case ActorIdentity(memberActors, supervisorActorRef) =>
       supervisorActorRef.foreach { ref =>
@@ -166,8 +170,7 @@ class JobManagerActor(daoActor: ActorRef, supervisorActorAddress: String,
           logger.info("Received supervisor's response for Identify message. Adding a watch.")
           context.watch(ref)
 
-          logger.info("ActorIdentity message received from master, stopping the timer.")
-          context.setReceiveTimeout(Duration.Undefined) // Deactivate receive timeout
+          logger.info("Waiting for Initialize message from master.")
         }
       }
 
@@ -179,11 +182,16 @@ class JobManagerActor(daoActor: ActorRef, supervisorActorAddress: String,
       }
 
     case ReceiveTimeout =>
-        logger.warn("Did not receive ActorIdentity message from master." +
-           s"Killing myself (${self.path.address.toString})!")
+        logger.warn("Did not receive ActorIdentity/Initialized message from master." +
+           s" Killing myself (${self.path.address.toString})!")
         self ! PoisonPill
 
     case Initialize(ctxConfig, resOpt, dataManagerActor) =>
+      if (isKillingContextOnUnresponsiveSupervisorEnabled()) {
+        logger.info("Initialize message received from master, stopping the timer.")
+        context.setReceiveTimeout(Duration.Undefined) // Deactivate receive timeout
+      }
+
       contextConfig = ctxConfig
       logger.info("Starting context with config:\n" + contextConfig.root.render)
       contextName = contextConfig.getString("context.name")


### PR DESCRIPTION
If due to some reason AkkaClusterSupervisorActor restarts,
the actor system leaves the cluster but it is still active. It
can receive POST /context commands and can spawn new JVMs but
cannot initialize them properly because MemberUp event is
never received. In that case, the slave JVMs can send the
Identify message to master and master will send ActorIdentify
message back. But then both will be halted, slave is waiting
for Initialize message and master is waiting for MemberUp
event. Since, master needs to rejoin the cluster somehow
and if it doesn't then it is a deadlock.

We extend the zombie killing logic to wait for Initialize
message, if the message doesn't arrive in the required time
then slave kills itself.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1056)
<!-- Reviewable:end -->
