### PR TITLE
feat(jobserver): Add CONTEXT_ID and STATE to the JOBS table

### DIFF
--- a/job-server-extras/src/test/scala/spark/jobserver/JavaStreamingSpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/JavaStreamingSpec.scala
@@ -6,7 +6,7 @@ import akka.testkit._
 import com.typesafe.config.ConfigFactory
 import spark.jobserver.CommonMessages._
 import spark.jobserver.context.JavaStreamingContextFactory
-import spark.jobserver.io.{JobDAOActor, JobInfo}
+import spark.jobserver.io.{JobDAOActor, JobInfo, JobStatus}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -50,7 +50,7 @@ class JavaStreamingSpec extends ExtrasJobSpecBase(JavaStreamingSpec.getNewSystem
       Thread.sleep(1000)
       val info = Await.result(dao.getJobInfo(id), 60 seconds)
       info.get match {
-        case JobInfo(_, _, _, _, _, None, _) => {}
+        case JobInfo(_, _, _, _, _, state, _, _, _) if state == JobStatus.Running => {}
         case e => fail(s":-( No worky work $e")
       }
     }

--- a/job-server-extras/src/test/scala/spark/jobserver/StreamingJobSpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/StreamingJobSpec.scala
@@ -5,7 +5,7 @@ import akka.pattern._
 import scala.concurrent.Await
 import com.typesafe.config.ConfigFactory
 import spark.jobserver.context.StreamingContextFactory
