### PR TITLE
feat(jobserver): Add restarting state and improve reconnect logic

### DIFF
--- a/doc/cluster.md
+++ b/doc/cluster.md
@@ -78,4 +78,4 @@ Note: Files uploaded via the JAR or binary API are stored and transfered via the
 
 ## Configuring Job Server for supervised cluster mode
 
-* Add the option akka.remote.netty.tcp.port to the related Jobserver configuration file (e.g. local.conf).
+* See the [supervise-mode document](https://github.com/spark-jobserver/spark-jobserver/blob/master/doc/supervise-mode.md)

--- a/doc/mesos.md
+++ b/doc/mesos.md
@@ -84,4 +84,4 @@ MANAGER_LOGGING_OPTS="-Dlog4j.configuration=log4j-cluster.properties"
 
 ## Configuring Job Server for supervised cluster mode
 
-* Add the option akka.remote.netty.tcp.port to the related Jobserver configuration file (e.g. local.conf).
+* See the [supervise-mode document](https://github.com/spark-jobserver/spark-jobserver/blob/master/doc/supervise-mode.md)

--- a/doc/supervise-mode.md
+++ b/doc/supervise-mode.md
@@ -43,9 +43,7 @@ Here are all the possible cases:
 Curently, this mode is tested with streaming/batch jobs.
 A few things to note
 - The criteria for a restart:
-    * Job is either in RUNNING state, or
-    * Job is in ERROR state with Context Terminated
-        exception as error message.
+    * Job is either in RUNNING or RESTARTING state, or
     * The job is async
 - The jobs for restart are selected based on unique context Id. So, we won't get jobs from any other context.
 - On master we detect a supervise scenario based on contextInitInfos hashmap. If the hashmap has an entry, it is a normal initialize of context but if it doesn't then it is a restart scenario. This approach is safe because contextInitInfos's key is the slaves job manager actor name, this name is a combination of jobManager-<uuid>. If the context was initialized properly then this entry will be removed for sure. If the initialization failed, then contextInitInfos might have the entry but it is useless because context was never initialized and restart is not possible.

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -478,10 +478,12 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
 
   private def getActiveContextByName(name: String): (Boolean, Option[ContextInfo]) = {
     val resp = getContextByName(name)
+    val statesInWhichContextCanBeActive =
+      List(ContextStatus.Started, ContextStatus.Running, ContextStatus.Restarting)
     resp match {
       case None => (false, None)
       case Some(JobDAOActor.ContextResponse(Some(c)))
-        if c.state == ContextStatus.Running || c.state == ContextStatus.Started => (true, Some(c))
+        if statesInWhichContextCanBeActive.contains(c.state) => (true, Some(c))
       case Some(_) => (true, None)
     }
   }

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -294,9 +294,9 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
               daoActor ! JobDAOActor.CleanContextJobInfos(c.id, DateTime.now())
          }
       case Some(JobDAOActor.ContextResponse(None)) =>
-        logger.error("No context for deletion is found in the DB")
+        logger.error(s"No context (contextId: ${contextId}) for deletion is found in the DB")
       case None =>
-        logger.error("Error occurred after Terminated message was recieved")
+        logger.error(s"Error occurred after Terminated message was recieved for (contextId: ${contextId})")
     }
     cluster.down(actorRef.path.address)
     jobManagerActorRefs.remove(actorRef.path.toString())

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -171,7 +171,8 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
 
     case ListContexts =>
       val resp = getDataFromDAO[JobDAOActor.ContextInfos](
-          JobDAOActor.GetContextInfos(None, Some(ContextStatus.Running)))
+          JobDAOActor.GetContextInfos(None, Some(
+              Seq(ContextStatus.Running, ContextStatus.Restarting))))
       resp match {
         case Some(JobDAOActor.ContextInfos(contextInfos)) => sender ! contextInfos.map(_.name)
         case None => sender ! UnexpectedError

--- a/job-server/src/main/scala/spark/jobserver/JobServer.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobServer.scala
@@ -162,7 +162,7 @@ object JobServer {
     val config = system.settings.config
     val daoAskTimeout = Timeout(config.getDuration("spark.jobserver.dao-timeout", TimeUnit.SECONDS).second)
     val resp = Await.result(
-        (jobDaoActor ? JobDAOActor.GetContextInfos(None, Some(ContextStatus.Running)))(daoAskTimeout).
+        (jobDaoActor ? JobDAOActor.GetContextInfos(None, Some(Seq(ContextStatus.Running))))(daoAskTimeout).
         mapTo[JobDAOActor.ContextInfos], daoAskTimeout.duration)
     resp.contextInfos.foreach(ci => validateContext(ci, system, jobDaoActor)(ec))
   }

--- a/job-server/src/main/scala/spark/jobserver/io/JobCassandraDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobCassandraDAO.scala
@@ -194,16 +194,16 @@ class JobCassandraDAO(config: Config) extends JobDAO with FileCacher {
     }
   }
 
