### PR TITLE
Various fixes

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -66,6 +66,8 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
   private val cluster = Cluster(context.system)
   protected val selfAddress = cluster.selfAddress
 
+  private val FINAL_STATES = Set(ContextStatus.Error, ContextStatus.Finished, ContextStatus.Killed)
+
   // This is for capturing results for ad-hoc jobs. Otherwise when ad-hoc job dies, resultActor also dies,
   // and there is no way to retrieve results.
   val globalResultActor = context.actorOf(Props[JobResultActor], "global-result-actor")
@@ -251,8 +253,9 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
       resp match {
         case Some(JobDAOActor.ContextResponse(Some(c))) =>
           logger.info("Shutting down context {}", name)
+          val state = if (FINAL_STATES contains c.state) c.state else ContextStatus.Stopping
           val contextInfo = ContextInfo(c.id, c.name, c.config, c.actorAddress, c.startTime,
-            c.endTime, ContextStatus.Stopping, c.error)
+            c.endTime, state, c.error)
           daoActor ! JobDAOActor.SaveContextInfo(contextInfo)
           val contextActorRef = getActorRef(c)
           contextActorRef match {

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -290,7 +290,7 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
                 if (c.state == ContextStatus.Stopping) ContextStatus.Finished else ContextStatus.Killed
         (isSuperviseModeEnabled(config, ConfigFactory.parseString(c.config)), state) match {
             case (true, ContextStatus.Killed) =>
-              setRestartingStateForContextAndJobs(c)
+              setStateForContextAndJobs(c, ContextStatus.Restarting)
             case _ =>
               val contextInfo = c.copy(endTime = Option(DateTime.now()), state = state)
               daoActor ! JobDAOActor.SaveContextInfo(contextInfo)
@@ -305,15 +305,15 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
     jobManagerActorRefs.remove(actorRef.path.toString())
   }
 
-  private def setRestartingStateForContextAndJobs(contextInfo: ContextInfo) {
-    val restartingContext = contextInfo.copy(endTime = Option(DateTime.now()),
-        state = ContextStatus.Restarting)
-    logger.info(s"Updating the status to Restarting for context ${contextInfo.id} and jobs within")
-    daoActor ! JobDAOActor.SaveContextInfo(restartingContext)
-    setRestartingStateForRunningJobs(contextInfo)
+  private def setStateForContextAndJobs(contextInfo: ContextInfo, state: String) {
+    val newContextInfo = contextInfo.copy(endTime = Option(DateTime.now()),
+        state = state)
+    logger.info(s"Updating the status to ${state} for context ${contextInfo.id} and jobs within")
+    daoActor ! JobDAOActor.SaveContextInfo(newContextInfo)
+    setStateForRunningJobs(contextInfo, state)
   }
 
-  private def setRestartingStateForRunningJobs(contextInfo: ContextInfo) {
+  private def setStateForRunningJobs(contextInfo: ContextInfo, state: String) {
     (daoActor ? JobDAOActor.GetJobInfosByContextId(
         contextInfo.id, Some(Seq(JobStatus.Running))))(daoAskTimeout).onComplete {
       case Success(JobDAOActor.JobInfos(Seq())) =>
@@ -321,8 +321,8 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
       case Success(JobDAOActor.JobInfos(jobInfos)) =>
         val error = ErrorData(JobManagerActor.ContextTerminatedException(contextInfo.id))
         jobInfos.foreach { jobInfo =>
-          logger.info(s"Found job ${jobInfo.jobId} for context. Setting state to Restarting.")
-          daoActor ! JobDAOActor.SaveJobInfo(jobInfo.copy(state = JobStatus.Restarting,
+          logger.info(s"Found job ${jobInfo.jobId} for context. Setting state to ${state}.")
+          daoActor ! JobDAOActor.SaveJobInfo(jobInfo.copy(state = state,
               endTime = Some(DateTime.now()), error = Some(error)))
         }
       case Failure(e: Exception) =>
@@ -387,18 +387,18 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
     val resp = getDataFromDAO[JobDAOActor.ContextResponse](JobDAOActor.GetContextInfo(managerActorName))
     resp match {
       case Some(JobDAOActor.ContextResponse(Some(context))) =>
-          val endTime = error match {
-            case None => context.endTime
-            case _ => Some(DateTime.now())
+          val contextInfo = ContextInfo(context.id,
+                                            context.name,
+                                            context.config,
+                                            clusterAddress,
+                                            context.startTime,
+                                            context.endTime,
+                                            state,
+                                            error)
+          error match {
+            case None => daoActor ! JobDAOActor.SaveContextInfo(contextInfo)
+            case _ => setStateForContextAndJobs(contextInfo, state)
           }
-          daoActor ! JobDAOActor.SaveContextInfo(ContextInfo(context.id,
-                                                  context.name,
-                                                  context.config,
-                                                  clusterAddress,
-                                                  context.startTime,
-                                                  endTime,
-                                                  state,
-                                                  error))
           None
       case Some(JobDAOActor.ContextResponse(None)) =>
           val e = new Throwable("Did not find context in the DB")

--- a/job-server/src/main/scala/spark/jobserver/JobStatusActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobStatusActor.scala
@@ -40,7 +40,7 @@ class JobStatusActor(jobDao: ActorRef) extends InstrumentedActor with YammerMetr
     val stopTime = DateTime.now()
     val stoppedInfos = infos.values.map { info =>
       val errorData = ErrorData(s"Context (${info.contextName}) for this job was terminated", "", "")
-      info.copy(endTime = Some(stopTime), error = Some(errorData))
+      info.copy(endTime = Some(stopTime), error = Some(errorData), state = JobStatus.Error)
     }
     stoppedInfos.foreach({info => jobDao ! JobDAOActor.SaveJobInfo(info)})
   }

--- a/job-server/src/main/scala/spark/jobserver/WebApi.scala
+++ b/job-server/src/main/scala/spark/jobserver/WebApi.scala
@@ -406,6 +406,9 @@ class WebApi(system: ActorSystem,
                     case ContextAlreadyExists => badRequest(ctx, "context " + contextName + " exists")
                     case ContextInitError(e) => ctx.complete(500, errMap(e, "CONTEXT INIT ERROR"));
                     case UnexpectedError => ctx.complete(500, errMap("UNEXPECTED ERROR OCCURRED"))
+                  }.recover {
+                    case e: Exception =>
+                      ctx.complete(500, errMap(e, "ERROR"));
                   }
                 }
               }
@@ -426,6 +429,9 @@ class WebApi(system: ActorSystem,
                 case NoSuchContext => notFound(ctx, "context " + contextName + " not found")
                 case ContextStopError(e) => ctx.complete(500, errMap(e, "CONTEXT DELETE ERROR"))
                 case UnexpectedError => ctx.complete(500, errMap("UNEXPECTED ERROR OCCURRED"))
+              }.recover {
+                case e: Exception =>
+                  ctx.complete(500, errMap(e, "ERROR"));
               }
             }
           }
@@ -519,6 +525,9 @@ class WebApi(system: ActorSystem,
               notFound(ctx, "No such job ID " + jobId)
             case cnf: Config =>
               ctx.complete(cnf.root().render(renderOptions))
+          }.recover {
+            case e: Exception =>
+              ctx.complete(500, errMap(e, "ERROR"));
           }
         }
       } ~
@@ -545,7 +554,13 @@ class WebApi(system: ActorSystem,
                     }
                   case _ =>
                     ctx.complete(jobReport)
+                }.recover {
+                  case e: Exception =>
+                    ctx.complete(500, errMap(e, "ERROR"));
                 }
+            }.recover {
+              case e: Exception =>
+                ctx.complete(500, errMap(e, "ERROR"));
             }
           }
         } ~