-import spark.jobserver.io.{JobDAOActor, JobInfo}
+import spark.jobserver.io.{JobDAOActor, JobInfo, JobStatus}
 
 /**
  * Test for Streaming Jobs.
@@ -58,7 +58,7 @@ class StreamingJobSpec extends JobSpecBase(StreamingJobSpec.getNewSystem) {
       Thread sleep 1000
       val jobInfo = Await.result(dao.getJobInfo(jobId), 60 seconds)
       jobInfo.get match  {
-        case JobInfo(_, _, _, _, _, None, _) => {  }
+        case JobInfo(_, _, _, _, _, state, _, _, _) if state == JobStatus.Running => {  }
         case e => fail("Unexpected JobInfo" + e)
       }
     }

--- a/job-server/src/main/scala/db/h2/migration/V0_7_8/V0_7_8__add_contextId_and_state_to_jobs.scala
+++ b/job-server/src/main/scala/db/h2/migration/V0_7_8/V0_7_8__add_contextId_and_state_to_jobs.scala
@@ -1,0 +1,24 @@
+package db.h2.migration.V0_7_8
+
+import org.slf4j.LoggerFactory
+import db.migration.V0_7_8.Migration
+
+import slick.driver.H2Driver.api.actionBasedSQLInterpolation
+import slick.profile.SqlAction
+import slick.dbio.Effect
+import slick.dbio.NoStream
+
+class V0_7_8__add_contextId_and_state_to_jobs extends Migration {
+  val logger = LoggerFactory.getLogger(getClass)
+
+  protected def insertState(id: String, status: String): SqlAction[Int, NoStream, Effect] = {
+    sqlu"""UPDATE "JOBS" SET "STATE"=${status} WHERE "JOB_ID"=${id}"""
+  }
+
+  val addContextId = sqlu"""ALTER TABLE "JOBS" ADD COLUMN "CONTEXT_ID" VARCHAR(255)"""
+  val updateContextId = sqlu"""UPDATE "JOBS" SET "CONTEXT_ID" = (SELECT "CONTEXT_NAME")"""
+  val setContextIdNotNull = sqlu"""ALTER TABLE "JOBS" ALTER COLUMN "CONTEXT_ID" SET NOT NULL"""
+  val addState = sqlu"""ALTER TABLE "JOBS" ADD COLUMN "STATE" VARCHAR(255)"""
+  val getJobsEndTimeAndError = sql"""SELECT "JOB_ID", "END_TIME", "ERROR" FROM "JOBS"""".as[JobData]
+  val setStateNotNull = sqlu"""ALTER TABLE "JOBS" ALTER COLUMN "STATE" SET NOT NULL"""
+}

--- a/job-server/src/main/scala/db/migration/V0_7_8/Migration.scala
+++ b/job-server/src/main/scala/db/migration/V0_7_8/Migration.scala
@@ -1,0 +1,70 @@
+package db.migration.V0_7_8
+
+import java.sql.Connection
+
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.control.NonFatal
+
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration
+import org.slf4j.Logger
+
+import slick.jdbc.GetResult
+import slick.profile.SqlAction
+import slick.dbio.DBIOAction
+import slick.dbio.Streaming
+import slick.dbio.Effect
+import slick.dbio.NoStream
+import spark.jobserver.slick.unmanaged.UnmanagedDatabase
+import spark.jobserver.io.{BinaryInfo, JobStatus, ErrorData}
+
+trait Migration extends JdbcMigration {
+  protected val timeout = 10 minutes
+  protected val logger: Logger
+
+  protected def logErrors = PartialFunction[Throwable, Unit] {
+    case e: Throwable => logger.error(e.getMessage, e)
+  }
+
+  protected case class JobData(id: String, endTime: Option[Object], error: Option[Object])
+  protected def insertState(id: String, status: String): SqlAction[Int, NoStream, Effect]
+
+  protected val addContextId: SqlAction[Int, NoStream, Effect]
+  protected val updateContextId: SqlAction[Int, NoStream, Effect]
+  protected val setContextIdNotNull: SqlAction[Int, NoStream, Effect]
+  protected val addState: SqlAction[Int, NoStream, Effect]
+  implicit val getJobsEndTimeAndErrorResult = GetResult[JobData](r =>
+      JobData(r.nextString(), r.nextObjectOption(), r.nextObjectOption()))
+  protected val getJobsEndTimeAndError: DBIOAction[Seq[(JobData)], Streaming[JobData], Effect]
+  protected val setStateNotNull: SqlAction[Int, NoStream, Effect]
+
+  protected def setState(db: UnmanagedDatabase, jobData: JobData): Unit = {
+    val status = jobData match {
+      case JobData(_, None, _) => JobStatus.Running
+      case JobData(_, _, Some(err)) => JobStatus.Error
+      case JobData(_, Some(e), None) => JobStatus.Finished
+    }
+    Await.ready(db.run(insertState(jobData.id, status)).recover{logErrors}, timeout)
+  }
+
+  def migrate(c: Connection): Unit = {
+    val db = new UnmanagedDatabase(c)
+    c.setAutoCommit(false)
+    try {
+      Await.ready(
+          for {
+            _ <- db.run(addContextId)
+            _ <- db.run(updateContextId)
+            _ <- db.run(setContextIdNotNull)
+            _ <- db.run(addState)
+            _ <- db.stream(getJobsEndTimeAndError).foreach(j => setState(db, j))
+          } yield Unit, timeout
+      ).recover{logErrors}
+      Await.ready(db.run(setStateNotNull).recover{logErrors}, timeout)
+      c.commit()
+    } catch {
+      case NonFatal(e) => { c.rollback() }
+    }
+  }
+}

--- a/job-server/src/main/scala/db/mysql/migration/V0_7_8/V0_7_8__add_contextId_and_state_to_jobs.scala
+++ b/job-server/src/main/scala/db/mysql/migration/V0_7_8/V0_7_8__add_contextId_and_state_to_jobs.scala
@@ -1,0 +1,24 @@
+package db.mysql.migration.V0_7_8
+
+import org.slf4j.LoggerFactory
+import db.migration.V0_7_8.Migration
+
+import slick.driver.H2Driver.api.actionBasedSQLInterpolation
+import slick.profile.SqlAction
+import slick.dbio.Effect
+import slick.dbio.NoStream
+
+class V0_7_8__add_contextId_and_state_to_jobs extends Migration {
+  val logger = LoggerFactory.getLogger(getClass)
+
+  protected def insertState(id: String, status: String): SqlAction[Int, NoStream, Effect] = {
+    sqlu"""UPDATE `JOBS` SET `STATE`=${status} WHERE `JOB_ID`=${id}"""
+  }
+
+  val addContextId = sqlu"""ALTER TABLE `JOBS` ADD COLUMN `CONTEXT_ID` VARCHAR(255)"""
+  val updateContextId = sqlu"""UPDATE `JOBS` SET `CONTEXT_ID` = (SELECT `CONTEXT_NAME`)"""
+  val setContextIdNotNull = sqlu"""ALTER TABLE `JOBS` MODIFY COLUMN `CONTEXT_ID` VARCHAR(255) NOT NULL"""
+  val addState = sqlu"""ALTER TABLE `JOBS` ADD COLUMN `STATE` VARCHAR(255)"""
+  val getJobsEndTimeAndError = sql"""SELECT `JOB_ID`, `END_TIME`, `ERROR` FROM `JOBS`""".as[JobData]
+  val setStateNotNull = sqlu"""ALTER TABLE `JOBS` MODIFY COLUMN `STATE` VARCHAR(255) NOT NULL"""
+}

--- a/job-server/src/main/scala/db/postgresql/migration/V0_7_8/V0_7_8__add_contextId_and_state_to_jobs.scala
+++ b/job-server/src/main/scala/db/postgresql/migration/V0_7_8/V0_7_8__add_contextId_and_state_to_jobs.scala
@@ -1,0 +1,24 @@
+package db.postgresql.migration.V0_7_8
+
+import org.slf4j.LoggerFactory
+import db.migration.V0_7_8.Migration
+
+import slick.driver.H2Driver.api.actionBasedSQLInterpolation
+import slick.profile.SqlAction
+import slick.dbio.Effect
+import slick.dbio.NoStream
+
+class V0_7_8__add_contextId_and_state_to_jobs extends Migration {
+  val logger = LoggerFactory.getLogger(getClass)
+
+  protected def insertState(id: String, status: String): SqlAction[Int, NoStream, Effect] = {
+    sqlu"""UPDATE "JOBS" SET "STATE"=${status} WHERE "JOB_ID"=${id}"""
+  }
+
+  val addContextId = sqlu"""ALTER TABLE "JOBS" ADD COLUMN "CONTEXT_ID" VARCHAR(255)"""
+  val updateContextId = sqlu"""UPDATE "JOBS" SET "CONTEXT_ID" = (SELECT "CONTEXT_NAME")"""
+  val setContextIdNotNull = sqlu"""ALTER TABLE "JOBS" ALTER COLUMN "CONTEXT_ID" SET NOT NULL"""
+  val addState = sqlu"""ALTER TABLE "JOBS" ADD COLUMN "STATE" VARCHAR(255)"""
+  val getJobsEndTimeAndError = sql"""SELECT "JOB_ID", "END_TIME", "ERROR" FROM "JOBS"""".as[JobData]
+  val setStateNotNull = sqlu"""ALTER TABLE "JOBS" ALTER COLUMN "STATE" SET NOT NULL"""
+}

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -248,7 +248,7 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
           val contextInfo = ContextInfo(c.id, c.name, c.config, c.actorAddress, c.startTime,
                 Option(DateTime.now()), state, c.error)
           daoActor ! JobDAOActor.SaveContextInfo(contextInfo)
-          daoActor ! JobDAOActor.CleanContextJobInfos(c.name, DateTime.now())
+          daoActor ! JobDAOActor.CleanContextJobInfos(c.id, DateTime.now())
         case Some(JobDAOActor.ContextResponse(None)) =>
           logger.error("No context for deletion is found in the DB")
         case None =>

--- a/job-server/src/main/scala/spark/jobserver/JobInfoActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobInfoActor.scala
@@ -5,7 +5,7 @@ import akka.pattern.ask
 import akka.util.Timeout
 import com.typesafe.config.Config
 import spark.jobserver.common.akka.InstrumentedActor
-import spark.jobserver.io.JobDAO
+import spark.jobserver.io.{JobDAO, JobStatus}
 
 object JobInfoActor {
   // Requests
@@ -47,7 +47,7 @@ class JobInfoActor(jobDao: JobDAO, contextSupervisor: ActorRef) extends Instrume
 
       jobDao.getJobInfo(jobId).collect {
         case Some(jobInfo) =>
-          if (jobInfo.isRunning || jobInfo.isErroredOut) {
+          if (jobInfo.state != JobStatus.Finished) {
             originator ! jobInfo
           } else {
             // get the context from jobInfo

--- a/job-server/src/main/scala/spark/jobserver/JobManager.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManager.scala
@@ -70,7 +70,8 @@ object JobManager {
       case false => ""
     }
 
-    val jobManager = system.actorOf(JobManagerActor.props(daoActor, masterAddress,
+    val contextId = managerName.replace(AkkaClusterSupervisorActor.MANAGER_ACTOR_PREFIX, "")
+    val jobManager = system.actorOf(JobManagerActor.props(daoActor, masterAddress, contextId,
         getManagerInitializationTimeout(systemConfig)), managerName)
 
     //Join akka cluster

--- a/job-server/src/main/scala/spark/jobserver/io/JobDAOActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobDAOActor.scala
@@ -34,7 +34,7 @@ object JobDAOActor {
 
   case class SaveJobConfig(jobId: String, jobConfig: Config) extends JobDAORequest
   case class GetJobConfig(jobId: String) extends JobDAORequest
-  case class CleanContextJobInfos(contextName: String, endTime: DateTime)
+  case class CleanContextJobInfos(contextId: String, endTime: DateTime)
 
   case class GetLastUploadTimeAndType(appName: String) extends JobDAORequest
   case class SaveContextInfo(contextInfo: ContextInfo) extends JobDAORequest
@@ -107,7 +107,7 @@ class JobDAOActor(dao: JobDAO) extends InstrumentedActor {
     case GetLastUploadTimeAndType(appName) =>
       sender() ! LastUploadTimeAndType(dao.getLastUploadTimeAndType(appName))
 
-    case CleanContextJobInfos(contextName, endTime) =>
-      dao.cleanRunningJobInfosForContext(contextName, endTime)
+    case CleanContextJobInfos(contextId, endTime) =>
+      dao.cleanRunningJobInfosForContext(contextId, endTime)
   }
 }

--- a/job-server/src/main/scala/spark/jobserver/io/JobFileDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobFileDAO.scala
@@ -182,9 +182,11 @@ class JobFileDAO(config: Config) extends JobDAO {
 
   private def writeJobInfo(out: DataOutputStream, jobInfo: JobInfo) {
     out.writeUTF(jobInfo.jobId)
+    out.writeUTF(jobInfo.contextId)
     out.writeUTF(jobInfo.contextName)
     writeJarInfo(out, jobInfo.binaryInfo)
     out.writeUTF(jobInfo.classPath)
+    out.writeUTF(jobInfo.state)
     out.writeLong(jobInfo.startTime.getMillis)
     val time = if (jobInfo.endTime.isEmpty) jobInfo.startTime.getMillis else jobInfo.endTime.get.getMillis
     out.writeLong(time)
@@ -203,7 +205,9 @@ class JobFileDAO(config: Config) extends JobDAO {
   private def readJobInfo(in: DataInputStream) = JobInfo(
     in.readUTF,
     in.readUTF,
+    in.readUTF,
     readJarInfo(in),
+    in.readUTF,
     in.readUTF,
     new DateTime(in.readLong),
     Some(new DateTime(in.readLong)),
@@ -216,20 +220,20 @@ class JobFileDAO(config: Config) extends JobDAO {
   override def getJobInfos(limit: Int, statusOpt: Option[String] = None): Future[Seq[JobInfo]] = Future {
     val allJobs = jobs.values.toSeq.sortBy(-_.startTime.getMillis)
     val filterJobs = statusOpt match {
-      case Some(JobStatus.Running) => {
-        allJobs.filter(jobInfo => !jobInfo.endTime.isDefined && !jobInfo.error.isDefined)
-      }
-      case Some(JobStatus.Error) => allJobs.filter(_.error.isDefined)
-      case Some(JobStatus.Finished) => {
-        allJobs.filter(jobInfo => jobInfo.endTime.isDefined && !jobInfo.error.isDefined)
-      }
+      case Some(state) => allJobs.filter(_.state.equals(state))
       case _ => allJobs
     }
     filterJobs.take(limit)
   }
 
-  override def getRunningJobInfosForContextName(contextName: String): Future[Seq[JobInfo]] = Future {
-    jobs.values.toSeq.filter(j => j.endTime.isEmpty && j.error.isEmpty && j.contextName == contextName)
+  override def getJobInfosByContextId(
+      contextId: String, jobStatus: Option[String] = None): Future[Seq[JobInfo]] = Future {
+    jobs.values.toSeq.filter(j => {
+      (contextId, jobStatus) match {
+        case (contextId, Some(status)) => contextId == j.contextId && status == j.state
+        case _ => contextId == j.contextId
+      }
+    })
   }
 
   override def saveJobConfig(jobId: String, jobConfig: Config) {

--- a/job-server/src/main/scala/spark/jobserver/io/JobSqlDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobSqlDAO.scala
@@ -62,19 +62,21 @@ class JobSqlDAO(config: Config) extends JobDAO with FileCacher {
 
   // Explicitly avoiding to label 'jarId' as a foreign key to avoid dealing with
   // referential integrity constraint violations.
-  class Jobs(tag: Tag) extends Table[(String, String, Int, String, Timestamp,
+  class Jobs(tag: Tag) extends Table[(String, String, String, Int, String, String, Timestamp,
     Option[Timestamp], Option[String], Option[String], Option[String])](tag, "JOBS") {
     def jobId = column[String]("JOB_ID", O.PrimaryKey)
+    def contextId = column[String]("CONTEXT_ID")
     def contextName = column[String]("CONTEXT_NAME")
     def binId = column[Int]("BIN_ID")
     // FK to JARS table
     def classPath = column[String]("CLASSPATH")
+    def state = column[String]("STATE")
     def startTime = column[Timestamp]("START_TIME")
     def endTime = column[Option[Timestamp]]("END_TIME")
     def error = column[Option[String]]("ERROR")
     def errorClass = column[Option[String]]("ERROR_CLASS")
     def errorStackTrace = column[Option[String]]("ERROR_STACK_TRACE")
-    def * = (jobId, contextName, binId, classPath, startTime, endTime, error, errorClass, errorStackTrace)
+    def * = (jobId, contextId, contextName, binId, classPath, state, startTime, endTime, error, errorClass, errorStackTrace)
   }
 
   val jobs = TableQuery[Jobs]
@@ -365,23 +367,26 @@ class JobSqlDAO(config: Config) extends JobDAO with FileCacher {
     val error = jobInfo.error.map(e => e.message)
     val errorClass = jobInfo.error.map(e => e.errorClass)
     val errorStackTrace = jobInfo.error.map(e => e.stackTrace)
-    val row = (jobInfo.jobId, jobInfo.contextName, jarId, jobInfo.classPath,
-      startTime, endTime, error, errorClass, errorStackTrace)
+    val row = (jobInfo.jobId, jobInfo.contextId, jobInfo.contextName, jarId, jobInfo.classPath,
+      jobInfo.state, startTime, endTime, error, errorClass, errorStackTrace)
     if(Await.result(db.run(jobs.insertOrUpdate(row)), 60 seconds) == 0){
       throw new SlickException(s"Could not update ${jobInfo.jobId} in the database")
     }
   }
 
-  private def jobInfoFromRow(row: (String, String, String, String,
-    Timestamp, String, Timestamp, Option[Timestamp],
+  private def jobInfoFromRow(row: (String, String, String, String, String,
+    Timestamp, String, String, Timestamp, Option[Timestamp],
     Option[String], Option[String], Option[String])): JobInfo = row match {
-    case (id, context, app, binType, upload, classpath, start, end, err, errCls, errStTr) =>
+    case (id, contextId, contextName, app, binType, upload, classpath,
+        state, start, end, err, errCls, errStTr) =>
       val errorInfo = err.map(ErrorData(_, errCls.getOrElse(""), errStTr.getOrElse("")))
       JobInfo(
         id,
-        context,
+        contextId,
+        contextName,
         BinaryInfo(app, BinaryType.fromString(binType), convertDateSqlToJoda(upload)),
         classpath,
+        state,
         convertDateSqlToJoda(start),
         end.map(convertDateSqlToJoda),
         errorInfo
@@ -392,20 +397,15 @@ class JobSqlDAO(config: Config) extends JobDAO with FileCacher {
 
     val joinQuery = for {
       bin <- binaries
-      j <- jobs if j.binId === bin.binId && (statusOpt match {
-                          // !endTime.isDefined
-                          case Some(JobStatus.Running) => !j.endTime.isDefined && !j.error.isDefined
-                          // endTime.isDefined && error.isDefined
-                          case Some(JobStatus.Error) => j.error.isDefined
-                          // not RUNNING AND NOT ERROR
-                          case Some(JobStatus.Finished) => j.endTime.isDefined && !j.error.isDefined
-                          case _ => true
+      j <- jobs if (statusOpt match {
+                          case Some(state) => j.binId === bin.binId && j.state === state
+                          case None => j.binId === bin.binId
                 })
     } yield {
-      (j.jobId, j.contextName, bin.appName, bin.binaryType,
-        bin.uploadTime, j.classPath, j.startTime, j.endTime, j.error, j.errorClass, j.errorStackTrace)
+      (j.jobId, j.contextId, j.contextName, bin.appName, bin.binaryType, bin.uploadTime, j.classPath,
+          j.state, j.startTime, j.endTime, j.error, j.errorClass, j.errorStackTrace)
     }
-    val sortQuery = joinQuery.sortBy(_._7.desc)
+    val sortQuery = joinQuery.sortBy(_._9.desc)
     val limitQuery = sortQuery.take(limit)
     // Transform the each row of the table into a map of JobInfo values
     for (r <- db.run(limitQuery.result)) yield {
@@ -418,29 +418,30 @@ class JobSqlDAO(config: Config) extends JobDAO with FileCacher {
     *
     * @return
     */
