### PR TITLE
feat(jobserver): Introduce supervise mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Spark Job Server is now included in Datastax Enterprise 4.8!
 - Job and jar info is persisted via a pluggable DAO interface
 - Named Objects (such as RDDs or DataFrames) to cache and retrieve RDDs or DataFrames by name, improving object sharing and reuse among jobs.
 - Supports Scala 2.10 and 2.11
+- Support for supervise mode of Spark (EXPERIMENTAL)
 
 ## Version Information
 

--- a/doc/cluster.md
+++ b/doc/cluster.md
@@ -75,3 +75,7 @@ Call the [DataFileCache](../job-server-api/src/main/scala/spark/jobserver/api/Sp
 The job server transfers the files via akka to the host running your driver and caches them there.
 
 Note: Files uploaded via the JAR or binary API are stored and transfered via the Job DB.
+
+## Configuring Job Server for supervised cluster mode
+
+* Add the option akka.remote.netty.tcp.port to the related Jobserver configuration file (e.g. local.conf).

--- a/doc/mesos.md
+++ b/doc/mesos.md
@@ -81,3 +81,7 @@ MANAGER_LOGGING_OPTS="-Dlog4j.configuration=log4j-cluster.properties"
     ```
     REMOTE_JOBSERVER_DIR=<path to job-server directory> # copy of job-server directory on all mesos agent nodes 
     ```
+
+## Configuring Job Server for supervised cluster mode
+
+* Add the option akka.remote.netty.tcp.port to the related Jobserver configuration file (e.g. local.conf).

--- a/doc/supervise-mode.md
+++ b/doc/supervise-mode.md
@@ -1,0 +1,86 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Supervise Mode](#supervise-mode)
+  - [Description of implementation within SJS](#description-of-implementation-within-sjs)
+  - [What Happens with Contexts/Jobs in Supervise Mode?](#what-happens-with-contextsjobs-in-supervise-mode)
+  - [Configurations required for supervise mode](#configurations-required-for-supervise-mode)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## [Supervise Mode](https://spark.apache.org/docs/latest/spark-standalone.html)
+Note: This is an experimental feature
+
+The supervise mode allows restarting a driver program on a different worker VM in a Spark cluster in case it died unexpectedly with a non-zero exit code.
+
+Note that restarting an application is the easy part, but you need to be aware of potential side effects of re-running an application! For example, let's assume an application updated the balance of a bank account by $100. If you implement this update as a simply increment of the current balance, then re-running the application might increasing the balance by another $100, resulting in $200 in the account.
+
+As a best practice it is strongly recommend to make the whole application idempotent. Idempotence means that re-running the application must not change state that has already been committed. This means, for instance, that you need a way to determine if a certain operation has already been performed, or not.
+
+### Description of implementation within SJS
+A global property `spark.driver.supervise` is introduced in SJS config file (with a default value of false).
+The value can be set to `true` or `false`.
+
+- True = Enable supervise mode by default for all the new contexts.
+- False = Disable supervise mode for all contexts but user can decide if the context needs to be supervised or not.
+
+For each context, a property `launcher.spark.driver.supervise` is provided, user can set individually for each context, if it should use this mode or not.
+
+Here are all the possible cases:
+
+| Default mode  |  Context mode  |    Action    |
+| ------------- | -------------- | ------------ |
+| true          |   true         |    enabled   |
+| true          |   false        |    disabled  |
+| false         |   true         |    enabled   |
+| false         |   false        |    disabled  |
+| true          |   Not defined  |    enabled   |
+| false         |   Not defined  |    disabled  |
+
+
+
+Curently, this mode is tested with streaming/batch jobs.
+A few things to note
+- The criteria for a restart:
+    * Job is either in RUNNING state, or
+    * Job is in ERROR state with Context Terminated
+        exception as error message.
+    * The job is async
+- The jobs for restart are selected based on unique context Id. So, we won't get jobs from any other context.
+- On master we detect a supervise scenario based on contextInitInfos hashmap. If the hashmap has an entry, it is a normal initialize of context but if it doesn't then it is a restart scenario. This approach is safe because contextInitInfos's key is the slaves job manager actor name, this name is a combination of jobManager-<uuid>. If the context was initialized properly then this entry will be removed for sure. If the initialization failed, then contextInitInfos might have the entry but it is useless because context was never initialized and restart is not possible.
+- If an existing job is restarted successfully, we change the error status back to running and also purge the endtime
+
+<b>Note: If supervise mode is active, JVMs will only be restarted if the JVM was killed with a non-zero exit code.</b>
+
+Some behaviors of cluster + supervise mode:
+- If we kill the application from MasterUI -> kills the app + driver and no restart
+- If we kill the driver from Master UI -> kills app + driver and no restart
+- If we kill the context from SJS -> Kills the driver + app and no restart
+- If we kill the job from SJS -> Keep the driver + app running and no restart of the job
+- If we kill the Driver Wrapper JVM using `kill -9 <pid>` -> Driver comes up with different PID but same driver ID,
+    application ID changes, restart happens.
+- If we kill the Executor JVM using `kill -9 <pid>` -> Drivers stays, app also stays, the executor JVM is
+     relaunched with different pid, not related to Restart, normal behavior of Spark
+- If we have a job which fails on the Executor and the executor restarts -> Driver stays, app also stays, executor JVM is relaunched.
+    We can delete the job/context through Master UI and SJS.
+- If we have a job which fails on the Driver -> Driver restarts (only if supervise mode is enabled), we can stop
+     it through SJS, we can always stop it from UI.
+
+Note: If due to some reason, some jobs are scheduled in Spark and you stop the context from SJS, it can become a zombie. SJS DELETE request is passed to context JVM but Spark context fails to stop. Due to this, delete request times out and context can become a zombie (i.e. SJS has no idea about context anymore but context is still running in Spark)
+
+### What Happens with Contexts/Jobs in Supervise Mode?
+* Streaming Contexts:
+    If a streaming context is restarted, Spark Job Server will try to restart the streaming job in the context (if any). If the job restart fails, it will also kill the driver program.
+* Batch Contexts:
+    If multiple batch jobs are running in a context that is being restarted, then all the jobs will be restarted. If all the batch jobs running in a context fail to restart, then the context will be killed. However, if at least one job restarts successfully, then the context is kept running. Already finished jobs of course will not be restarted.
+* If a context fails during restart, all jobs running inside this context will be marked as failed.
+
+### Configurations required for supervise mode
+- Cluster mode should be enabled, please refer to the [cluster.md](https://github.com/spark-jobserver/spark-jobserver/blob/master/doc/cluster.md), [mesos.md](https://github.com/spark-jobserver/spark-jobserver/blob/master/doc/mesos.md), [yarn.md](https://github.com/spark-jobserver/spark-jobserver/blob/master/doc/yarn.md)
+- set `spark.driver.supervise` to `true` or if by default is disabled then for each context, you should enable it using `launcher.spark.driver.supervise` e.g. `curl -X POST localhost:8090/contexts/abc?launcher.spark.driver.supervise=true`
+- `spark.jobserver.ignore-akka-hostname` should be configured according to your environment. This property is tricky and depends on your network configuration. Since in cluster mode, all the drivers run on Workers. Each driver is running Akka inside which requires an IP address and it should not be 127.0.0.1. So, if your network configuration is done in a way that Akka picks up 127.0.0.1 then you should set this property to `false` and provide a valid hostname in property `akka.remote.netty.tcp.hostname` within your config file.
+- set `spark.master` property to use port `6066` instead of `7077`
+- Akka port should not be random and the property `akka.remote.netty.tcp.port` should be set to a valid port e.g. 2552.
+- `spark.jobserver.kill-context-on-supervisor-down` should be `false`. Since SJS HTTP JVM can be restarted and can connect back to the contexts, we disable the zombie killing logic.
+

--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -5,6 +5,8 @@ spark {
 
   # client or cluster deployment
   submit.deployMode = "client"
+
+  # For more details see https://github.com/spark-jobserver/spark-jobserver/tree/master/doc/supervise-mode.md
   driver.supervise = false
 
   # spark web UI port

--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -5,6 +5,7 @@ spark {
 
   # client or cluster deployment
   submit.deployMode = "client"
+  driver.supervise = false
 
   # spark web UI port
   webUrlPort = 8080

--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -23,6 +23,8 @@ spark {
     kill-context-on-supervisor-down = false
     manager-initialization-timeout = 40s
 
+    ignore-akka-hostname = true
+
     # Note: JobFileDAO is deprecated from v0.7.0 because of issues in
     # production and will be removed in future, now defaults to H2 file.
     jobdao = spark.jobserver.io.JobSqlDAO

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -21,7 +21,7 @@ import scala.concurrent.Await
 import akka.pattern.gracefulStop
 import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
-import spark.jobserver.JobManagerActor.{GetContexData, ContexData, SparkContextDead}
+import spark.jobserver.JobManagerActor.{GetContexData, ContexData, SparkContextDead, RestartExistingJobs}
 import spark.jobserver.io.{JobDAOActor, ContextInfo, ContextStatus}
 import spark.jobserver.util.{InternalServerErrorException, NoCallbackFoundException}
 
@@ -124,20 +124,31 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
           (contextFromDAO, callbacks) match {
             case (Some(JobDAOActor.ContextResponse(Some(contextInfo))),
                 Some((successCallback, failureCallback))) =>
-              val contextConfig = ConfigFactory.parseString(contextInfo.config)
-              val isAdhoc = contextConfig.getBoolean("is-adhoc")
-              initContext(contextConfig, actorName,
-                     actorRef, contextInitTimeout)(isAdhoc, successCallback, failureCallback)
+              initContext(contextInfo, actorName, actorRef, false)(successCallback, failureCallback)
             case (Some(JobDAOActor.ContextResponse(None)), _) =>
               logger.error(
                  s"No such contextId ${contextId} was found in DB. Cannot initialize actor ${actorName}")
               actorRef ! PoisonPill
             case (Some(JobDAOActor.ContextResponse(Some(contextInfo))), None) =>
-              val exception = NoCallbackFoundException(contextInfo.id, actorRef.path.toSerializationFormat)
-              logger.error(exception.getMessage, exception)
-              actorRef ! PoisonPill // Since no watch was added, Terminated will not be fired
-              daoActor ! JobDAOActor.SaveContextInfo(contextInfo.copy(
-                  state = ContextStatus.Error, endTime = Some(DateTime.now()), error = Some(exception)))
+              isSuperviseModeEnabled(config, ConfigFactory.parseString(contextInfo.config)) match {
+                case isRestartScenario @ true =>
+                  logger.info(
+                     s"Restart request for context (${contextId}) received, probably due to supervise mode")
+                  initContext(contextInfo, actorName, actorRef, isRestartScenario)(
+                     { ref =>
+                       logger.info(s"Successfully reinitialized context (${contextId}) under supervise mode")
+                     },
+                     { ref =>
+                         logger.error(s"Failed to reinitialize context (${contextId}) under supervise mode")
+                     })
+                case false =>
+                  val exception =
+                    NoCallbackFoundException(contextInfo.id, actorRef.path.toSerializationFormat)
+                  logger.error(exception.getMessage, exception)
+                  actorRef ! PoisonPill // Since no watch was added, Terminated will not be fired
+                  daoActor ! JobDAOActor.SaveContextInfo(contextInfo.copy(
+                      state = ContextStatus.Error, endTime = Some(DateTime.now()), error = Some(exception)))
+              }
             case (None, Some((_, failureCallback))) =>
               val exception = InternalServerErrorException(contextId)
               logger.error(exception.getMessage, exception)
@@ -281,7 +292,8 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
   private def initContext(contextConfig: Config,
                           actorName: String,
                           ref: ActorRef,
-                          timeoutSecs: Long = 1)
+                          timeoutSecs: Long = 1,
+                          isRestartScenario: Boolean)
                          (isAdHoc: Boolean,
                           successFunc: ActorRef => Unit,
                           failureFunc: Throwable => Unit): Unit = {
@@ -305,9 +317,14 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
         logger.info("SparkContext {} joined", ctxName)
         resultActorRefs(ctxName) = resActor
         context.watch(ref)
-        initContextHelp(actorName, Some(ref.path.address.toString), ContextStatus.Running, None) match {
-          case None => successFunc(ref)
-          case Some(e) => ref ! PoisonPill
+        (initContextHelp(actorName, Some(ref.path.address.toString), ContextStatus.Running, None),
+            isRestartScenario) match {
+          case (None, false) => successFunc(ref)
+          case (None, true) =>
+            logger.info("Context initialized, trying to restart existing jobs.")
+            ref ! RestartExistingJobs
+          case (Some(e), _) =>
+            ref ! PoisonPill
             failureFunc(e)
         }
       case _ => logger.info("Failed for unknown reason.")
@@ -327,7 +344,7 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
     val resp = getDataFromDAO[JobDAOActor.ContextResponse](JobDAOActor.GetContextInfo(managerActorName))
     resp match {
       case Some(JobDAOActor.ContextResponse(Some(context))) =>
-                    val endTime = error match {
+          val endTime = error match {
             case None => context.endTime
             case _ => Some(DateTime.now())
           }
@@ -428,5 +445,21 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
         if c.state == ContextStatus.Running || c.state == ContextStatus.Started => (true, Some(c))
       case Some(_) => (true, None)
     }
+  }
+
+  private def isSuperviseModeEnabled(config: Config, contextConfig: Config): Boolean = {
+    val defaultSuperviseMode = config.getBoolean(ManagerLauncher.SJS_SUPERVISE_MODE_KEY)
+    val contextSuperviseMode = Try(
+        Some(contextConfig.getBoolean(ManagerLauncher.CONTEXT_SUPERVISE_MODE_KEY))).getOrElse(None)
+    ManagerLauncher.shouldSuperviseModeBeEnabled(defaultSuperviseMode, contextSuperviseMode)
+  }
+
+  private def initContext(contextInfo: ContextInfo, actorName: String, actorRef: ActorRef,
+      isRestartScenario: Boolean)
+      (successCallback: ActorRef => Unit, failureCallback: Throwable => Unit): Unit = {
+    val contextConfig = ConfigFactory.parseString(contextInfo.config)
+    val isAdhoc = contextConfig.getBoolean("is-adhoc")
+    initContext(contextConfig, actorName,
+           actorRef, contextInitTimeout, isRestartScenario)(isAdhoc, successCallback, failureCallback)
   }
 }

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -72,25 +72,28 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
   logger.info("AkkaClusterSupervisor initialized on {}", selfAddress)
 
   def getActorRef(contextInfo: ContextInfo) : Option[ActorRef] = {
-    if (jobManagerActorRefs.exists(_._1 == contextInfo.id)) {
-      Some(jobManagerActorRefs(contextInfo.id))
-    } else if (contextInfo.actorAddress.nonEmpty) {
-      val finiteDuration = FiniteDuration(3, SECONDS)
-      val address = contextInfo.actorAddress.get + "/user/" +
+    contextInfo.actorAddress match {
+      case Some(address) =>
+        val actorPath = contextInfo.actorAddress.get + "/user/" +
           AkkaClusterSupervisorActor.MANAGER_ACTOR_PREFIX + contextInfo.id
-      try {
-        val contextActorRefFuture = context.actorSelection(address).resolveOne(finiteDuration)
-        jobManagerActorRefs(contextInfo.id) = Await.result(contextActorRefFuture, finiteDuration)
-        Some(jobManagerActorRefs(contextInfo.id))
-      } catch {
-        case e: Exception =>
-          logger.error("Failed to resolve reference for context " + contextInfo.name
-              + " with exception " + e.getMessage)
-          None
-      }
-    } else {
-      logger.error("Reference for context " + contextInfo.name + " does not exist")
-      None
+        jobManagerActorRefs.exists(_._1 == actorPath) match {
+          case true => Some(jobManagerActorRefs(actorPath))
+          case false =>
+            val finiteDuration = FiniteDuration(3, SECONDS)
+            try {
+              val contextActorRefFuture = context.actorSelection(actorPath).resolveOne(finiteDuration)
+              jobManagerActorRefs(actorPath) = Await.result(contextActorRefFuture, finiteDuration)
+              Some(jobManagerActorRefs(actorPath))
+            } catch {
+              case e: Exception =>
+                logger.error("Failed to resolve reference for context " + contextInfo.name
+                    + " with exception " + e.getMessage)
+                None
+            }
+          }
+      case None =>
+        logger.error("Reference for context " + contextInfo.name + " does not exist")
+        None
     }
   }
 
@@ -286,7 +289,7 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
           logger.error("Error occurred after Terminated message was recieved")
       }
       cluster.down(actorRef.path.address)
-      jobManagerActorRefs.remove(contextId)
+      jobManagerActorRefs.remove(actorRef.path.toString())
   }
 
   private def initContext(contextConfig: Config,

--- a/job-server/src/main/scala/spark/jobserver/CommonMessages.scala
+++ b/job-server/src/main/scala/spark/jobserver/CommonMessages.scala
@@ -16,6 +16,7 @@ object CommonMessages {
   case class JobValidationFailed(jobId: String, endTime: DateTime, err: Throwable) extends StatusMessage
   case class JobErroredOut(jobId: String, endTime: DateTime, err: Throwable) extends StatusMessage
   case class JobKilled(jobId: String, endTime: DateTime) extends StatusMessage
+  case class JobRestartFailed(jobId: String, err: Throwable) extends StatusMessage
 
   /**
    * NOTE: For Subscribe, make sure to use `classOf[]` to get the Class for the case classes above.

--- a/job-server/src/main/scala/spark/jobserver/JobManager.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManager.scala
@@ -40,7 +40,7 @@ object JobManager {
     }
 
     val defaultConfig = ConfigFactory.load()
-    val systemConfig = ConfigFactory.parseFile(systemConfigFile).withFallback(defaultConfig)
+    var systemConfig = ConfigFactory.parseFile(systemConfigFile).withFallback(defaultConfig)
     val master = Try(systemConfig.getString("spark.master")).toOption
       .getOrElse("local[4]").toLowerCase()
     val deployMode = Try(systemConfig.getString("spark.submit.deployMode")).toOption
@@ -50,8 +50,11 @@ object JobManager {
       logger.info("Cluster mode: Replacing spark.jobserver.sqldao.rootdir with container tmp dir.")
       val sqlDaoDir = Files.createTempDirectory("sqldao")
       val sqlDaoDirConfig = ConfigValueFactory.fromAnyRef(sqlDaoDir.toAbsolutePath.toString)
-      systemConfig.withoutPath("akka.remote.netty.tcp.hostname")
-                  .withValue("spark.jobserver.sqldao.rootdir", sqlDaoDirConfig)
+      val ignoreAkkaHostname = systemConfig.getBoolean("spark.jobserver.ignore-akka-hostname")
+      if (ignoreAkkaHostname) {
+        systemConfig = systemConfig.withoutPath("akka.remote.netty.tcp.hostname")
+      }
+      systemConfig.withValue("spark.jobserver.sqldao.rootdir", sqlDaoDirConfig)
                   .withoutPath("akka.remote.netty.tcp.port")
                   .withValue("akka.remote.netty.tcp.port", ConfigValueFactory.fromAnyRef(0))
     } else {

--- a/job-server/src/main/scala/spark/jobserver/JobManager.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManager.scala
@@ -52,6 +52,8 @@ object JobManager {
       val sqlDaoDirConfig = ConfigValueFactory.fromAnyRef(sqlDaoDir.toAbsolutePath.toString)
       systemConfig.withoutPath("akka.remote.netty.tcp.hostname")
                   .withValue("spark.jobserver.sqldao.rootdir", sqlDaoDirConfig)
+                  .withoutPath("akka.remote.netty.tcp.port")
+                  .withValue("akka.remote.netty.tcp.port", ConfigValueFactory.fromAnyRef(0))
     } else {
       systemConfig
     }

--- a/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
@@ -635,8 +635,6 @@ class JobManagerActor(daoActor: ActorRef, supervisorActorAddress: String, contex
     respMsg = respMsg + s"contextName=${existingJobInfo.contextName})"
     logger.info(respMsg)
     val fullJobConfig = existingJobConfig.withFallback(config).resolve()
-    val contextConfig = Try(existingJobConfig.getConfig("spark.context-settings"))
-      .getOrElse(ConfigFactory.empty).resolve()
     val events: Set[Class[_]] = Set(classOf[JobStarted]) ++ Set(classOf[JobValidationFailed])
 
     sendStartJobMessage(self, StartJob(existingJobInfo.binaryInfo.appName,

--- a/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
@@ -4,9 +4,12 @@ import java.io.File
 import java.net.{URI, URL}
 import java.util.concurrent.Executors._
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.TimeUnit
 
 import akka.actor.{ActorRef, PoisonPill, Props, ReceiveTimeout, Identify, ActorIdentity, Terminated}
-import com.typesafe.config.Config
+import akka.pattern.ask
+import akka.util.Timeout
+import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.{SparkConf, SparkEnv}
 import org.apache.spark.scheduler.SparkListener
@@ -14,29 +17,32 @@ import org.apache.spark.scheduler.SparkListenerApplicationEnd
 import org.joda.time.DateTime
 import org.scalactic._
 import spark.jobserver.api.{JobEnvironment, DataFileCache}
-import spark.jobserver.context.{JobContainer, SparkContextFactory}
-import spark.jobserver.io.{BinaryInfo, JobDAOActor, JobInfo, RemoteFileCache, JobStatus}
-import spark.jobserver.util.{ContextURLClassLoader, SparkJobUtils}
+import spark.jobserver.io.{BinaryInfo, JobDAOActor, JobInfo, RemoteFileCache, JobStatus, ErrorData}
+import spark.jobserver.util.{ContextURLClassLoader, SparkJobUtils,
+  NoJobConfigFoundException, UnexpectedMessageReceivedException}
+import spark.jobserver.context._
+import spark.jobserver.common.akka.InstrumentedActor
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 import scala.concurrent.duration._
-import spark.jobserver.common.akka.InstrumentedActor
+import org.spark_project.guava.annotations.VisibleForTesting
 
 object JobManagerActor {
   // Messages
   case class Initialize(contextConfig: Config, resultActorOpt: Option[ActorRef],
                         dataFileActor: ActorRef)
   case class StartJob(appName: String, classPath: String, config: Config,
-                      subscribedEvents: Set[Class[_]])
+                      subscribedEvents: Set[Class[_]], existingJobInfo: Option[JobInfo] = None)
   case class KillJob(jobId: String)
   case class JobKilledException(jobId: String) extends Exception(s"Job $jobId killed")
-  case class ContextTerminatedException(contextName: String)
-    extends Exception(s"Unexpected termination of context $contextName")
+  case class ContextTerminatedException(contextId: String)
+    extends Exception(s"Unexpected termination of context $contextId")
 
   case object GetContextConfig
   case object SparkContextStatus
   case object GetContexData
+  case object RestartExistingJobs
 
   case class DeleteData(name: String)
 
@@ -90,12 +96,15 @@ class JobManagerActor(daoActor: ActorRef, supervisorActorAddress: String, contex
 
   import CommonMessages._
   import JobManagerActor._
+  import context.dispatcher
 
   import collection.JavaConverters._
 
   val config = context.system.settings.config
   private val maxRunningJobs = SparkJobUtils.getMaxRunningJobs(config)
   val executionContext = ExecutionContext.fromExecutorService(newFixedThreadPool(maxRunningJobs))
+
+  val daoAskTimeout = Timeout(config.getDuration("spark.jobserver.dao-timeout", TimeUnit.SECONDS).second)
 
   var jobContext: ContextLike = _
   var sparkEnv: SparkEnv = _
@@ -115,10 +124,15 @@ class JobManagerActor(daoActor: ActorRef, supervisorActorAddress: String, contex
   private var contextConfig: Config = _
   private var contextName: String = _
   private var isAdHoc: Boolean = _
-  private var statusActor: ActorRef = _
+  @VisibleForTesting
+  protected var statusActor: ActorRef = _
+  @VisibleForTesting
   protected var resultActor: ActorRef = _
   private var factory: SparkContextFactory = _
   private var remoteFileCache: RemoteFileCache = _
+  @VisibleForTesting
+  protected var totalJobsToRestart = 0
+  private var totalJobsWhichFailedToRestart = 0
 
   // NOTE: Must be initialized after sparkContext is created
   private var jobCache: JobCache = _
@@ -219,7 +233,7 @@ class JobManagerActor(daoActor: ActorRef, supervisorActorAddress: String, contex
           self ! PoisonPill
       }
 
-    case StartJob(appName, classPath, jobConfig, events) => {
+    case StartJob(appName, classPath, jobConfig, events, existingJobInfo) => {
       val loadedJars = jarLoader.getURLs
       getSideJars(jobConfig).foreach { jarUri =>
         val jarToLoad = new URL(convertJarUriSparkToJava(jarUri))
@@ -229,7 +243,7 @@ class JobManagerActor(daoActor: ActorRef, supervisorActorAddress: String, contex
           jobContext.sparkContext.addJar(jarUri)
         }
       }
-      startJobInternal(appName, classPath, jobConfig, events, jobContext, sparkEnv)
+      startJobInternal(appName, classPath, jobConfig, events, jobContext, sparkEnv, existingJobInfo)
     }
 
     case KillJob(jobId: String) => {
@@ -297,6 +311,37 @@ class JobManagerActor(daoActor: ActorRef, supervisorActorAddress: String, contex
     case DeleteData(name: String) => {
       remoteFileCache.deleteDataFile(name)
     }
+
+    case RestartExistingJobs => {
+      logger.info("Job restart message received, trying to restart existing jobs.")
+      restartTerminatedJobs(contextId, sender)
+    }
+
+    /**
+     * Normally, JobStarted/JobValidationFailed are sent back to WebAPI but in restart scenario,
+     * this class will receive these messages. This class only handles the following
+     * messages because we are subscribed to only these during restart.
+     *
+     * Other possible messages like JobErroredOut/JobFinished/JobKilled relate more to
+     * what happens after the job was restarted. These messages won't be received by this actor,
+     * since we are not subscribed but the statusActor will update DAO based on these messages.
+     */
+    case JobStarted(jobId, jobInfo) => {
+      logger.info(s"Job ($jobId) restarted successfully")
+    }
+
+    case msg @ JobValidationFailed(jobId, dateTime, error) => {
+      handleJobRestartFailure(jobId, error, msg)
+    }
+
+    /**
+     * This message is specific to restart scenario. It is sent for all the errors before
+     * StartJob message is sent to restart a job. All the messages after StartJob are
+     * handled by JobStarted/JobValidationFailed
+     */
+    case msg @ JobRestartFailed(jobId, error) => {
+      handleJobRestartFailure(jobId, error, msg)
+    }
   }
 
   def startJobInternal(appName: String,
@@ -304,10 +349,9 @@ class JobManagerActor(daoActor: ActorRef, supervisorActorAddress: String, contex
                        jobConfig: Config,
                        events: Set[Class[_]],
                        jobContext: ContextLike,
-                       sparkEnv: SparkEnv): Option[Future[Any]] = {
-    import akka.pattern.ask
+                       sparkEnv: SparkEnv,
+                       existingJobInfo: Option[JobInfo]): Option[Future[Any]] = {
     import akka.util.Timeout
-    import spark.jobserver.context._
 
     import scala.concurrent.Await
 
@@ -328,7 +372,16 @@ class JobManagerActor(daoActor: ActorRef, supervisorActorAddress: String, contex
     if (!lastUploadTimeAndType.isDefined) return failed(NoSuchApplication)
     val (lastUploadTime, binaryType) = lastUploadTimeAndType.get
 
-    val jobId = java.util.UUID.randomUUID().toString()
+    val (jobId, startDateTime) = existingJobInfo match {
+      case Some(info) =>
+        logger.info(s"Restarting a previously terminated job with id ${info.jobId}" +
+            s" and context ${info.contextName}")
+        (info.jobId, info.startTime)
+      case None =>
+        logger.info(s"Creating new JobId for current job")
+        (java.util.UUID.randomUUID().toString(), DateTime.now())
+    }
+
     val jobContainer = factory.loadAndValidateJob(appName, lastUploadTime,
                                                   classPath, jobCache) match {
       case Good(container) => container
@@ -343,7 +396,7 @@ class JobManagerActor(daoActor: ActorRef, supervisorActorAddress: String, contex
 
     val binInfo = BinaryInfo(appName, binaryType, lastUploadTime)
     val jobInfo = JobInfo(jobId, contextId, contextName, binInfo, classPath,
-        JobStatus.Running, DateTime.now(), None, None)
+        JobStatus.Running, startDateTime, None, None)
 
     Some(getJobFuture(jobContainer, jobInfo, jobConfig, sender, jobContext, sparkEnv))
   }
@@ -459,6 +512,27 @@ class JobManagerActor(daoActor: ActorRef, supervisorActorAddress: String, contex
     return result
   }
 
+  protected def sendStartJobMessage(receiverActor: ActorRef, msg: StartJob) {
+    receiverActor ! msg
+  }
+
+  /**
+   * During restart scenario, we use best effort approach. So, we try our best to start all
+   * the jobs in a context. If some jobs fail to start but others succeed then we just report
+   * the failure in logs and continue. If all the jobs fail, then we just kill the context JVM.
+   */
+  protected def handleJobRestartFailure(jobId: String, error: Throwable, msg: StatusMessage) {
+    logger.error(error.getMessage, error)
+    totalJobsWhichFailedToRestart += 1
+    (totalJobsToRestart - totalJobsWhichFailedToRestart) match {
+      case 0 =>
+        logger.error(s"Restart report -> $totalJobsWhichFailedToRestart failed out of $totalJobsToRestart")
+        self ! PoisonPill
+      case _ =>
+        logger.warn(s"Job ($jobId) errored out during restart but continuing", error)
+    }
+  }
+
   // Use our classloader and a factory to create the SparkContext.  This ensures the SparkContext will use
   // our class loader when it spins off threads, and ensures SparkContext can find the job and dependent jars
   // when doing serialization, for example.
@@ -496,4 +570,89 @@ class JobManagerActor(daoActor: ActorRef, supervisorActorAddress: String, contex
   private def getSideJars(config: Config): Seq[String] =
     Try(config.getStringList("dependent-jar-uris").asScala.toSeq).
      orElse(Try(config.getString("dependent-jar-uris").split(",").toSeq)).getOrElse(Nil)
+
+  /**
+   * This function is responsible for restarting terminated jobs. It selects jobs based on the
+   * following criteria
+   * a) The job is in Running state
+   * b) The job is in Error state with ContextTerminatedException in the message
+   * c) The job is async. Sync jobs are normally short lived and user is waiting on
+   *    the other side to receive the response immediately. So, restart feature currently
+   *    is only for long running jobs. There is no direct way to check if the job was
+   *    originally started with async. Therefore the indirect way via the JobConfig, which
+   *    contains this option, is used here.
+   */
+  private def restartTerminatedJobs(contextId: String, senderRef: ActorRef): Unit = {
+    (daoActor ? JobDAOActor.GetJobInfosByContextId(
+        contextId, Some(Seq(JobStatus.Running, JobStatus.Error))))(daoAskTimeout).onComplete {
+      case Success(JobDAOActor.JobInfos(Seq())) =>
+        logger.info(s"No job found for context ${contextName} which was terminated unexpectedly." +
+            " Not restarting any job.")
+      case Success(JobDAOActor.JobInfos(jobInfos)) =>
+        logger.info(s"Found jobs for this context ${contextId}")
+
+        val restartCandidates = getRestartCandidates(jobInfos)
+        logger.info(s"Total restart candidates are ${restartCandidates.length}")
+        totalJobsToRestart = restartCandidates.length
+        restartCandidates.foreach { jobInfo =>
+          (daoActor ? JobDAOActor.GetJobConfig(jobInfo.jobId))(daoAskTimeout).onComplete {
+            case Success(JobDAOActor.JobConfig(Some(config))) =>
+              restartJob(jobInfo, config)
+            case Success(JobDAOActor.JobConfig(None)) =>
+              updateJobInfoAndReportFailure(jobInfo, NoJobConfigFoundException(jobInfo.jobId))
+            case Failure(e: Exception) =>
+              // In case of error during job restart, an error will be written to the DAO.
+              // In case that this job is a dependency for another job, it may cause problems.
+              // A strategy must be implemented at this point.
+              updateJobInfoAndReportFailure(jobInfo, e)
+            case _ =>
+              updateJobInfoAndReportFailure(jobInfo, UnexpectedMessageReceivedException(jobInfo.jobId))
+          }
+        }
+      case Failure(e: Exception) =>
+        logger.error(s"Exception occured while accessing job ids for context ${contextId} from DAO.", e)
+        self ! PoisonPill
+      case unexpectedMsg @ _ =>
+        logger.error(s"Unexpected scenario occured, message received is $unexpectedMsg")
+        self ! PoisonPill
+    }
+  }
+
+  private def updateJobInfoAndReportFailure(jobInfo: JobInfo, error: Exception) {
+    updateJobInfoWithErrorState(jobInfo, error)
+    self ! JobRestartFailed(jobInfo.jobId, error)
+  }
+
+  private def updateJobInfoWithErrorState(jobInfo: JobInfo, error: Throwable) {
+   val updatedJobInfo = jobInfo.copy(state = JobStatus.Error,
+     endTime = Some(DateTime.now()), error = Some(ErrorData(error)))
+   daoActor ! JobDAOActor.SaveJobInfo(updatedJobInfo)
+  }
+
+  private def restartJob(existingJobInfo: JobInfo, existingJobConfig: Config) {
+    // Add response to master for testing
+    var respMsg = s"Restarting the last job (JobId=${existingJobInfo.jobId} & "
+    respMsg = respMsg + s"contextName=${existingJobInfo.contextName})"
+    logger.info(respMsg)
+    val fullJobConfig = existingJobConfig.withFallback(config).resolve()
+    val contextConfig = Try(existingJobConfig.getConfig("spark.context-settings"))
+      .getOrElse(ConfigFactory.empty).resolve()
+    val events: Set[Class[_]] = Set(classOf[JobStarted]) ++ Set(classOf[JobValidationFailed])
+
+    sendStartJobMessage(self, StartJob(existingJobInfo.binaryInfo.appName,
+        existingJobInfo.classPath, fullJobConfig, events, Some(existingJobInfo)))
+    logger.info(s"Job restart message has been sent for old job (${existingJobInfo.jobId})" +
+        s" and context ${existingJobInfo.contextName}.")
+  }
+
+  private def getRestartCandidates(jobInfos: Seq[JobInfo]): Seq[JobInfo] = {
+    jobInfos.filter { jobInfo =>
+      (jobInfo.state, jobInfo.error) match {
+        case (JobStatus.Running, _) => true
+        case (JobStatus.Error, Some(error)) =>
+            error.message.equals(ContextTerminatedException(contextId).getMessage)
+        case _ => false
+      }
+    }
+  }
 }

--- a/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
@@ -28,6 +28,7 @@ object ContextSupervisor {
   case class GetResultActor(name: String)  // returns JobResultActor
   case class StopContext(name: String)
   case class GetSparkContexData(name: String)
+  case class RestartOfTerminatedJobsFailed(contextId: String)
 
   // Errors/Responses
   case object ContextInitialized

--- a/job-server/src/main/scala/spark/jobserver/io/JobDAOActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobDAOActor.scala
@@ -31,6 +31,7 @@ object JobDAOActor {
 
   case class SaveJobInfo(jobInfo: JobInfo) extends JobDAORequest
   case class GetJobInfos(limit: Int) extends JobDAORequest
+  case class GetJobInfosByContextId(contextId: String, jobStatuses: Option[Seq[String]]) extends JobDAORequest
 
   case class SaveJobConfig(jobId: String, jobConfig: Config) extends JobDAORequest
   case class GetJobConfig(jobId: String) extends JobDAORequest
@@ -109,5 +110,8 @@ class JobDAOActor(dao: JobDAO) extends InstrumentedActor {
 
     case CleanContextJobInfos(contextId, endTime) =>
       dao.cleanRunningJobInfosForContext(contextId, endTime)
+
+    case GetJobInfosByContextId(contextId, jobStatuses) =>
+      dao.getJobInfosByContextId(contextId, jobStatuses).map(JobInfos).pipeTo(sender)
   }
 }

--- a/job-server/src/main/scala/spark/jobserver/io/JobFileDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobFileDAO.scala
@@ -227,10 +227,10 @@ class JobFileDAO(config: Config) extends JobDAO {
   }
 
   override def getJobInfosByContextId(
-      contextId: String, jobStatus: Option[String] = None): Future[Seq[JobInfo]] = Future {
+      contextId: String, jobStatuses: Option[Seq[String]] = None): Future[Seq[JobInfo]] = Future {
     jobs.values.toSeq.filter(j => {
-      (contextId, jobStatus) match {
-        case (contextId, Some(status)) => contextId == j.contextId && status == j.state
+      (contextId, jobStatuses) match {
+        case (contextId, Some(statuses)) => contextId == j.contextId && statuses.contains(j.state)
         case _ => contextId == j.contextId
       }
     })

--- a/job-server/src/main/scala/spark/jobserver/util/CustomException.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/CustomException.scala
@@ -9,3 +9,9 @@ final case class InternalServerErrorException(id: String) extends
 
 final case class NoCallbackFoundException(id: String, actorPath: String) extends
   Exception(s"Callback methods not found for actor with id=$id, path=$actorPath")
+
+final case class NoJobConfigFoundException(jobId: String) extends
+  Exception(s"Failed to load config for job with id: $jobId")
+
+final case class UnexpectedMessageReceivedException(jobId: String) extends
+  Exception(s"Received unexpected message for job $jobId")

--- a/job-server/src/main/scala/spark/jobserver/util/Launcher.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/Launcher.scala
@@ -22,6 +22,8 @@ abstract class Launcher(config: Config, sparkLauncher: SparkLauncher, enviornmen
     private var handler: SparkAppHandle = null
 
     protected final val master = config.getString("spark.master")
+    protected final val defaultSuperviseModeEnabled = Try(
+        config.getBoolean(ManagerLauncher.SJS_SUPERVISE_MODE_KEY)).getOrElse(false)
     protected final val deployMode = config.getString("spark.submit.deployMode")
     protected final val sjsJarPath = getEnvironmentVariable("MANAGER_JAR_FILE")
     protected final val baseGCOPTS = getEnvironmentVariable("GC_OPTS_BASE")

--- a/job-server/src/main/scala/spark/jobserver/util/ManagerLauncher.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/ManagerLauncher.scala
@@ -7,6 +7,19 @@ import com.typesafe.config.Config
 import org.slf4j.LoggerFactory
 import org.apache.spark.launcher.SparkLauncher
 
+object ManagerLauncher {
+  final val SJS_SUPERVISE_MODE_KEY = "spark.driver.supervise"
+  final val CONTEXT_SUPERVISE_MODE_KEY = "launcher.spark.driver.supervise"
+
+  def shouldSuperviseModeBeEnabled(sjsSupervisorMode: Boolean,
+      contextSupervisorMode: Option[Boolean]): Boolean = {
+    (sjsSupervisorMode, contextSupervisorMode) match {
+      case (_, Some(contextSupervisorMode)) => contextSupervisorMode
+      case (_, None) => sjsSupervisorMode
+    }
+  }
+}
+
 class ManagerLauncher(systemConfig: Config, contextConfig: Config,
                       masterAddress: String, contextActorName: String, contextDir: String,
                       sparkLauncher: SparkLauncher = new SparkLauncher,
@@ -19,6 +32,10 @@ class ManagerLauncher(systemConfig: Config, contextConfig: Config,
   val extraSparkConfigurations = getEnvironmentVariable("MANAGER_EXTRA_SPARK_CONFS")
   val extraJavaOPTS = getEnvironmentVariable("MANAGER_EXTRA_JAVA_OPTIONS")
   var gcOPTS = baseGCOPTS
+  lazy val contextSuperviseModeEnabled: Option[Boolean] = Try(Some(
+    contextConfig.getBoolean(ManagerLauncher.CONTEXT_SUPERVISE_MODE_KEY))).getOrElse(None)
+  lazy val useSuperviseMode = ManagerLauncher.shouldSuperviseModeBeEnabled(
+      defaultSuperviseModeEnabled, contextSuperviseModeEnabled)
 
   override def addCustomArguments() {
       if (deployMode == "client") {
@@ -37,13 +54,20 @@ class ManagerLauncher(systemConfig: Config, contextConfig: Config,
       launcher.addSparkArg("--driver-java-options",
           s"$gcOPTS $baseJavaOPTS $loggingOpts $configOverloads $extraJavaOPTS")
 
+      if (useSuperviseMode) {
+        launcher.addSparkArg("--supervise")
+      }
+
       if (contextConfig.hasPath(SparkJobUtils.SPARK_PROXY_USER_PARAM)) {
          launcher.addSparkArg("--proxy-user", contextConfig.getString(SparkJobUtils.SPARK_PROXY_USER_PARAM))
       }
 
       for (e <- Try(contextConfig.getConfig("launcher"))) {
          e.entrySet().asScala.map { c =>
+           // Supervise mode was already handled above, no need to do it here again
+           if (c.getKey != "spark.driver.supervise") {
             launcher.addSparkArg("--conf", s"${c.getKey}=${c.getValue.unwrapped.toString}")
+           }
          }
       }
 
@@ -63,10 +87,15 @@ class ManagerLauncher(systemConfig: Config, contextConfig: Config,
   override def validate(): (Boolean, String) = {
      super.validate() match {
        case (true, _) =>
-         validateMemory(contextConfig.getString("launcher.spark.driver.memory")) match {
-           case true => (true, "")
-           case false => (false,
+         if (!validateMemory(contextConfig.getString("launcher.spark.driver.memory"))) {
+           (false,
              "Context error: spark.driver.memory has invalid value. Accepted formats 1024k, 2g, 512m")
+         } else if (deployMode == "client" && useSuperviseMode) {
+           (false, "Supervise mode can only be used with cluster mode")
+         } else if (master.startsWith("yarn") && useSuperviseMode) {
+           (false, "Supervise mode is only supported with spark standalone or Mesos")
+         } else {
+           (true, "")
          }
        case (false, error) => (false, error)
      }

--- a/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
@@ -8,12 +8,14 @@ import akka.testkit._
 import spark.jobserver.common.akka.AkkaTestUtils
 import spark.jobserver.io.{JobDAO, JobDAOActor, ContextInfo, ContextStatus}
 import ContextSupervisor._
+import spark.jobserver.util.ManagerLauncher
+import spark.jobserver.JobManagerActor._
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Try
-import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
+import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory, ConfigRenderOptions}
 import org.scalatest.{Matchers, FunSpec, BeforeAndAfter, BeforeAndAfterAll, FunSpecLike}
 import org.joda.time.DateTime
 import scala.concurrent.Await
@@ -39,6 +41,7 @@ object AkkaClusterSupervisorActorSpec {
     }
     spark {
       master = "local[4]"
+      driver.supervise = false
       temp-contexts {
         num-cpu-cores = 4           # Number of cores to allocate.  Required.
         memory-per-node = 512m      # Executor memory per node, -Xmx style eg 512m, 1G, etc.
@@ -140,12 +143,14 @@ class StubbedJobManagerActor(contextConfig: Config) extends Actor {
 class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorSpec.system) with ImplicitSender
       with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
 
+  val daoTimeout = 5.seconds.dilated
   val contextInitTimeout = 10.seconds.dilated
   var supervisor: ActorRef = _
   var dao: JobDAO = _
   var daoActor: ActorRef = _
   var managerProbe = TestProbe()
   val contextConfig = AkkaClusterSupervisorActorSpec.config.getConfig("spark.context-settings")
+  val unusedDummyInput = 1
 
   // This is needed to help tests pass on some MBPs when working from home
   System.setProperty("spark.driver.host", "localhost")
@@ -245,6 +250,7 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
 
       supervisor ! StopContext("test-context4")
       expectMsg(ContextStopped)
+      managerProbe.expectMsgClass(classOf[Terminated])
     }
 
     it("context stop should be able to handle case when no context is present") {
@@ -268,12 +274,13 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
       val deathWatch = TestProbe()
       deathWatch.watch(managerProbe.ref)
 
-      supervisor ! ActorIdentity(1, Some(managerProbe.ref))
+      supervisor ! ActorIdentity(unusedDummyInput, Some(managerProbe.ref))
 
       deathWatch.expectTerminated(managerProbe.ref)
     }
 
-    it("should kill context JVM if context was found in DB but no callback was available") {
+    it("should kill context JVM if context was found in DB but no callback was available" +
+        " and supervise mode is not enabled") {
       val managerProbe = TestProbe(AkkaClusterSupervisorActor.MANAGER_ACTOR_PREFIX + "dummy")
       val contextId = managerProbe.ref.path.name.replace(AkkaClusterSupervisorActor.MANAGER_ACTOR_PREFIX, "")
       val deathWatch = TestProbe()
@@ -282,7 +289,7 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
           DateTime.now(), None, ContextStatus.Started, None)
       dao.saveContextInfo(dummyContext)
 
-      supervisor ! ActorIdentity(1, Some(managerProbe.ref))
+      supervisor ! ActorIdentity(unusedDummyInput, Some(managerProbe.ref))
 
       deathWatch.expectTerminated(managerProbe.ref)
     }
@@ -296,7 +303,7 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
       supervisor ! StubbedAkkaClusterSupervisorActor.AddContextToContextInitInfos(contextActorName)
       supervisor ! StubbedAkkaClusterSupervisorActor.DisableDAOCommunication // Simulate DAO failure
 
-      supervisor ! ActorIdentity(1, Some(managerProbe.ref))
+      supervisor ! ActorIdentity(unusedDummyInput, Some(managerProbe.ref))
       deathWatch.expectTerminated(managerProbe.ref)
 
       supervisor ! StubbedAkkaClusterSupervisorActor.EnableDAOCommunication
@@ -308,7 +315,7 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
       deathWatch.watch(managerProbe.ref)
       supervisor ! StubbedAkkaClusterSupervisorActor.DisableDAOCommunication // Simulate DAO failure
 
-      supervisor ! ActorIdentity(1, Some(managerProbe.ref))
+      supervisor ! ActorIdentity(unusedDummyInput, Some(managerProbe.ref))
       deathWatch.expectTerminated(managerProbe.ref)
 
       supervisor ! StubbedAkkaClusterSupervisorActor.EnableDAOCommunication
@@ -364,6 +371,69 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
       supervisor ! GetSparkContexData("test-context11")
       // JobManagerActor Stub by default return NoSuchContext
       expectMsg(NoSuchContext)
+    }
+  }
+
+  describe("Supervise mode tests") {
+    it("should start context if supervise mode is disabled") {
+      supervisor ! AddContext("test-context", contextConfig)
+      expectMsg(contextInitTimeout, ContextInitialized)
+
+      val contextInfo = Await.result(dao.getContextInfoByName("test-context"), daoTimeout)
+      contextInfo should not be (None)
+    }
+
+    it("should start adhoc context if supervise mode is disabled") {
+      supervisor ! StartAdHocContext("test-adhoc-classpath", contextConfig)
+
+      val isValid = expectMsgPF(contextInitTimeout, "manager and result actors") {
+        case (manager: ActorRef) =>
+          manager.path.name.startsWith("jobManager-")
+      }
+
+      isValid should be (true)
+    }
+
+    it("should start context with supervise mode enabled") {
+      val configWithSuperviseMode = ConfigFactory.parseString(
+          s"${ManagerLauncher.CONTEXT_SUPERVISE_MODE_KEY}=true").withFallback(contextConfig)
+      supervisor ! AddContext("test-context", configWithSuperviseMode)
+      expectMsg(contextInitTimeout, ContextInitialized)
+
+      val contextInfo = Await.result(dao.getContextInfoByName("test-context"), daoTimeout)
+      contextInfo should not be (None)
+    }
+
+    it("should try to restart context if supervise mode is enabled") {
+      val managerProbe = TestProbe(AkkaClusterSupervisorActor.MANAGER_ACTOR_PREFIX + "123")
+      managerProbe.setAutoPilot(new TestActor.AutoPilot {
+        def run(sender: ActorRef, msg: Any): TestActor.AutoPilot = {
+          msg match {
+            case Initialize(_,_,_) => sender ! Initialized("", TestProbe().ref)
+            case RestartExistingJobs =>
+          }
+          TestActor.KeepRunning
+        }
+      })
+
+      val contextId = managerProbe.ref.path.name.replace(AkkaClusterSupervisorActor.MANAGER_ACTOR_PREFIX, "")
+      val configWithSuperviseMode = ConfigFactory.parseString(
+          s"${ManagerLauncher.CONTEXT_SUPERVISE_MODE_KEY}=true, is-adhoc=false, context.name=name, context.id=$contextId")
+          .withFallback(contextConfig)
+      val convertedContextConfig = configWithSuperviseMode.root().render(ConfigRenderOptions.concise())
+      val restartedContext = ContextInfo(contextId, "", convertedContextConfig, None, DateTime.now(), None, ContextStatus.Started, None)
+      dao.saveContextInfo(restartedContext)
+
+      supervisor ! ActorIdentity(unusedDummyInput, Some(managerProbe.ref))
+
+      managerProbe.expectMsgClass(classOf[Initialize])
+      managerProbe.expectMsg(RestartExistingJobs)
+
+      // After restart the context status is RUNNING. The after{} block of this class,
+      // lists all contexts and then tries to stop them. Since this manager slave is just a
+      // TestProbe it's address doesn't get resolved so, it cannot be stopped. So, we change
+      // the status to finish to cleanup.
+      dao.saveContextInfo(restartedContext.copy(state = ContextStatus.Finished))
     }
   }
 }

--- a/job-server/src/test/scala/spark/jobserver/InMemoryDAO.scala
+++ b/job-server/src/test/scala/spark/jobserver/InMemoryDAO.scala
@@ -100,10 +100,10 @@ class InMemoryDAO extends JobDAO {
   }
 
   override def getJobInfosByContextId(
-      contextId: String, jobStatus: Option[String] = None): Future[Seq[JobInfo]] = Future {
+      contextId: String, jobStatuses: Option[Seq[String]] = None): Future[Seq[JobInfo]] = Future {
     jobInfos.values.toSeq.filter(j => {
-      (contextId, jobStatus) match {
-        case (contextId, Some(status)) => contextId == j.contextId && status == j.state
+      (contextId, jobStatuses) match {
+        case (contextId, Some(statuses)) => contextId == j.contextId && statuses.contains(j.state)
         case _ => contextId == j.contextId
       }
     })

--- a/job-server/src/test/scala/spark/jobserver/JobManagerActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobManagerActorSpec.scala
@@ -596,7 +596,7 @@ class JobManagerActorSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) 
       daoProbe.expectMsgClass(classOf[JobDAOActor.GetJobInfosByContextId])
       // Not replying to GetJobInfosByContextId will result in a timeout
       // and failure will occur
-      managerWatcher.expectTerminated(manager)
+      managerWatcher.expectTerminated(manager, 5.seconds)
     }
 
     it("should kill itself if an unexpected message is received from DAO") {
@@ -669,7 +669,7 @@ class JobManagerActorSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) 
 
       daoProbe.expectMsgClass(classOf[JobDAOActor.GetJobConfig])
 
-      daoProbe.expectMsgPF(3.seconds.dilated, "store error in DAO since config not found") {
+      daoProbe.expectMsgPF(5.seconds.dilated, "store error in DAO since config not found") {
         case jobInfo: JobDAOActor.SaveJobInfo =>
           jobInfo.jobInfo.state should be(JobStatus.Error)
       }

--- a/job-server/src/test/scala/spark/jobserver/JobManagerSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobManagerSpec.scala
@@ -97,6 +97,24 @@ class JobManagerSpec extends FunSpecLike with Matchers with BeforeAndAfter {
         makeSystem, waitForTerminationDummy)
     }
 
+    it ("shouldn't have a configuration for akka remote port") {
+      val tmpDir = Files.createTempDirectory("job-manager-sqldao").toString
+      val configFileName = writeConfigFile(Map(
+        "spark.submit.deployMode" -> "cluster",
+        "akka.remote.netty.tcp.hostname" -> "localhost",
+        "akka.remote.netty.tcp.port" -> "1337",
+        "spark.jobserver.sqldao.rootdir" -> tmpDir
+      ))
+
+      def makeSystem(config: Config): ActorSystem = {
+        config.getInt("akka.remote.netty.tcp.port") should be (0)
+        system
+      }
+
+      JobManager.start(Seq(clusterAddr, "test-manager", configFileName).toArray,
+        makeSystem, waitForTerminationDummy)
+    }
+
     it ("starts dao-manager and job manager actor") {
       val configFileName = writeConfigFile(Map(
         "spark.submit.deployMode" -> "cluster"

--- a/job-server/src/test/scala/spark/jobserver/JobServerSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobServerSpec.scala
@@ -60,6 +60,20 @@ class JobServerSpec extends TestKit(JobServerSpec.system) with FunSpecLike with 
       }
     }
 
+   it("requires akka.remote.netty.tcp.port in supervise mode") {
+      val configFileName = writeConfigFile(Map(
+        "spark.submit.deployMode" -> "cluster",
+        "spark.jobserver.context-per-jvm" -> true,
+        "spark.driver.supervise" -> true,
+        "akka.remote.netty.tcp.port" -> 0))
+
+      val invalidConfException = intercept[InvalidConfiguration] {
+        JobServer.start(Seq(configFileName).toArray, makeSupervisorSystem(_))
+      }
+      invalidConfException.getMessage should
+        be("Supervise mode requires akka.remote.netty.tcp.port to be hardcoded")
+    }
+
     it("requires context-per-jvm in Mesos mode") {
       val configFileName = writeConfigFile(Map(
         "spark.master " -> "mesos://test:123",

--- a/job-server/src/test/scala/spark/jobserver/JobSpecBase.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobSpecBase.scala
@@ -27,6 +27,7 @@ trait JobSpecConfig {
   lazy val config = {
     val ConfigMap = Map(
       "spark.jobserver.job-result-cache-size" -> JobResultCacheSize,
+      "spark.jobserver.dao-timeout" -> "3s",
       "num-cpu-cores" -> NumCpuCores,
       "memory-per-node" -> MemoryPerNode,
       "spark.jobserver.max-jobs-per-context" -> MaxJobsPerContext,

--- a/job-server/src/test/scala/spark/jobserver/LocalContextSupervisorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/LocalContextSupervisorSpec.scala
@@ -25,6 +25,7 @@ object LocalContextSupervisorSpec {
 |     jobserver.context-deletion-timeout = 2 s
       jobserver.yarn-context-creation-timeout = 40 s
       jobserver.named-object-creation-timeout = 60 s
+      jobserver.dao-timeout = 3 s
       contexts {
         olap-demo {
           num-cpu-cores = 4
@@ -174,6 +175,9 @@ class LocalContextSupervisorSpec extends TestKit(LocalContextSupervisorSpec.syst
       val (jobManager: ActorRef) = expectMsgType[ActorRef]
 
       jobManager ! PoisonPill
+
+      // Since LocalContextSupervisor does not support contextId support yet,
+      // the class passes contextName in cleanContextJobInfos message.
       daoProbe.expectMsgType[CleanContextJobInfos]
     }
   }

--- a/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
@@ -181,13 +181,13 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
       case StartAdHocContext(_, _) => sender ! (self)
 
       // These routes are part of JobManagerActor
-      case StartJob("no-app", _, _, _)   =>  sender ! NoSuchApplication
-      case StartJob(_, "no-class", _, _) =>  sender ! NoSuchClass
-      case StartJob("wrong-type", _, _, _) => sender ! WrongJobType
-      case StartJob("err", _, config, _) =>  sender ! JobErroredOut("foo", dt,
+      case StartJob("no-app", _, _, _, _)   =>  sender ! NoSuchApplication
+      case StartJob(_, "no-class", _, _, _) =>  sender ! NoSuchClass
+      case StartJob("wrong-type", _, _, _, _) => sender ! WrongJobType
+      case StartJob("err", _, config, _, _) =>  sender ! JobErroredOut("foo", dt,
                                                         new RuntimeException("oops",
                                                           new IllegalArgumentException("foo")))
-      case StartJob("foo", _, config, events)     =>
+      case StartJob("foo", _, config, events, _)     =>
         statusActor ! Subscribe("foo", sender, events)
 
         val jobInfo = JobInfo("foo", "cid", "context", null, "com.abc.meme", getStateBasedOnEvents(events), dt, None, None)
@@ -197,7 +197,7 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
         if (events.contains(classOf[JobResult])) sender ! JobResult("foo", map)
         statusActor ! Unsubscribe("foo", sender)
 
-      case StartJob("foo.stream", _, config, events)     =>
+      case StartJob("foo.stream", _, config, events, _)     =>
         statusActor ! Subscribe("foo.stream", sender, events)
         val jobInfo = JobInfo("foo.stream", "cid", "context", null, "", getStateBasedOnEvents(events), dt, None, None)
         statusActor ! JobStatusActor.JobInit(jobInfo)

--- a/job-server/src/test/scala/spark/jobserver/io/JobDAOActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/JobDAOActorSpec.scala
@@ -55,7 +55,7 @@ object JobDAOActorSpec {
       Future.successful(Seq())
 
     override def getJobInfosByContextId(
-        contextId: String, jobStatus: Option[String] = None): Future[Seq[JobInfo]] = ???
+        contextId: String, jobStatuses: Option[Seq[String]] = None): Future[Seq[JobInfo]] = ???
 
     override def getJobInfo(jobId: String): Future[Option[JobInfo]] = ???
 

--- a/job-server/src/test/scala/spark/jobserver/util/ManagerLauncherSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/util/ManagerLauncherSpec.scala
@@ -12,7 +12,8 @@ class ManagerLauncherSpec extends FunSpec with Matchers with BeforeAndAfter {
     val stubbedSparkLauncher = new StubbedSparkLauncher()
     val environment = new InMemoryEnvironment
 
-    lazy val baseSystemConf = buildConfig(Map("spark.master" -> "local[*]", "spark.submit.deployMode" -> "client"))
+    lazy val baseSystemConfMap = Map("spark.master" -> "local[*]", "spark.submit.deployMode" -> "client")
+    lazy val baseSystemConf = buildConfig(baseSystemConfMap)
     lazy val baseContextMap = Map("launcher.spark.driver.memory" -> "1g")
     lazy val baseContextConf = buildConfig(baseContextMap)
     lazy val managerLauncherFunc = new ManagerLauncher(baseSystemConf, _:Config, "", "", "", stubbedSparkLauncher, environment)
@@ -114,6 +115,101 @@ class ManagerLauncherSpec extends FunSpec with Matchers with BeforeAndAfter {
 
        stubbedSparkLauncher.getLauncherConfig().containsValue(StubbedSparkLauncher.APP_ARGS, "master-address,actor-name,conf-file") should be (true)
      }
+
+     it("should fail if supervise mode is specified with client mode") {
+       val baseConfWithSuperviseMode = baseSystemConfMap + ("spark.driver.supervise" -> "true")
+       val launcher = new ManagerLauncher(buildConfig(baseConfWithSuperviseMode), baseContextConf, "", "", "", stubbedSparkLauncher, environment)
+
+       launcher.start() should be (false, "Supervise mode can only be used with cluster mode")
+     }
+
+      it("should fail if supervise mode is specified (in context config) with client mode") {
+       val contextConfMap = baseContextMap + ("launcher.spark.driver.supervise" -> "true")
+
+       val launcher = managerLauncherFunc(buildConfig(contextConfMap))
+
+       launcher.start() should be (false, "Supervise mode can only be used with cluster mode")
+     }
+
+     it("should fail if supervise mode is specified with yarn") {
+       val systemConfMap = Map("spark.master" -> "yarn", "spark.submit.deployMode" -> "cluster", "spark.driver.supervise" -> "true")
+
+       val launcher = new ManagerLauncher(buildConfig(systemConfMap), baseContextConf, "", "", "", stubbedSparkLauncher, environment)
+
+       launcher.start() should be (false, "Supervise mode is only supported with spark standalone or Mesos")
+     }
+
+     it("should fail if supervise mode is specified (in context config) with yarn") {
+       val systemConfMap = Map("spark.master" -> "yarn", "spark.submit.deployMode" -> "cluster")
+       val contextConfMap = baseContextMap + (ManagerLauncher.CONTEXT_SUPERVISE_MODE_KEY -> "true")
+       val launcher = new ManagerLauncher(buildConfig(systemConfMap), buildConfig(contextConfMap), "", "", "", stubbedSparkLauncher, environment)
+
+       launcher.start() should be (false, "Supervise mode is only supported with spark standalone or Mesos")
+     }
+
+     it("should set supervise flag if system config and context config have supervise mode enabled") {
+       val systemConfMap = Map("spark.master" -> "local[4]", "spark.submit.deployMode" -> "cluster", "spark.driver.supervise" -> "true")
+       val contextConfMap = baseContextMap + (ManagerLauncher.CONTEXT_SUPERVISE_MODE_KEY -> "true")
+       val launcher = new ManagerLauncher(buildConfig(systemConfMap), buildConfig(contextConfMap), "", "", "", stubbedSparkLauncher, environment)
+
+       launcher.start()
+
+       stubbedSparkLauncher.getLauncherConfig().containsValue(StubbedSparkLauncher.SPARK_DRIVER_SUPERVISE, "--supervise") should be (true)
+       // The supervise mode should not be added again while processing the launcher section
+       stubbedSparkLauncher.getLauncherConfig().containsValue("--conf", "spark.driver.supervise=true") should be (false)
+     }
+
+     it("should set supervise flag if only context config has supervise mode enabled") {
+       val systemConfMap = Map("spark.master" -> "local[4]", "spark.submit.deployMode" -> "cluster")
+       val contextConfMap = baseContextMap + (ManagerLauncher.CONTEXT_SUPERVISE_MODE_KEY -> "true")
+       val launcher = new ManagerLauncher(buildConfig(systemConfMap), buildConfig(contextConfMap), "", "", "", stubbedSparkLauncher, environment)
+
+       launcher.start()
+
+       stubbedSparkLauncher.getLauncherConfig().containsValue(StubbedSparkLauncher.SPARK_DRIVER_SUPERVISE, "--supervise") should be (true)
+       stubbedSparkLauncher.getLauncherConfig().containsValue("--conf", "spark.driver.supervise=true") should be (false)
+     }
+
+     it("should not set supervise flag if supervise mode is enabled in system config but context config doesn't have a value defined") {
+       val systemConfMap = Map("spark.master" -> "local[4]", "spark.submit.deployMode" -> "cluster", ManagerLauncher.SJS_SUPERVISE_MODE_KEY -> "true")
+       val contextConfMap = baseContextMap
+       val launcher = new ManagerLauncher(buildConfig(systemConfMap), buildConfig(contextConfMap), "", "", "", stubbedSparkLauncher, environment)
+
+       launcher.start()
+
+       stubbedSparkLauncher.getLauncherConfig().containsValue(StubbedSparkLauncher.SPARK_DRIVER_SUPERVISE, "--supervise") should be (true)
+       stubbedSparkLauncher.getLauncherConfig().containsValue("--conf", "spark.driver.supervise=true") should be (false)
+     }
+
+     it("should not set supervise flag if supervise mode is disabled in system config and context config doesn't have a value defined") {
+       val systemConfMap = Map("spark.master" -> "local[4]", "spark.submit.deployMode" -> "cluster", ManagerLauncher.SJS_SUPERVISE_MODE_KEY -> "false")
+       val contextConfMap = baseContextMap
+       val launcher = new ManagerLauncher(buildConfig(systemConfMap), buildConfig(contextConfMap), "", "", "", stubbedSparkLauncher, environment)
+
+       launcher.start()
+
+       stubbedSparkLauncher.getLauncherConfig().containsValue(StubbedSparkLauncher.SPARK_DRIVER_SUPERVISE, "--supervise") should be (false)
+       stubbedSparkLauncher.getLauncherConfig().containsValue("--conf", "spark.driver.supervise=true") should be (false)
+     }
+
+     it("should not set supervise flag if supervise mode is enabled in system config but disabled in context config") {
+       val systemConfMap = Map("spark.master" -> "local[4]", "spark.submit.deployMode" -> "cluster", ManagerLauncher.SJS_SUPERVISE_MODE_KEY -> "true")
+       val contextConfMap = baseContextMap + (ManagerLauncher.CONTEXT_SUPERVISE_MODE_KEY -> "false")
+       val launcher = new ManagerLauncher(buildConfig(systemConfMap), buildConfig(contextConfMap), "", "", "", stubbedSparkLauncher, environment)
+
+       launcher.start()
+
+       stubbedSparkLauncher.getLauncherConfig().containsValue(StubbedSparkLauncher.SPARK_DRIVER_SUPERVISE, "--supervise") should be (false)
+       stubbedSparkLauncher.getLauncherConfig().containsValue("--conf", "spark.driver.supervise=true") should be (false)
+     }
+
+     it("should not set supervise flag if both configs don't have supervise mode enabled") {
+       val launcher = managerLauncherFunc(buildConfig(baseContextMap))
+
+       launcher.start()
+
+       stubbedSparkLauncher.getLauncherConfig().containsValue(StubbedSparkLauncher.SPARK_DRIVER_SUPERVISE, "--supervise") should be (false)
+     }
    }
 }
 
@@ -141,6 +237,7 @@ object StubbedSparkLauncher {
     final val MAIN_CLASS = "fake.spark.main.class"
     final val APP_ARGS = "fake.spark.app.args"
     final val SPARK_ARGS = "fake.spark.conf"
+    final val SPARK_DRIVER_SUPERVISE = "fake.spark.driver.supervise"
 }
 
 class StubbedSparkLauncher extends SparkLauncher {
@@ -186,6 +283,11 @@ class StubbedSparkLauncher extends SparkLauncher {
 
       override def addSparkArg(key: String, value: String): SparkLauncher = {
         launcherConfig.put(key, value)
+        null
+      }
+
+      override def addSparkArg(value: String): SparkLauncher = {
+        launcherConfig.put(StubbedSparkLauncher.SPARK_DRIVER_SUPERVISE, value)
         null
       }
 


### PR DESCRIPTION
Note: This change is a combination of 6 related commits. Each commit has its own explanation.
This change was only tested with spark-standalone.


This change allows contexts and jobs within these contexts
to get restarted if they get stopped unexpectedly. This
is achieved using the supervise mode provided by Spark.

This change introduces a global property
spark.driver.supervise. The value can be set to true or false.
True = Enable supervise mode by default for all the new contexts.
False = Disable supervise mode for all contexts but user can
decide if the context needs to be supervised or not.

For each context, a property launcher.spark.driver.supervise is
provided, user can set individually for each context, if it
should use this mode or not.

Here are all the possible cases:

Default mode  |  context mode  |  Action
true             true             enabled
true             false            disabled
false            true             enabled
false            false            disabled
true             Not defined      enabled
false            Not defined      disabled

Curently, this mode is tested with streaming/batch jobs.
A few things to note
* The criteria for a restart:
    * Job is either in RUNNING state, or
    * Job is in ERROR state with Context Terminated
        exception as error message.
    * The job is async
* The jobs for restart are selected based on unique context Id. So, we won't get jobs from any other context.
* After the restart, we get the contextId from the managerName provided by slave launch command.
* If a batch context has multiple jobs, then all the jobs will be restarted
* A context without any successfully restarted job will be deleted automatically. If there is at least one job, which doesn't fail, the context won't be deleted.
* If a context fails during the restart, this job will be marked as failed in the db.
* Since currently we have 1 master, to avoid overloading the master with all the restart scenario, the job restart logic is implemented on slaves. Only the context initialization logic is on master
* On master we detect a supervise scenario based on contextInitInfos hashmap. If the hashmap has an entry, it is a normal initialize of context but if it doesn't then it is a restart scenario. This apporach is safe because contextInitInfos's key is the slaves job manager actor name, this name is a combination of jobManager-<uuid>. If the context was initialized properly then this entry will be removed for sure. If the initialization failed, then contextInitInfos might have the entry but it is useless because context was never initialized and restart is not possible.
* If an existing job is restarted successfully, we change the error status back to running and also purge the endtime.

Note: If supervise mode is active, JVMs will only be restarted if the
JVM was killed with a non-zero exit code.

Some behaviors of cluster + supervise mode:
1- If we kill the application from MasterUI -> kills the app + driver and no restart
2- If we kill the driver from Master UI -> kills app + driver and no restart
3- If we kill the context from SJS -> Kills the driver + app and no restart
4- If we kill the job from SJS -> Keep the driver + app running and no restart of the job
5- If we kill the Driver Wrapper JVM using kill -9 -> Driver comes up with different PID but same driver ID, application ID changes, restart happened.
6- If we kill the Executor JVM using kill -9 -> Drivers stays, app also stays, the executor JVM is relauched with different pid, not related to Restart, normal behavior of Spark
7 - If we have a job which fails on the Executor and the executor restarts -> We can delete the job through Master UI, killing it through SJS makes it a zombie.
8- If we have a job which fails on the Driver -> Driver restarts (only if supervise mode is enabled), we can stop it through SJS, we can always stop it from UI.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
Supervise mode is not supported


**New behavior :**
Supervise mode is now supported


**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1066)
<!-- Reviewable:end -->