@@ -572,6 +587,9 @@ class WebApi(system: ActorSystem,
                 if (state.equals(JobStatus.Finished) || state.equals(JobStatus.Killed)) =>
                 notFound(ctx, "No running job with ID " + jobId)
               case _ => ctx.complete(500, errMap("Received an unexpected message"))
+            }.recover {
+              case e: Exception =>
+                ctx.complete(500, errMap(e, "ERROR"));
             }
           }
         } ~

--- a/job-server/src/main/scala/spark/jobserver/util/ManagerLauncher.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/ManagerLauncher.scala
@@ -38,11 +38,13 @@ class ManagerLauncher(systemConfig: Config, contextConfig: Config,
       defaultSuperviseModeEnabled, contextSuperviseModeEnabled)
 
   override def addCustomArguments() {
+      val gcFileName = getEnvironmentVariable("GC_OUT_FILE_NAME", "gc.out")
       if (deployMode == "client") {
-        val gcFilePath = new File(contextDir,
-            getEnvironmentVariable("GC_OUT_FILE_NAME", "gc.out")).toString()
+        val gcFilePath = new File(contextDir, gcFileName).toString()
         loggingOpts += s" -DLOG_DIR=$contextDir"
         gcOPTS += s" -Xloggc:$gcFilePath"
+      } else {
+        gcOPTS += s" -Xloggc:$gcFileName"
       }
 
       val contextSparkMaster = Try(contextConfig.getString("launcher.spark.master"))

--- a/job-server/src/test/scala/spark/jobserver/io/JobCassandraDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/JobCassandraDAOSpec.scala
@@ -497,8 +497,7 @@ class JobCassandraDAOSpec extends TestJarFinder with FunSpecLike with Matchers w
       contexts should be (orderedExpectedList)
 
       orderedExpectedList = Seq(contextInfo5, contextInfo2)
-      .sortBy(_.id)
-      .sortBy(_.startTime.getMillis)(Desc)
+          .sortBy(_.startTime.getMillis)(Desc)
 
       contexts = Await.result(
           dao.getContextInfos(Some(2), Some(Seq(ContextStatus.Running, ContextStatus.Restarting))), timeout)

--- a/job-server/src/test/scala/spark/jobserver/util/ManagerLauncherSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/util/ManagerLauncherSpec.scala
@@ -210,6 +210,26 @@ class ManagerLauncherSpec extends FunSpec with Matchers with BeforeAndAfter {
 
        stubbedSparkLauncher.getLauncherConfig().containsValue(StubbedSparkLauncher.SPARK_DRIVER_SUPERVISE, "--supervise") should be (false)
      }
+
+     it("should write gc logs to current execution directory in cluster/supervise mode") {
+       val systemConfMap = Map("spark.master" -> "yarn", "spark.submit.deployMode" -> "cluster")
+       val launcher = new ManagerLauncher(buildConfig(systemConfMap), baseContextConf, "", "", "", stubbedSparkLauncher, environment)
+
+       launcher.start()
+
+       val driverOptions = stubbedSparkLauncher.getLauncherConfig().get("--driver-java-options").asInstanceOf[java.util.ArrayList[String]]
+       driverOptions.get(0).trim() should be("-Xloggc:gc.out")
+     }
+
+     it("should write gc logs to directory passed as argument (client mode scenario)") {
+       val systemConfMap = Map("spark.master" -> "yarn", "spark.submit.deployMode" -> "client")
+       val launcher = new ManagerLauncher(buildConfig(systemConfMap), baseContextConf, "", "", "/test/directory", stubbedSparkLauncher, environment)
+
+       launcher.start()
+
+       val driverOptions = stubbedSparkLauncher.getLauncherConfig().get("--driver-java-options").asInstanceOf[java.util.ArrayList[String]]
+       driverOptions.get(0).trim() should be("-Xloggc:/test/directory/gc.out   -DLOG_DIR=/test/directory")
+     }
    }
 }
 


### PR DESCRIPTION
This PR contains various fixes, which aren't worth to be requested in separate PRs.

**Pull Request checklist**

- [ X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [ X] Tests for the changes have been added (for bug fixes / features) ?
- [ X] Docs have been added / updated (for bug fixes / features) ?

**New behavior :**
* The state of jobs with unprocessed states on context termination will be set to error.

* If a context will be deleted, the context status will always be changed to "STOPPING" state if the information and reference of this context is found. But the state should not be changed if it is a final state (we define final states as "FINISHED", "ERROR" and "KILLED").

* If supervise mode is enabled and context comes up, than ActorIdentity message is sent. If AkkaClusterSupervisor receives it, it is trying to reinitialize this context properly. Some times this reinitialization fails. In this case context will be killed and state ERROR will be written in the DB. But for the jobs inside this context nothing was done. This change adds also the functionality to change the states of the jobs of an errored out context to an ERROR state.

Status of jobs which are not is set to error, if the related context terminates an

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1085)
<!-- Reviewable:end -->