-  override def getRunningJobInfosForContextName(contextName: String): Future[Seq[JobInfo]] = {
+  override def getJobInfosByContextId(
+      contextId: String, jobStatus: Option[String] = None): Future[Seq[JobInfo]] = {
     val joinQuery = for {
       bin <- binaries
-      j <- jobs if (j.binId === bin.binId
-        && !j.endTime.isDefined && !j.error.isDefined
-        && j.contextName === contextName)
+      j <- jobs if ((contextId, jobStatus) match {
+                          case (contextId, Some(jobStatus)) => j.binId === bin.binId &&
+                              j.contextId === contextId && j.state === jobStatus
+                          case _ => j.binId === bin.binId && j.contextId === contextId
+                })
     } yield {
-      (j.jobId, j.contextName, bin.appName, bin.binaryType,
-        bin.uploadTime, j.classPath, j.startTime, j.endTime, j.error, j.errorClass, j.errorStackTrace)
+      (j.jobId, j.contextId, j.contextName, bin.appName, bin.binaryType, bin.uploadTime, j.classPath,
+          j.state, j.startTime, j.endTime, j.error, j.errorClass, j.errorStackTrace)
     }
     db.run(joinQuery.result).map(_.map(jobInfoFromRow))
   }
 
 
-  override def cleanRunningJobInfosForContext(contextName: String, endTime: DateTime): Future[Unit] = {
+  override def cleanRunningJobInfosForContext(contextId: String, endTime: DateTime): Future[Unit] = {
     val sqlEndTime = Some(convertDateJodaToSql(endTime))
-    val error = Some(new ContextTerminatedException(contextName).getMessage())
+    val error = Some(new ContextTerminatedException(contextId).getMessage())
     val selectQuery = for {
-      j <- jobs if (!j.endTime.isDefined
-        && !j.error.isDefined
-        && j.contextName === contextName)
-    } yield (j.endTime, j.error)
-    val updateQuery = selectQuery.update((sqlEndTime, error))
+      j <- jobs if (j.contextId === contextId && j.state === JobStatus.Running)
+    } yield (j.endTime, j.error, j.state)
+    val updateQuery = selectQuery.update((sqlEndTime, error, JobStatus.Error))
     db.run(updateQuery).map(_ => ())
   }
 
@@ -451,8 +452,8 @@ class JobSqlDAO(config: Config) extends JobDAO with FileCacher {
       bin <- binaries
       j <- jobs if j.binId === bin.binId && j.jobId === jobId
     } yield {
-      (j.jobId, j.contextName, bin.appName, bin.binaryType, bin.uploadTime, j.classPath, j.startTime,
-        j.endTime, j.error, j.errorClass, j.errorStackTrace)
+      (j.jobId, j.contextId, j.contextName, bin.appName, bin.binaryType, bin.uploadTime, j.classPath,
+         j.state, j.startTime, j.endTime, j.error, j.errorClass, j.errorStackTrace)
     }
     for (r <- db.run(joinQuery.result)) yield {
       r.map(jobInfoFromRow).headOption

--- a/job-server/src/test/scala/spark/jobserver/InMemoryDAO.scala
+++ b/job-server/src/test/scala/spark/jobserver/InMemoryDAO.scala
@@ -99,8 +99,14 @@ class InMemoryDAO extends JobDAO {
     filterJobs.take(limit)
   }
 
-  override def getRunningJobInfosForContextName(contextName: String): Future[Seq[JobInfo]] = Future {
-    jobInfos.values.toSeq.filter(j => j.endTime.isEmpty && j.error.isEmpty && j.contextName == contextName)
+  override def getJobInfosByContextId(
+      contextId: String, jobStatus: Option[String] = None): Future[Seq[JobInfo]] = Future {
+    jobInfos.values.toSeq.filter(j => {
+      (contextId, jobStatus) match {
+        case (contextId, Some(status)) => contextId == j.contextId && status == j.state
+        case _ => contextId == j.contextId
+      }
+    })
   }
 
   override def getJobInfo(jobId: String): Future[Option[JobInfo]] = Future {

--- a/job-server/src/test/scala/spark/jobserver/JobInfoActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobInfoActorSpec.scala
@@ -70,7 +70,7 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
     it("should return job info when requested for jobId that exists") {
       val dt = DateTime.parse("2013-05-29T00Z")
       val jobInfo =
-        JobInfo("foo", "context", BinaryInfo("demo", BinaryType.Jar, dt), "com.abc.meme", dt, None, None)
+        JobInfo("foo", "cid", "context", BinaryInfo("demo", BinaryType.Jar, dt), "com.abc.meme", JobStatus.Running, dt, None, None)
       dao.saveJobInfo(jobInfo)
       actor ! GetJobStatus("foo")
       expectMsg(jobInfo)
@@ -79,7 +79,7 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
     it("should return job info when requested for jobId that exists, where the job is a Python job") {
       val dt = DateTime.parse("2013-05-29T00Z")
       val jobInfo =
-        JobInfo("bar", "context", BinaryInfo("demo", BinaryType.Egg, dt), "com.abc.meme", dt, None, None)
+        JobInfo("bar", "cid", "context", BinaryInfo("demo", BinaryType.Egg, dt), "com.abc.meme", JobStatus.Running, dt, None, None)
       dao.saveJobInfo(jobInfo)
       actor ! GetJobStatus("bar")
       expectMsg(jobInfo)
@@ -94,9 +94,9 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
       val dt1 = DateTime.parse("2013-05-28T00Z")
       val dt2 = DateTime.parse("2013-05-29T00Z")
       val jobInfo1 =
-        JobInfo("foo-1", "context", BinaryInfo("demo", BinaryType.Jar, dt1), "com.abc.meme", dt2, None, None)
+        JobInfo("foo-1", "cid", "context", BinaryInfo("demo", BinaryType.Jar, dt1), "com.abc.meme", JobStatus.Running, dt2, None, None)
       val jobInfo2 =
-        JobInfo("foo-2", "context", BinaryInfo("demo", BinaryType.Jar, dt2), "com.abc.meme", dt2, None, None)
+        JobInfo("foo-2", "cid", "context", BinaryInfo("demo", BinaryType.Jar, dt2), "com.abc.meme", JobStatus.Running, dt2, None, None)
       dao.saveJobInfo(jobInfo1)
       dao.saveJobInfo(jobInfo2)
       actor ! GetJobStatuses(Some(10))
@@ -107,9 +107,9 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
       val dt1 = DateTime.parse("2013-05-28T00Z")
       val dt2 = DateTime.parse("2013-05-29T00Z")
       val jobInfo1 =
-        JobInfo("foo-1", "context", BinaryInfo("demo", BinaryType.Jar, dt1), "com.abc.meme", dt1, None, None)
+        JobInfo("foo-1", "cid", "context", BinaryInfo("demo", BinaryType.Jar, dt1), "com.abc.meme", JobStatus.Running, dt1, None, None)
       val jobInfo2 =
-        JobInfo("foo-2", "context", BinaryInfo("demo", BinaryType.Egg, dt2), "com.abc.meme", dt2, None, None)
+        JobInfo("foo-2", "cid", "context", BinaryInfo("demo", BinaryType.Egg, dt2), "com.abc.meme", JobStatus.Running, dt2, None, None)
       dao.saveJobInfo(jobInfo1)
       dao.saveJobInfo(jobInfo2)
       actor ! GetJobStatuses(Some(1))
@@ -122,9 +122,9 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
       val dt4 = dt3.plusMinutes(5)
       val binaryInfo = BinaryInfo("demo", BinaryType.Jar, dt1)
       val someError = Some(ErrorData(new Throwable("test-error")))
-      val runningJob = JobInfo("running-1", "context", binaryInfo, "com.abc.meme", dt1, None, None)
-      val errorJob = JobInfo("error-1", "context", binaryInfo, "com.abc.meme", dt2, None, someError)
-      val finishedJob = JobInfo("finished-1", "context", binaryInfo, "com.abc.meme", dt3, Some(dt4), None)
+      val runningJob = JobInfo("running-1", "cid", "context", binaryInfo, "com.abc.meme", JobStatus.Running, dt1,None, None)
+      val errorJob = JobInfo("error-1", "cid", "context", binaryInfo, "com.abc.meme", JobStatus.Error, dt2, Some(dt2), someError)
+      val finishedJob = JobInfo("finished-1", "cid", "context", binaryInfo, "com.abc.meme", JobStatus.Finished, dt3, Some(dt4), None)
 
       dao.saveJobInfo(runningJob)
       dao.saveJobInfo(errorJob)
@@ -153,21 +153,30 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
       expectMsg(NoSuchJobId)
     }
 
-    it("should return job info if job result is requested for running or errored out job") {
+    it("should return job info if job result is requested for running or errored out or killed job") {
       val someError = Some(ErrorData(new Throwable("test-error")))
       val dt1 = DateTime.parse("2013-05-28T00Z")
       val dt2 = DateTime.parse("2013-05-29T00Z")
       val jobInfo1 =
-        JobInfo("foo-1", "context", BinaryInfo("demo", BinaryType.Jar, dt1), "com.abc.meme", dt1, None, None)
+        JobInfo("foo-1", "cid" ,"context", BinaryInfo("demo", BinaryType.Jar, dt1), "com.abc.meme", JobStatus.Running, dt1, None, None)
       val jobInfo2 =
-        JobInfo("foo-2", "context", BinaryInfo("demo", BinaryType.Jar, dt2),
-          "com.abc.meme", dt2, None, someError)
+        JobInfo("foo-2", "cid" ,"context", BinaryInfo("demo", BinaryType.Jar, dt2),
+          "com.abc.meme", JobStatus.Error, dt2, Some(DateTime.now()), someError)
+      val jobInfo3 =
+        JobInfo("foo-3", "cid" ,"context", BinaryInfo("demo", BinaryType.Jar, dt2),
+          "com.abc.meme", JobStatus.Killed, dt2, Some(DateTime.now()), someError)
       dao.saveJobInfo(jobInfo1)
       dao.saveJobInfo(jobInfo2)
+      dao.saveJobInfo(jobInfo3)
+
       actor ! GetJobResult("foo-1")
       expectMsg(jobInfo1)
+
       actor ! GetJobResult("foo-2")
       expectMsg(jobInfo2)
+
+      actor ! GetJobResult("foo-3")
+      expectMsg(jobInfo3)
     }
   }
 }

--- a/job-server/src/test/scala/spark/jobserver/JobStatusActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobStatusActorSpec.scala
@@ -1,7 +1,7 @@
 package spark.jobserver
 
 import akka.actor.{ActorRef, ActorSystem, Props}
-import akka.testkit.{ImplicitSender, TestKit}
+import akka.testkit.{ImplicitSender, TestKit, TestProbe, TestActor}
 import spark.jobserver.io._
 import org.joda.time.DateTime
 import org.scalatest.Matchers
@@ -20,11 +20,15 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
   import JobStatusActor._
 
   private val jobId = "jobId"
+  private val contextId = "contextId"
   private val contextName = "contextName"
   private val appName = "appName"
   private val jarInfo = BinaryInfo(appName, BinaryType.Jar, DateTime.now)
   private val classPath = "classPath"
-  private val jobInfo = JobInfo(jobId, contextName, jarInfo, classPath, DateTime.now, None, None)
+  private val jobInfo = JobInfo(jobId, contextId, contextName, jarInfo, classPath, JobStatus.Running,
+      DateTime.now, None, None)
+  private val endTime = DateTime.now()
+  private val error = new Throwable
 
   override def afterAll() {
     akka.AkkaTestUtils.shutdownAndWait(JobStatusActorSpec.system)
@@ -34,10 +38,21 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
   var receiver: ActorRef = _
   var dao: JobDAO = _
   var daoActor: ActorRef = _
+  var daoProbe: TestProbe = _
+  var daoMsgReceiverProbe: TestProbe = _
 
   before {
-    dao = new InMemoryDAO
-    daoActor = system.actorOf(JobDAOActor.props(dao))
+    daoProbe = TestProbe()
+    daoMsgReceiverProbe = TestProbe()
+    daoProbe.setAutoPilot(new TestActor.AutoPilot {
+      def run(sender: ActorRef, msg: Any): TestActor.AutoPilot = {
+        sender ! "All good"
+        daoMsgReceiverProbe.ref ! msg
+        TestActor.KeepRunning
+      }
+    })
+
+    daoActor = daoProbe.ref
     actor = system.actorOf(Props(classOf[JobStatusActor], daoActor))
     receiver = system.actorOf(Props[JobResultActor])
   }
@@ -49,6 +64,7 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
   describe("JobStatusActor") {
     it("should return empty sequence if there is no job infos") {
       actor ! GetRunningJobStatus
+      daoMsgReceiverProbe.expectNoMsg()
       expectMsg(Seq.empty)
     }
 
@@ -68,6 +84,7 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
       actor ! Subscribe(jobId, self, Set(classOf[JobStarted]))
       val msg = JobStarted(jobId, jobInfo)
       actor ! msg
+      daoMsgReceiverProbe.expectMsg(JobDAOActor.SaveJobInfo(jobInfo))
       expectMsg(msg)
 
       actor ! msg
@@ -75,52 +92,68 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
 
       actor ! Unsubscribe(jobId, self)
       actor ! JobStarted(jobId, jobInfo)
+      daoMsgReceiverProbe.expectMsg(JobDAOActor.SaveJobInfo(jobInfo))
       expectNoMsg()   // shouldn't get it again
 
       actor ! Unsubscribe(jobId, self)
       expectMsg(NoSuchJobId)
     }
 
-    it("should be ok to subscribe beofore job init") {
+    it("should be ok to subscribe before job init") {
       actor ! Subscribe(jobId, self, Set(classOf[JobStarted]))
       actor ! JobInit(jobInfo)
       val msg = JobStarted(jobId, jobInfo)
       actor ! msg
+      daoMsgReceiverProbe.expectMsg(JobDAOActor.SaveJobInfo(jobInfo))
       expectMsg(msg)
     }
 
     it("should be informed JobValidationFailed once") {
       actor ! JobInit(jobInfo)
       actor ! Subscribe(jobId, self, Set(classOf[JobValidationFailed]))
-      val msg = JobValidationFailed(jobId, DateTime.now, new Throwable)
+      val msg = JobValidationFailed(jobId, endTime, error)
+
       actor ! msg
+      daoMsgReceiverProbe.expectMsg(JobDAOActor.SaveJobInfo(jobInfo.copy(
+          state = JobStatus.Error, endTime = Some(endTime), error = Some(ErrorData(error)))))
       expectMsg(msg)
 
       actor ! msg
+      daoMsgReceiverProbe.expectNoMsg()
       expectMsg(NoSuchJobId)
     }
 
     it("should be informed JobFinished until it is unsubscribed") {
       actor ! JobInit(jobInfo)
       actor ! JobStarted(jobId, jobInfo)
+      daoMsgReceiverProbe.expectMsg(JobDAOActor.SaveJobInfo(jobInfo))
       actor ! Subscribe(jobId, self, Set(classOf[JobFinished]))
-      val msg = JobFinished(jobId, DateTime.now)
+
+      val msg = JobFinished(jobId, endTime)
       actor ! msg
+      daoMsgReceiverProbe.expectMsg(JobDAOActor.SaveJobInfo(jobInfo.copy(
+          state = JobStatus.Finished, endTime = Some(endTime))))
       expectMsg(msg)
 
       actor ! msg
+      daoMsgReceiverProbe.expectNoMsg()
       expectMsg(NoSuchJobId)
     }
 
     it("should be informed JobErroredOut until it is unsubscribed") {
       actor ! JobInit(jobInfo)
       actor ! JobStarted(jobId, jobInfo)
+      daoMsgReceiverProbe.expectMsg(JobDAOActor.SaveJobInfo(jobInfo))
       actor ! Subscribe(jobId, self, Set(classOf[JobErroredOut]))
-      val msg = JobErroredOut(jobId, DateTime.now, new Throwable)
+
+      val msg = JobErroredOut(jobId, endTime, error)
       actor ! msg
+      daoMsgReceiverProbe.expectMsg(JobDAOActor.SaveJobInfo(jobInfo.copy(
+          state = JobStatus.Error, endTime = Some(endTime), error = Some(ErrorData(error)))))
       expectMsg(msg)
 
       actor ! msg
+      daoMsgReceiverProbe.expectNoMsg()
       expectMsg(NoSuchJobId)
     }
 
@@ -129,39 +162,70 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
       actor ! GetRunningJobStatus
       expectMsg(Seq(jobInfo))
 
-      val startTime = DateTime.now
-      actor ! JobStarted(jobId, jobInfo.copy(startTime=startTime))
-      actor ! GetRunningJobStatus
-      expectMsg(Seq(JobInfo(jobId, contextName, jarInfo, classPath, startTime, None, None)))
+      val jobInfoWithStartTime = jobInfo.copy(startTime=DateTime.now)
+      actor ! JobStarted(jobId, jobInfoWithStartTime)
+      daoMsgReceiverProbe.expectMsg(JobDAOActor.SaveJobInfo(jobInfoWithStartTime))
 
-      val finishTIme = DateTime.now
-      actor ! JobFinished(jobId, finishTIme)
       actor ! GetRunningJobStatus
+      expectMsg(Seq(jobInfoWithStartTime))
+
+      val finishTime = DateTime.now
+      actor ! JobFinished(jobId, finishTime)
+      daoMsgReceiverProbe.expectMsg(JobDAOActor.SaveJobInfo(jobInfoWithStartTime.copy(
+          state = JobStatus.Finished, endTime = Some(finishTime))))
+
+      actor ! GetRunningJobStatus
+      daoMsgReceiverProbe.expectNoMsg()
       expectMsg(Seq.empty)
     }
 
     it("should update JobValidationFailed status correctly") {
-      val initTime = DateTime.now
-      val jobInfo = JobInfo(jobId, contextName, jarInfo, classPath, initTime, None, None)
-      actor ! JobInit(jobInfo)
+      val jobInfoWithInitTime = jobInfo.copy(startTime=DateTime.now)
+      actor ! JobInit(jobInfoWithInitTime)
 
-      val failedTime = DateTime.now
-      val err = new Throwable
-      actor ! JobValidationFailed(jobId, failedTime, err)
+      actor ! JobValidationFailed(jobId, endTime, error)
+      daoMsgReceiverProbe.expectMsg(JobDAOActor.SaveJobInfo(jobInfoWithInitTime.copy(
+          state = JobStatus.Error, endTime = Some(endTime), error = Some(ErrorData(error)))))
+
       actor ! GetRunningJobStatus
+      daoMsgReceiverProbe.expectNoMsg()
       expectMsg(Seq.empty)
     }
 
     it("should update JobErroredOut status correctly") {
       actor ! JobInit(jobInfo)
 
-      val startTime = DateTime.now
       actor ! JobStarted(jobId, jobInfo)
+      daoMsgReceiverProbe.expectMsg(JobDAOActor.SaveJobInfo(jobInfo))
 
-      val failedTime = DateTime.now
-      val err = new Throwable
-      actor ! JobErroredOut(jobId, failedTime, err)
+      actor ! JobErroredOut(jobId, endTime, error)
+      daoMsgReceiverProbe.expectMsg(JobDAOActor.SaveJobInfo(jobInfo.copy(
+          state = JobStatus.Error, endTime = Some(endTime), error = Some(ErrorData(error)))))
+
       actor ! GetRunningJobStatus
+      daoMsgReceiverProbe.expectNoMsg()
+      expectMsg(Seq.empty)
+    }
+
+    it("should update JobKilled status correctly") {
+      import spark.jobserver.JobManagerActor.JobKilledException
+      import scala.concurrent.duration._
+      actor ! JobInit(jobInfo)
+
+      actor ! JobStarted(jobId, jobInfo)
+      daoMsgReceiverProbe.expectMsg(JobDAOActor.SaveJobInfo(jobInfo))
+
+      actor ! JobKilled(jobId, endTime)
+      val id = daoMsgReceiverProbe.expectMsgPF(3 seconds, "We cannot pass custom throwable inside JobKilled") {
+        case JobDAOActor.SaveJobInfo(receivedJobInfo) =>
+          receivedJobInfo.jobId should be (jobId)
+          receivedJobInfo.state should be (JobStatus.Killed)
+          receivedJobInfo.endTime should be (Some(endTime))
+          receivedJobInfo.error.get.message should be (s"Job $jobId killed")
+      }
+
+      actor ! GetRunningJobStatus
+      daoMsgReceiverProbe.expectNoMsg()
       expectMsg(Seq.empty)
     }
   }

--- a/job-server/src/test/scala/spark/jobserver/LocalContextSupervisorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/LocalContextSupervisorSpec.scala
@@ -174,8 +174,7 @@ class LocalContextSupervisorSpec extends TestKit(LocalContextSupervisorSpec.syst
       val (jobManager: ActorRef) = expectMsgType[ActorRef]
 
       jobManager ! PoisonPill
-      val msg = daoProbe.expectMsgType[CleanContextJobInfos]
-      msg.contextName shouldBe "c1"
+      daoProbe.expectMsgType[CleanContextJobInfos]
     }
   }
 }

--- a/job-server/src/test/scala/spark/jobserver/WebApiMainRoutesSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiMainRoutesSpec.scala
@@ -18,6 +18,7 @@ class WebApiMainRoutesSpec extends WebApiSpec {
   val getJobStatusInfoMap = {
     Map(
       "jobId" -> "foo-1",
+      "contextId" -> "cid",
       "startTime" -> "2013-05-29T00:00:00.000Z",
       "classPath" -> "com.abc.meme",
       "context"  -> "context",
@@ -118,12 +119,14 @@ class WebApiMainRoutesSpec extends WebApiSpec {
         status should be (OK)
         responseAs[Seq[Map[String, String]]] should be (Seq(
           Map("jobId" -> "foo-1",
+              "contextId" -> "cid",
               "startTime" -> "2013-05-29T00:00:00.000Z",
               "classPath" -> "com.abc.meme",
               "context"  -> "context",
               "duration" -> "Job not done yet",
               StatusKey -> JobStatus.Running),
           Map("jobId" -> "foo-1",
+              "contextId" -> "cid",
               "startTime" -> "2013-05-29T00:00:00.000Z",
               "classPath" -> "com.abc.meme",
               "context"  -> "context",
@@ -137,6 +140,7 @@ class WebApiMainRoutesSpec extends WebApiSpec {
         status should be (OK)
         responseAs[Seq[Map[String, String]]] should be (Seq(
           Map("jobId" -> "foo-1",
+            "contextId" -> "cid",
             "startTime" -> "2013-05-29T00:00:00.000Z",
             "classPath" -> "com.abc.meme",
             "context"  -> "context",
@@ -170,6 +174,7 @@ class WebApiMainRoutesSpec extends WebApiSpec {
         status should be (OK)
         responseAs[Seq[Map[String, String]]] should be (Seq(
           Map("jobId" -> "foo-1",
+            "contextId" -> "cid",
             "startTime" -> "2013-05-29T00:00:00.000Z",
             "classPath" -> "com.abc.meme",
             "context"  -> "context",
@@ -221,6 +226,7 @@ class WebApiMainRoutesSpec extends WebApiSpec {
         status should be (Accepted)
         responseAs[Map[String, String]] should be (Map(
           "jobId" -> "foo",
+          "contextId" -> "cid",
           "startTime" -> "2013-05-29T00:00:00.000Z",
           "classPath" -> "com.abc.meme",
           "context"  -> "context",
@@ -282,6 +288,7 @@ class WebApiMainRoutesSpec extends WebApiSpec {
         status should be (Accepted)
         responseAs[Map[String, String]] should be (Map(
           "jobId" -> "foo",
+          "contextId" -> "cid",
           "startTime" -> "2013-05-29T00:00:00.000Z",
           "classPath" -> "com.abc.meme",
           "context"  -> "context",
@@ -296,6 +303,7 @@ class WebApiMainRoutesSpec extends WebApiSpec {
         status should be (OK)
         responseAs[Map[String, String]] should be (Map(
           "jobId" -> "foo-1",
+          "contextId" -> "cid",
           "startTime" -> "2013-05-29T00:00:00.000Z",
           "classPath" -> "com.abc.meme",
           "context"  -> "context",
@@ -310,6 +318,7 @@ class WebApiMainRoutesSpec extends WebApiSpec {
         status should be (OK)
         responseAs[Map[String, String]] should be (Map(
           "jobId" -> "foo-1",
+          "contextId" -> "cid",
           "startTime" -> "2013-05-29T00:00:00.000Z",
           "classPath" -> "com.abc.meme",
           "context"  -> "context",

--- a/job-server/src/test/scala/spark/jobserver/auth/WebApiWithAuthenticationSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/auth/WebApiWithAuthenticationSpec.scala
@@ -5,7 +5,7 @@ import akka.testkit.TestKit
 import com.typesafe.config.{ ConfigFactory, ConfigValueFactory }
 import spark.jobserver._
 import spark.jobserver.util.SparkJobUtils
-import spark.jobserver.io.{BinaryType, BinaryInfo, JobInfo}
+import spark.jobserver.io.{BinaryType, BinaryInfo, JobInfo, JobStatus}
 import org.joda.time.DateTime
 import org.scalatest.{ Matchers, FunSpec, BeforeAndAfterAll }
 import spray.http.StatusCodes._
@@ -125,8 +125,8 @@ class WebApiWithAuthenticationSpec extends FunSpec with Matchers with BeforeAndA
   private val authorizationInvalidPassword = new Authorization(new BasicHttpCredentials(USER_NAME, "xxx"))
   private val authorizationUnknownUser = new Authorization(new BasicHttpCredentials("whoami", "xxx"))
   private val dt = DateTime.parse("2013-05-29T00Z")
-  private val jobInfo =
-    JobInfo("foo-1", "context", BinaryInfo("demo", BinaryType.Jar, dt), "com.abc.meme", dt, None, None)
+  private val jobInfo = JobInfo("foo-1", "cid", "context", BinaryInfo("demo", BinaryType.Jar, dt), "com.abc.meme",
+      JobStatus.Running, dt, None, None)
   private val ResultKey = "result"
 
   private val addedContexts = new scala.collection.mutable.HashSet[String] with SynchronizedSet[String]

--- a/job-server/src/test/scala/spark/jobserver/io/FlywayMigrationSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/FlywayMigrationSpec.scala
@@ -92,8 +92,8 @@ class FlywayMigrationSpec extends FunSpec with Matchers {
       val descJobsIt = ResultSetIterator(descJobs){ r: ResultSet =>
         r.getString("FIELD")
       }
-      descJobsIt.toList should be (List(
-        "JOB_ID", "CONTEXT_NAME", "BIN_ID", "CLASSPATH", "START_TIME", "END_TIME", "ERROR", "ERROR_CLASS", "ERROR_STACK_TRACE"))
+      descJobsIt.toList should be (List("JOB_ID", "CONTEXT_NAME", "BIN_ID", "CLASSPATH", "START_TIME", "END_TIME",
+          "ERROR", "ERROR_CLASS","ERROR_STACK_TRACE", "CONTEXT_ID", "STATE"))
 
       val descConfigs = sqlConn.createStatement().executeQuery("SHOW COLUMNS FROM CONFIGS")
       val descConfigsIt = ResultSetIterator(descConfigs){ r: ResultSet =>
@@ -180,7 +180,7 @@ class FlywayMigrationSpec extends FunSpec with Matchers {
         r.getString("COLUMN_NAME")
       }
       descJobsIt.toList should be (List(
-        "JOB_ID", "CONTEXT_NAME", "BIN_ID", "CLASSPATH", "START_TIME", "END_TIME", "ERROR"))
+        "JOB_ID", "CONTEXT_NAME", "BIN_ID", "CLASSPATH", "START_TIME", "END_TIME", "ERROR", "CONTEXT_ID", "STATE"))
 
       val descConfigs = sqlConn.getMetaData.getColumns(null, null, "CONFIGS", null)
       val descConfigsIt = ResultSetIterator(descConfigs){ r: ResultSet =>

--- a/job-server/src/test/scala/spark/jobserver/io/JobCassandraDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/JobCassandraDAOSpec.scala
@@ -34,11 +34,10 @@ class JobCassandraDAOSpec extends TestJarFinder with FunSpecLike with Matchers w
   )
 
   // jobInfo test data; order is important
-  val jobInfoNoEndNoErr:JobInfo = genJobInfo(jarInfo, false, false, false)
+  val jobInfoNoEndNoErr:JobInfo = genJobInfo(jarInfo, false, JobStatus.Running)
   val expectedJobInfo = jobInfoNoEndNoErr
-  val jobInfoNoEndSomeErr: JobInfo = genJobInfo(jarInfo, false, true, false)
-  val jobInfoSomeEndNoErr: JobInfo = genJobInfo(jarInfo, true, false, false)
-  val jobInfoSomeEndSomeErr: JobInfo = genJobInfo(jarInfo, true, true, false)
+  val jobInfoSomeEndNoErr: JobInfo = genJobInfo(jarInfo, true, JobStatus.Finished)
+  val jobInfoSomeEndSomeErr: JobInfo = genJobInfo(jarInfo, true, JobStatus.Error)
 
   // job config test data
   val jobId: String = jobInfoNoEndNoErr.jobId
@@ -67,7 +66,8 @@ class JobCassandraDAOSpec extends TestJarFinder with FunSpecLike with Matchers w
   case class GenJobInfoClosure() {
     var count: Int = 0
 
-    def apply(jarInfo: BinaryInfo, hasEndTime: Boolean, hasError: Boolean, isNew:Boolean, contextName: String = "test-context"):JobInfo ={
+    def apply(jarInfo: BinaryInfo, isNew:Boolean, state: String, contextName: String = "test-context",
+        contextId: String = UUIDs.random().toString):JobInfo ={
       count = count + (if (isNew) 1 else 0)
 
       val id: String = UUIDs.random().toString
@@ -78,11 +78,15 @@ class JobCassandraDAOSpec extends TestJarFinder with FunSpecLike with Matchers w
       val someEndTime: Option[DateTime] = Some(startTime.plusSeconds(5)) // Any DateTime Option is fine
       val someError = Some(ErrorData(throwable))
 
-      val endTime: Option[DateTime] = if (hasEndTime) someEndTime else noEndTime
-      val error = if (hasError) someError else None
+      val endTimeAndError = state match {
+        case JobStatus.Started | JobStatus.Running => (None, None)
+        case JobStatus.Finished => (someEndTime, None)
+        case JobStatus.Error | JobStatus.Killed => (someEndTime, someError)
+      }
 
       Thread.sleep(2) // hack to guarantee order
-      JobInfo(id, contextName, jarInfo, classPath, startTime, endTime, error)
+      JobInfo(id, contextId, contextName, jarInfo, classPath, state, startTime,
+          endTimeAndError._1, endTimeAndError._2)
     }
 
   }
@@ -166,7 +170,7 @@ class JobCassandraDAOSpec extends TestJarFinder with FunSpecLike with Matchers w
     }
 
     it("Save a new config, bring down DB, bring up DB, should get configs from DB") {
-      val jobId2: String = genJobInfo(genJarInfo(false, false), false, false, true).jobId
+      val jobId2: String = genJobInfo(genJarInfo(false, false), true, JobStatus.Running).jobId
       val jobConfig2: Config = ConfigFactory.parseString("{merry=xmas}")
       val expectedConfig2 = ConfigFactory.empty().withValue("merry", ConfigValueFactory.fromAnyRef("xmas"))
       // config previously saved
@@ -217,7 +221,7 @@ class JobCassandraDAOSpec extends TestJarFinder with FunSpecLike with Matchers w
     }
 
     it("Save another new jobInfo, bring down DB, bring up DB, should JobInfos from DB") {
-      val jobInfo2 = genJobInfo(jarInfo, false, false, true)
+      val jobInfo2 = genJobInfo(jarInfo, true, JobStatus.Running)
       val jobId2 = jobInfo2.jobId
       val expectedJobInfo2 = jobInfo2
       // jobInfo previously saved
@@ -239,7 +243,7 @@ class JobCassandraDAOSpec extends TestJarFinder with FunSpecLike with Matchers w
     }
 
     it("saving a JobInfo with the same jobId should update the JOBS table") {
-      val expectedNoEndSomeErr = jobInfoNoEndSomeErr
+      val expectedNoEndNoErr = jobInfoNoEndNoErr
       val expectedSomeEndNoErr = jobInfoSomeEndNoErr
       val expectedSomeEndSomeErr = jobInfoSomeEndSomeErr
       val exJobId = jobInfoNoEndNoErr.jobId
@@ -257,15 +261,11 @@ class JobCassandraDAOSpec extends TestJarFinder with FunSpecLike with Matchers w
       // Second Test
       // Cannot compare JobInfos directly if error is a Some(Throwable) because
       // Throwable uses referential equality
-      dao.saveJobInfo(jobInfoNoEndSomeErr)
+      dao.saveJobInfo(expectedNoEndNoErr)
       val jobs2 = Await.result(dao.getJobInfos(2), timeout)
       jobs2.size should equal (2)
       jobs2.last.endTime should equal (None)
-      jobs2.last.error.isDefined should equal (true)
-      jobs2.last.error shouldBe defined
-      jobs2.last.error.get.message should equal (throwable.getMessage)
-      jobs2.last.error.get.errorClass should equal (throwable.getClass.getName)
-      jobs2.last.error.get.stackTrace should not be empty
+      jobs2.last.error should equal (None)
 
       // Third Test
       dao.saveJobInfo(jobInfoSomeEndNoErr)
@@ -292,12 +292,12 @@ class JobCassandraDAOSpec extends TestJarFinder with FunSpecLike with Matchers w
       val dt1 = DateTime.now()
       val dt2 = Some(DateTime.now())
       val someError = Some(ErrorData("test-error", "", ""))
-      val finishedJob: JobInfo =
-        JobInfo(UUID.randomUUID.toString, "test", jarInfo, "test-class", dt1, dt2, None)
-      val errorJob: JobInfo =
-        JobInfo(UUID.randomUUID.toString, "test", jarInfo, "test-class", dt1, dt2, someError)
-      val runningJob: JobInfo =
-        JobInfo(UUID.randomUUID.toString, "test", jarInfo, "test-class", dt1, None, None)
+      val finishedJob: JobInfo = JobInfo(UUID.randomUUID.toString, UUID.randomUUID.toString,
+          "test", jarInfo, "test-class", JobStatus.Finished, dt1, dt2, None)
+      val errorJob: JobInfo = JobInfo(UUID.randomUUID.toString, UUID.randomUUID.toString,
+          "test", jarInfo, "test-class", JobStatus.Error, dt1, dt2, someError)
+      val runningJob: JobInfo = JobInfo(UUID.randomUUID.toString, UUID.randomUUID.toString,
+          "test", jarInfo, "test-class", JobStatus.Running, dt1, None, None)
       dao.saveJobInfo(finishedJob)
       dao.saveJobInfo(runningJob)
       dao.saveJobInfo(errorJob)
@@ -327,20 +327,52 @@ class JobCassandraDAOSpec extends TestJarFinder with FunSpecLike with Matchers w
       retrieved.error.isDefined should equal (true)
     }
 
-    it("retrieve running jobs by context name") {
-      val jobInfo = genJobInfo(jarInfo, false, false, true, "context")
+    it("should retrieve jobs by context id") {
+      val jobInfo = genJobInfo(jarInfo, true, JobStatus.Running, "context")
       dao.saveJobInfo(jobInfo)
 
-      val results = Await.result(dao.getRunningJobInfosForContextName("context"), timeout)
+      val results = Await.result(dao.getJobInfosByContextId(jobInfo.contextId), timeout)
+
       results should have size 1
       results.head.jobId shouldBe jobInfo.jobId
     }
 
-    it("should clean jobs for given context") {
-      val jobInfo = genJobInfo(jarInfo, false, false, false, "context")
+    it("should retrieve multiple jobs if they have the same context id") {
+      val contextId = UUIDs.random().toString
+      val finishedJob = genJobInfo(jarInfo, true, JobStatus.Finished, "context", contextId)
+      val jobWithDifferentContextId = genJobInfo(jarInfo, true, JobStatus.Error)
+      val runningJob = genJobInfo(jarInfo, true, JobStatus.Running, "context", contextId)
+      val finishedJob2 = genJobInfo(jarInfo, true, JobStatus.Finished, "context", contextId)
+      dao.saveJobInfo(finishedJob)
+      dao.saveJobInfo(jobWithDifferentContextId)
+      dao.saveJobInfo(runningJob)
+      dao.saveJobInfo(finishedJob2)
+
+      val results = Await.result(dao.getJobInfosByContextId(contextId), timeout)
+
+      results should have size 3
+      results.filter(_.contextId == contextId).size shouldBe 3
+      results.map(_.jobId) should contain allOf(finishedJob.jobId, runningJob.jobId, finishedJob2.jobId)
+    }
+
+    it("retrieve finished jobs by context id") {
+      val contextId = UUIDs.random().toString
+      val finishedJob = genJobInfo(jarInfo, true, JobStatus.Finished, "context", contextId)
+      val runningJob = genJobInfo(jarInfo, true, JobStatus.Running, "context", contextId)
+      dao.saveJobInfo(finishedJob)
+      dao.saveJobInfo(runningJob)
+
+      val results = Await.result(dao.getJobInfosByContextId(contextId, Some(JobStatus.Finished)), timeout)
+      results should have size 1
+      results.head.jobId shouldBe finishedJob.jobId //Jobid is unique
+    }
+
+    it("should clean jobs for given context id") {
+      val jobInfo = genJobInfo(jarInfo, false, JobStatus.Running, "context")
       dao.saveJobInfo(jobInfo)
 
-      Await.result(dao.cleanRunningJobInfosForContext("context", DateTime.now()), timeout)
+      Await.result(dao.cleanRunningJobInfosForContext(jobInfo.contextId, DateTime.now()), timeout)
+
       val updatedJobInfo = Await.result(dao.getJobInfo(jobInfo.jobId), timeout)
       updatedJobInfo shouldBe defined
       updatedJobInfo.get.endTime shouldBe defined

--- a/job-server/src/test/scala/spark/jobserver/io/JobDAOActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/JobDAOActorSpec.scala
@@ -54,7 +54,8 @@ object JobDAOActorSpec {
     override def getJobInfos(limit: Int, status: Option[String]): Future[Seq[JobInfo]] =
       Future.successful(Seq())
 
-    override def getRunningJobInfosForContextName(contextName: String): Future[Seq[JobInfo]] = ???
+    override def getJobInfosByContextId(
+        contextId: String, jobStatus: Option[String] = None): Future[Seq[JobInfo]] = ???
 
     override def getJobInfo(jobId: String): Future[Option[JobInfo]] = ???
 

--- a/job-server/src/test/scala/spark/jobserver/io/JobSqlDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/JobSqlDAOSpec.scala
@@ -10,6 +10,7 @@ import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
 import org.joda.time.DateTime
 import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
 import spark.jobserver.TestJarFinder
+import java.util.UUID
 
 abstract class JobSqlDAOSpecBase {
   def config : Config
@@ -38,11 +39,10 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
     eggInfo.appName + "-" + jarInfo.uploadTime.toString("yyyyMMdd_hhmmss_SSS") + ".egg")
 
   // jobInfo test data
-  val jobInfoNoEndNoErr:JobInfo = genJobInfo(jarInfo, false, false, false)
+  val jobInfoNoEndNoErr:JobInfo = genJobInfo(jarInfo, false, JobStatus.Running)
   val expectedJobInfo = jobInfoNoEndNoErr
-  val jobInfoSomeEndNoErr: JobInfo = genJobInfo(jarInfo, true, false, false)
-  val jobInfoNoEndSomeErr: JobInfo = genJobInfo(jarInfo, false, true, false)
-  val jobInfoSomeEndSomeErr: JobInfo = genJobInfo(jarInfo, true, true, false)
+  val jobInfoSomeEndNoErr: JobInfo = genJobInfo(jarInfo, false, JobStatus.Finished)
+  val jobInfoSomeEndSomeErr: JobInfo = genJobInfo(jarInfo, false, ContextStatus.Error)
 
   // job config test data
   val jobId: String = jobInfoNoEndNoErr.jobId
@@ -68,15 +68,19 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
     genTestJarInfo _
   }
 
-  private def genJobInfoClosure = {
+  case class GenJobInfoClosure() {
     var count: Int = 0
 
-    def genTestJobInfo(jarInfo: BinaryInfo,
-                       hasEndTime: Boolean,
-                       hasError: Boolean,
-                       isNew:Boolean): JobInfo = {
+    def apply(jarInfo: BinaryInfo, isNew:Boolean, state: String,
+        contextId: Option[String] = None): JobInfo = {
       count = count + (if (isNew) 1 else 0)
       val id: String = "test-id" + count
+
+      val ctxId = contextId match {
+        case Some(id) => id
+        case None => "test-context-id" + count
+      }
+
       val contextName: String = "test-context"
       val classPath: String = "test-classpath"
       val startTime: DateTime = time
@@ -85,17 +89,19 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
       val someEndTime: Option[DateTime] = Some(time) // Any DateTime Option is fine
       val someError = Some(ErrorData(throwable))
 
-      val endTime: Option[DateTime] = if (hasEndTime) someEndTime else noEndTime
-      val error = if (hasError) someError else None
+      val endTimeAndError = state match {
+        case JobStatus.Started | JobStatus.Running => (None, None)
+        case JobStatus.Finished => (someEndTime, None)
+        case JobStatus.Error | JobStatus.Killed => (someEndTime, someError)
+      }
 
-      JobInfo(id, contextName, jarInfo, classPath, startTime, endTime, error)
+      JobInfo(id, ctxId, contextName, jarInfo, classPath, state, startTime,
+          endTimeAndError._1, endTimeAndError._2)
     }
-
-    genTestJobInfo _
   }
 
   def genJarInfo: (Boolean, Boolean) => BinaryInfo = genJarInfoClosure
-  def genJobInfo: (BinaryInfo, Boolean, Boolean, Boolean) => JobInfo = genJobInfoClosure
+  lazy val genJobInfo = GenJobInfoClosure()
   //**********************************
 
   before {
@@ -212,7 +218,7 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
     }
 
     it("Save a new config, bring down DB, bring up DB, should get configs from DB") {
-      val jobId2: String = genJobInfo(genJarInfo(false, false), false, false, true).jobId
+      val jobId2: String = genJobInfo(genJarInfo(false, false), true, JobStatus.Running).jobId
       val jobConfig2: Config = ConfigFactory.parseString("{merry=xmas}")
       val expectedConfig2 = ConfigFactory.empty().withValue("merry", ConfigValueFactory.fromAnyRef("xmas"))
       // config previously saved
@@ -261,7 +267,7 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
     }
 
     it("Save another new jobInfo, bring down DB, bring up DB, should JobInfos from DB") {
-      val jobInfo2 = genJobInfo(jarInfo, false, false, true)
+      val jobInfo2 = genJobInfo(jarInfo, true, JobStatus.Running)
       val jobId2 = jobInfo2.jobId
       val expectedJobInfo2 = jobInfo2
       // jobInfo previously saved
@@ -283,14 +289,13 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
     }
 
     it("saving a JobInfo with the same jobId should update the JOBS table") {
-      val expectedNoEndSomeErr = jobInfoNoEndSomeErr
+      val expectedNoEndNoErr = jobInfoNoEndNoErr
       val expectedSomeEndNoErr = jobInfoSomeEndNoErr
       val expectedSomeEndSomeErr = jobInfoSomeEndSomeErr
       val exJobId = jobInfoNoEndNoErr.jobId
 
       val info = genJarInfo(true, false)
       info.uploadTime should equal (jarInfo.uploadTime)
-
       // Get all jobInfos
       val jobs: Seq[JobInfo] = Await.result(dao.getJobInfos(2), timeout)
 
@@ -301,14 +306,11 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
       // Second Test
       // Cannot compare JobInfos directly if error is a Some(Throwable) because
       // Throwable uses referential equality
-      dao.saveJobInfo(jobInfoNoEndSomeErr)
+      dao.saveJobInfo(expectedNoEndNoErr)
       val jobs2 = Await.result(dao.getJobInfos(2), timeout)
       jobs2.size should equal (2)
       jobs2.last.endTime should equal (None)
-      jobs2.last.error shouldBe defined
-      jobs2.last.error.get.message should equal (throwable.getMessage)
-      jobs2.last.error.get.errorClass should equal (throwable.getClass.getName)
-      jobs2.last.error.get.stackTrace should not be empty
+      jobs2.last.error shouldBe None
 
       // Third Test
       dao.saveJobInfo(jobInfoSomeEndNoErr)
@@ -329,18 +331,17 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
       jobs4.last.error.get.errorClass should equal (throwable.getClass.getName)
       jobs4.last.error.get.stackTrace should not be empty
     }
+
     it("retrieve by status equals running should be no end and no error") {
       //save some job insure exist one running job
       val dt1 = DateTime.now()
       val dt2 = Some(DateTime.now())
       val someError = Some(ErrorData("test-error", "", ""))
-      val finishedJob: JobInfo = JobInfo("test-finished", "test", jarInfo, "test-class", dt1, dt2, None)
-      val errorJob: JobInfo = JobInfo("test-error", "test", jarInfo, "test-class", dt1, dt2, someError)
-      val runningJob: JobInfo = JobInfo("test-running", "test", jarInfo, "test-class", dt1, None, None)
-      val runningJobWithContext: JobInfo = JobInfo("test-running-with-context", "context", jarInfo, "test-class", dt1, None, None)
+      val finishedJob: JobInfo = JobInfo("test-finished", "cid","test", jarInfo, "test-class", JobStatus.Finished, dt1, dt2, None)
+      val errorJob: JobInfo = JobInfo("test-error", "cid", "test", jarInfo, "test-class", JobStatus.Error, dt1, dt2, someError)
+      val runningJob: JobInfo = JobInfo("test-running", "cid", "test", jarInfo, "test-class", JobStatus.Running, dt1, None, None)
       dao.saveJobInfo(finishedJob)
       dao.saveJobInfo(runningJob)
-      dao.saveJobInfo(runningJobWithContext)
       dao.saveJobInfo(errorJob)
 
       //retrieve by status equals RUNNING
@@ -368,18 +369,62 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
       retrieved.error.isDefined should equal (true)
     }
 
-    it("retrieve running jobs by cluster name") {
-      val retrieved = Await.result(dao.getRunningJobInfosForContextName("context"), timeout)
+    it("should retrieve jobs by context id") {
+      val contextId = UUID.randomUUID().toString()
+      val runningJob = genJobInfo(jarInfo, true, JobStatus.Running, Some(contextId))
+      dao.saveJobInfo(runningJob)
+
+      val retrieved = Await.result(dao.getJobInfosByContextId(contextId), timeout)
 
       //test
       retrieved.size shouldBe 1
-      retrieved.head.contextName shouldBe "context"
+      retrieved.head.contextId shouldBe contextId
+    }
+
+    it("should retrieve multiple jobs if they have the same context id") {
+      val contextId = UUID.randomUUID().toString()
+      val finishedJob = genJobInfo(jarInfo, true, JobStatus.Finished, Some(contextId))
+      val jobWithDifferentContextId = genJobInfo(jarInfo, true, JobStatus.Finished)
+      val runningJob = genJobInfo(jarInfo, true, JobStatus.Running, Some(contextId))
+      val finishedJob2 = genJobInfo(jarInfo, true, JobStatus.Error, Some(contextId))
+      dao.saveJobInfo(finishedJob)
+      dao.saveJobInfo(jobWithDifferentContextId)
+      dao.saveJobInfo(runningJob)
+      dao.saveJobInfo(finishedJob2)
+
+      val retrieved = Await.result(dao.getJobInfosByContextId(contextId), timeout)
+
+      //test
+      retrieved.size shouldBe 3
+      retrieved.filter(_.contextId == contextId).size shouldBe 3
+      retrieved.map(_.jobId) should contain allOf(finishedJob.jobId, runningJob.jobId, finishedJob2.jobId)
+    }
+
+    it("retrieve running jobs by context id") {
+      val contextId = UUID.randomUUID().toString()
+      val runningJob = genJobInfo(jarInfo, true, JobStatus.Running, Some(contextId))
+      val finishedJob = genJobInfo(jarInfo, true, JobStatus.Finished, Some(contextId))
+      dao.saveJobInfo(runningJob)
+      dao.saveJobInfo(finishedJob)
+
+      val retrieved = Await.result(
+          dao.getJobInfosByContextId(contextId, Some(JobStatus.Running)), timeout)
+
+      //test
+      retrieved.size shouldBe 1
+      retrieved.head.contextId shouldBe contextId
+      retrieved.head.state shouldBe JobStatus.Running
     }
 
     it("clean running jobs for context") {
-      Await.ready(dao.cleanRunningJobInfosForContext("context", DateTime.now()), timeout)
+      val ctxToBeCleaned: JobInfo = JobInfo(
+          "jobId", UUID.randomUUID().toString(), "context", jarInfo,
+          "test-class", JobStatus.Running, DateTime.now(), None, None)
+      dao.saveJobInfo(ctxToBeCleaned)
 
-      val jobInfo = Await.result(dao.getJobInfo("test-running-with-context"), timeout).get
+      Await.ready(dao.cleanRunningJobInfosForContext(ctxToBeCleaned.contextId, DateTime.now()), timeout)
+
+      val jobInfo = Await.result(dao.getJobInfo(ctxToBeCleaned.jobId), timeout).get
       jobInfo.endTime shouldBe defined
       jobInfo.error shouldBe defined
     }


### PR DESCRIPTION
This change is related to
https://github.com/spark-jobserver/spark-jobserver/issues/1040

With this change the relation between context and jobs table is fully
defined

* Implement migrations for h2, mysql and postgres
* Reflect new schema changes in JobSqlDAO, C*DAO, InMamoryDAO and
FileDAO
* Persist job's state and contextId in DAO
* Use state from DAO instead of old state calculation

* Add tests in C*/SQL DAO spec to cover the new DAO function
* Add test to cover the changes inside JobManagerActor
* Add tests for JobStatusActorSpec/JobInfoActorSpec

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)


**New behavior :**


**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1058)
<!-- Reviewable:end -->