-  override def getContextInfos(limitOpt: Option[Int] = None, statusOpt: Option[String] = None):
+  override def getContextInfos(limitOpt: Option[Int] = None, statuses: Option[Seq[String]] = None):
     Future[Seq[ContextInfo]] = {
     val query = QB.select(ContextId, ContextName, ContextConfig, ActorAddress, StartTime, EndTime,
             State, Error).
         from(OrderedContextsByStateTable)
-    val filteredQuery = (limitOpt, statusOpt) match {
-       case (Some(limit), Some(status)) => query.where(QB.eq(State, status)).limit(limit)
+    val filteredQuery = (limitOpt, statuses) match {
+       case (Some(limit), Some(statuses)) => query.where(QB.in(State, statuses.toList.asJava)).limit(limit)
        case (Some(limit), None) =>
          throw new UnsupportedOperationException("Current cassandra model doesnot support this operation")
-       case (None, Some(status)) => query.where(QB.eq(State, status))
+       case (None, Some(statuses)) => query.where(QB.in(State, statuses.toList.asJava))
        case (None, None) =>
          throw new UnsupportedOperationException("Current cassandra model doesnot support this operation")
      }

--- a/job-server/src/main/scala/spark/jobserver/io/JobDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobDAO.scala
@@ -83,6 +83,7 @@ object JobStatus {
   val Started = "STARTED"
   val Killed = "KILLED"
   val Restarting = "RESTARTING"
+  def getNonFinalStates(): Seq[String] = Seq(Started, Running, Restarting)
 }
 
 object ContextStatus {

--- a/job-server/src/main/scala/spark/jobserver/io/JobDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobDAO.scala
@@ -82,6 +82,7 @@ object JobStatus {
   val Finished = "FINISHED"
   val Started = "STARTED"
   val Killed = "KILLED"
+  val Restarting = "RESTARTING"
 }
 
 object ContextStatus {
@@ -91,6 +92,7 @@ object ContextStatus {
   val Finished = "FINISHED"
   val Started = "STARTED"
   val Killed = "KILLED"
+  val Restarting = "RESTARTING"
 }
 
 object JobDAO {

--- a/job-server/src/main/scala/spark/jobserver/io/JobDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobDAO.scala
@@ -160,7 +160,7 @@ trait JobDAO {
    *
    * @return
    */
-  def getContextInfos(limit: Option[Int] = None, statusOpt: Option[String] = None):
+  def getContextInfos(limit: Option[Int] = None, statuses: Option[Seq[String]] = None):
     Future[Seq[ContextInfo]]
 
   /**

--- a/job-server/src/main/scala/spark/jobserver/io/JobDAOActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobDAOActor.scala
@@ -42,7 +42,7 @@ object JobDAOActor {
   case class GetContextInfo(id: String) extends JobDAORequest
   case class GetContextInfoByName(name: String) extends JobDAORequest
   case class GetContextInfos(limit: Option[Int] = None,
-      statusOpt: Option[String] = None) extends JobDAORequest
+      statuses: Option[Seq[String]] = None) extends JobDAORequest
 
   //Responses
   sealed trait JobDAOResponse
@@ -90,8 +90,8 @@ class JobDAOActor(dao: JobDAO) extends InstrumentedActor {
     case GetContextInfoByName(name) =>
       dao.getContextInfoByName(name).map(ContextResponse).pipeTo(sender)
 
-    case GetContextInfos(limit, statusOpt) =>
-      dao.getContextInfos(limit, statusOpt).map(ContextInfos).pipeTo(sender)
+    case GetContextInfos(limit, statuses) =>
+      dao.getContextInfos(limit, statuses).map(ContextInfos).pipeTo(sender)
 
     case SaveJobInfo(jobInfo) =>
       dao.saveJobInfo(jobInfo)

--- a/job-server/src/main/scala/spark/jobserver/io/JobFileDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobFileDAO.scala
@@ -165,7 +165,7 @@ class JobFileDAO(config: Config) extends JobDAO {
     throw new NotImplementedError;
   }
 
-  override def getContextInfos(limit: Option[Int] = None, statusOpt: Option[String] = None):
+  override def getContextInfos(limit: Option[Int] = None, statuses: Option[Seq[String]] = None):
     Future[Seq[ContextInfo]] = {
     throw new NotImplementedError;
   }

--- a/job-server/src/main/scala/spark/jobserver/io/JobSqlDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobSqlDAO.scala
@@ -298,10 +298,10 @@ class JobSqlDAO(config: Config) extends JobDAO with FileCacher {
     db.run(query.headOption).map(r => r.map(contextInfoFromRow(_)))
   }
 
-  override def getContextInfos(limit: Option[Int] = None, statusOpt: Option[String] = None):
+  override def getContextInfos(limit: Option[Int] = None, statuses: Option[Seq[String]] = None):
   Future[Seq[ContextInfo]] = {
-    val query = statusOpt match {
-      case Some(i) => contexts.filter(_.state === i)
+    val query = statuses match {
+      case Some(statuses) => contexts.filter(_.state.inSet(statuses))
       case None => contexts
     }
     val sortQuery = query.sortBy(_.startTime.desc)

--- a/job-server/src/main/scala/spark/jobserver/util/CustomException.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/CustomException.scala
@@ -15,3 +15,9 @@ final case class NoJobConfigFoundException(jobId: String) extends
 
 final case class UnexpectedMessageReceivedException(jobId: String) extends
   Exception(s"Received unexpected message for job $jobId")
+
+final case class ContextJVMInitializationTimeout() extends
+  Exception("Context failed to connect back within initialization time")
+
+final case class ContextReconnectFailedException() extends
+  Exception("Reconnect failed after Jobserver restart")

--- a/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
@@ -375,6 +375,22 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
       // JobManagerActor Stub by default return NoSuchContext
       expectMsg(NoSuchContext)
     }
+
+    it("should not allow to create the same context if in restarting state") {
+      val contextId = "restartingContextId"
+      val contextName = "restartingContextName"
+      val convertedContextConfig = contextConfig.root().render(ConfigRenderOptions.concise())
+
+      val contextInfoPF = ContextInfo(contextId, contextName, convertedContextConfig, None, DateTime.now(),
+          None, _: String, None)
+      val restartingContext = contextInfoPF(ContextStatus.Restarting)
+      dao.saveContextInfo(restartingContext)
+
+      supervisor ! AddContext(contextName, contextConfig)
+      expectMsg(contextInitTimeout, ContextAlreadyExists)
+
+      dao.saveContextInfo(contextInfoPF(ContextStatus.Finished)) // cleanup
+    }
   }
 
   describe("Supervise mode tests") {

--- a/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
@@ -76,6 +76,7 @@ object StubbedAkkaClusterSupervisorActor {
   case class AddContextToContextInitInfos(contextName: String)
   case object DisableDAOCommunication
   case object EnableDAOCommunication
+  case class DummyTerminated(actorRef: ActorRef)
 }
 
 class StubbedAkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef, managerProbe: TestProbe)
@@ -114,6 +115,8 @@ class StubbedAkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: Ac
       daoCommunicationDisabled = true
     case StubbedAkkaClusterSupervisorActor.EnableDAOCommunication =>
       daoCommunicationDisabled = false
+    case StubbedAkkaClusterSupervisorActor.DummyTerminated(actorRef) =>
+      handleTerminatedEvent(actorRef)
   }
 
   override def getDataFromDAO[T: ClassTag](msg: JobDAOActor.JobDAORequest): Option[T] = {
@@ -434,6 +437,44 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
       // TestProbe it's address doesn't get resolved so, it cannot be stopped. So, we change
       // the status to finish to cleanup.
       dao.saveContextInfo(restartedContext.copy(state = ContextStatus.Finished))
+    }
+
+    it("should set state restarting for context which was terminated unexpectedly and had supervise mode enabled") {
+      val contextId = "testid"
+      val configWithSuperviseMode = ConfigFactory.parseString(
+          s"${ManagerLauncher.CONTEXT_SUPERVISE_MODE_KEY}=true").withFallback(contextConfig)
+      val convertedContextConfig = configWithSuperviseMode.root().render(ConfigRenderOptions.concise())
+
+      val runningContext = ContextInfo(contextId, "c", convertedContextConfig, None, DateTime.now(), None, ContextStatus.Running, None)
+      dao.saveContextInfo(runningContext)
+      val managerProbe = system.actorOf(Props.empty, s"jobManager-$contextId")
+      val daoProbe = TestProbe()
+
+      supervisor ! StubbedAkkaClusterSupervisorActor.DummyTerminated(managerProbe)
+
+      Thread.sleep(3000)
+      val updatedContextInfo = Await.result(dao.getContextInfo(contextId), daoTimeout)
+      updatedContextInfo.get.state should be(ContextStatus.Restarting)
+
+      dao.saveContextInfo(updatedContextInfo.get.copy(state = ContextStatus.Finished)) //cleanup
+    }
+
+    it("should set state killed for context which was terminated unexpectedly and supervise mode disabled") {
+      val contextId = "testid2"
+      val convertedContextConfig = contextConfig.root().render(ConfigRenderOptions.concise())
+
+      val runningContext = ContextInfo(contextId, "c", convertedContextConfig, None, DateTime.now(), None, ContextStatus.Running, None)
+      dao.saveContextInfo(runningContext)
+      val managerProbe = system.actorOf(Props.empty, s"jobManager-$contextId")
+      val daoProbe = TestProbe()
+
+      supervisor ! StubbedAkkaClusterSupervisorActor.DummyTerminated(managerProbe)
+
+      Thread.sleep(3000)
+      val updatedContextInfo = Await.result(dao.getContextInfo(contextId), daoTimeout)
+      updatedContextInfo.get.state should be(ContextStatus.Killed)
+
+      dao.saveContextInfo(updatedContextInfo.get.copy(state = ContextStatus.Finished)) //cleanup
     }
   }
 }

--- a/job-server/src/test/scala/spark/jobserver/InMemoryDAO.scala
+++ b/job-server/src/test/scala/spark/jobserver/InMemoryDAO.scala
@@ -61,12 +61,12 @@ class InMemoryDAO extends JobDAO {
       c1.startTime.isAfter(c2.startTime)
   }
 
-  override def getContextInfos(limit: Option[Int] = None, statusOpt: Option[String] = None):
+  override def getContextInfos(limit: Option[Int] = None, statuses: Option[Seq[String]] = None):
         Future[Seq[ContextInfo]] = Future {
     val allContexts = contextInfos.values.toSeq.sortWith(sortTime)
-    val filteredContexts = statusOpt match {
-      case Some(state) =>
-        allContexts.filter(_.state == state)
+    val filteredContexts = statuses match {
+      case Some(statuses) =>
+        allContexts.filter(j => statuses.contains(j.state))
       case _ => allContexts
     }
 

--- a/job-server/src/test/scala/spark/jobserver/io/JobCassandraDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/JobCassandraDAOSpec.scala
@@ -480,18 +480,28 @@ class JobCassandraDAOSpec extends TestJarFinder with FunSpecLike with Matchers w
       val contextInfo2 = contextInfo(UUIDs.random().toString, "test-context8", DateTime.now(), ContextStatus.Running)
       val contextInfo3 = contextInfo(UUIDs.random().toString, "test-context9", DateTime.now(), ContextStatus.Started)
       val contextInfo4 = contextInfo(UUIDs.random().toString, "test-context10",DateTime.now(), ContextStatus.Started)
+      val contextInfo5 = contextInfo(UUIDs.random().toString, "test-context11",DateTime.now(), ContextStatus.Restarting)
 
       dao.saveContextInfo(contextInfo1)
       dao.saveContextInfo(contextInfo2)
       dao.saveContextInfo(contextInfo3)
       dao.saveContextInfo(contextInfo4)
+      dao.saveContextInfo(contextInfo5)
 
       def Desc[T : Ordering] = implicitly[Ordering[T]].reverse
-      val orderedExpectedList = Seq(contextInfo4, contextInfo3, contextInfo1)
+      var orderedExpectedList = Seq(contextInfo4, contextInfo3, contextInfo1)
                                     .sortBy(_.id)
                                     .sortBy(_.startTime.getMillis)(Desc)
 
-      val contexts = Await.result(dao.getContextInfos(Some(3), Some(ContextStatus.Started)), timeout)
+      var contexts = Await.result(dao.getContextInfos(Some(3), Some(Seq(ContextStatus.Started))), timeout)
+      contexts should be (orderedExpectedList)
+
+      orderedExpectedList = Seq(contextInfo5, contextInfo2)
+      .sortBy(_.id)
+      .sortBy(_.startTime.getMillis)(Desc)
+
+      contexts = Await.result(
+          dao.getContextInfos(Some(2), Some(Seq(ContextStatus.Running, ContextStatus.Restarting))), timeout)
       contexts should be (orderedExpectedList)
     }
 
@@ -502,7 +512,7 @@ class JobCassandraDAOSpec extends TestJarFinder with FunSpecLike with Matchers w
 
       dao.saveContextInfo(contextInfo1)
       dao.saveContextInfo(contextInfo2)
-      val contexts = Await.result(dao.getContextInfos(None, Some(ContextStatus.Started)), timeout)
+      val contexts = Await.result(dao.getContextInfos(None, Some(Seq(ContextStatus.Started))), timeout)
       contexts.head should be (contextInfo1)
     }
 

--- a/job-server/src/test/scala/spark/jobserver/io/JobDAOActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/JobDAOActorSpec.scala
@@ -44,7 +44,7 @@ object JobDAOActorSpec {
 
     override def getContextInfo(id: String): Future[Option[ContextInfo]] = ???
 
-    override def getContextInfos(limit: Option[Int] = None, statusOpt: Option[String] = None):
+    override def getContextInfos(limit: Option[Int] = None, statuses: Option[Seq[String]] = None):
       Future[Seq[ContextInfo]] = ???
 
     override def getContextInfoByName(name: String): Future[Option[ContextInfo]] = ???

--- a/job-server/src/test/scala/spark/jobserver/io/JobSqlDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/JobSqlDAOSpec.scala
@@ -508,7 +508,7 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
       contexts should contain theSameElementsAs Seq(dummyContext, dummyContextNew)
     }
 
-    it("should get ContextInfos all contexts with state FINISHED") {
+    it("should get ContextInfos of all contexts with state FINISHED") {
       val dummyContextOld = ContextInfo("someIdOld", "contextName", "", None, DateTime.now(), None,
           ContextStatus.Finished, None)
       dao.saveContextInfo(dummyContextOld)
@@ -521,9 +521,33 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
           ContextStatus.Started, None)
       dao.saveContextInfo(dummyContextNew)
 
-      val contexts: Seq[ContextInfo] = Await.result(dao.getContextInfos(None, Some(ContextStatus.Finished)), timeout)
+      val contexts: Seq[ContextInfo] = Await.result(dao.getContextInfos(
+          None, Some(Seq(ContextStatus.Finished))), timeout)
       contexts.size should equal (2)
       contexts should contain theSameElementsAs Seq(dummyContextOld, dummyContext)
+    }
+
+    it("should get ContextInfos of all contexts with state Finished OR Running") {
+      val dummyContextOld = ContextInfo("someIdOld", "contextName", "", None, DateTime.now(), None,
+          ContextStatus.Finished, None)
+      dao.saveContextInfo(dummyContextOld)
+
+      val dummyContext = ContextInfo("someId", "contextName", "", None, DateTime.now(), None,
+          ContextStatus.Finished, None)
+      dao.saveContextInfo(dummyContext)
+
+      val dummyContextNew = ContextInfo("someIdNew", "contextNameNew", "", None, DateTime.now(), None,
+          ContextStatus.Started, None)
+      dao.saveContextInfo(dummyContextNew)
+
+      val dummyContextRestarting = ContextInfo("someIdRestarting", "contextNameRestarting", "", None, DateTime.now(), None,
+          ContextStatus.Restarting, None)
+      dao.saveContextInfo(dummyContextRestarting)
+
+      val contexts: Seq[ContextInfo] = Await.result(dao.getContextInfos(
+          None, Some(Seq(ContextStatus.Restarting, ContextStatus.Started))), timeout)
+      contexts.size should equal (2)
+      contexts should contain theSameElementsAs Seq(dummyContextRestarting, dummyContextNew)
     }
 
     it("should update the context, if id is the same for two saveContextInfo requests") {


### PR DESCRIPTION
**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?
- [X] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
#1040
Currently, if a job is restarting and the user submits
/jobs, figuring out the restarting scenario is not too
obvious by just looking at the output.

User needs to know that if state is ERROR, error msg is
Context Terminated exception and supervise mode is
enabled for that context, only then it will be restarting.

The /contexts endpoint only shows contexts in state "RUNNING". 

If the reconnect failed, the state of the context is set to error, but the state of jobs which were running
in this context isn't touched.

**New behavior :**

This PR adds an explicit state ("RESTARTING") which is also shown in /jobs.
The /contexts endpoint will also show contexts in state "RESTARTING".
If the reconnect failed, the state of jobs which are running is set to ERROR.

**Other information**:

Known issues which will be fixed in upcoming changes:
* In Restarting state if POST /context is submitted with
the same name, then SJS will allow the creation of context
and restart of context will fail. This should be avoided.
* In Restarting state if DELETE /context is submitted,
then SJS will respond with NoSuchContext because the
Akka address in DB is not valid. It should be handled
more gracefully.
* There is a scenario in which the new restarting feature
can produce zombies:
  1. Driver gets killed and try to restart
  2. SJS Master writes state "Restarting" into database for
this Driver
  3. SJS Master crashes before Driver restarted and SJS Master
wrote state "Running" in the database for the Driver
  4. Driver comes up and becomes a zombie
If this happens, clean up on SJS Master start will not happen,
because Driver is in state "Restarting" not "Running".
Also the Driver cannot connect back to the SJS Master,
because it was restarted in the meantime.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1077)
<!-- Reviewable:end -->
