### PR TITLE
feat(jobserver): return also information from db for GET context/<name>

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -184,23 +184,24 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
       val originator = sender
       val resp = getContextByName(name)
       resp match {
-        case Some(JobDAOActor.ContextResponse(Some(c))) =>
-          val contextActorRef = getActorRef(c)
+        case Some(JobDAOActor.ContextResponse(Some(contextInfo))) =>
+          val contextActorRef = getActorRef(contextInfo)
           contextActorRef match {
             case Some(ref) => val future = (ref ? GetContexData)(30.seconds)
               future.collect {
                 case ContexData(appId, Some(webUi)) =>
-                  originator ! SparkContexData(name, appId, Some(webUi))
+                  originator ! SparkContexData(contextInfo, Some(appId), Some(webUi))
                 case ContexData(appId, None) =>
-                  originator ! SparkContexData(name, appId, None)
+                  originator ! SparkContexData(contextInfo, Some(appId), None)
                 case SparkContextDead =>
-                  logger.info("SparkContext {} is dead", name)
-                  originator ! NoSuchContext
+                  originator ! SparkContexData(contextInfo, None, None)
+              }.recover {
+                case e: Exception => originator ! SparkContexData(contextInfo, None, None)
               }
-            case None => sender ! NoSuchContext
+            case None => originator ! SparkContexData(contextInfo, None, None)
           }
-        case Some(JobDAOActor.ContextResponse(None)) => sender ! NoSuchContext
-        case None => sender ! UnexpectedError
+        case Some(JobDAOActor.ContextResponse(None)) => originator ! NoSuchContext
+        case None => originator ! UnexpectedError
       }
 
     case AddContext(name, contextConfig) =>

--- a/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
@@ -37,7 +37,7 @@ object ContextSupervisor {
   case object ContextAlreadyExists
   case object NoSuchContext
   case object ContextStopped
-  case class SparkContexData(name: String, appId: String, url: Option[String])
+  case class SparkContexData[T](context: T, appId: Option[String], url: Option[String])
   case object UnexpectedError
 }
 
@@ -105,8 +105,8 @@ class LocalContextSupervisorActor(dao: ActorRef, dataManagerActor: ActorRef) ext
           val originator = sender
           future.collect {
             case ContexData(appId, Some(webUi)) =>
-              originator ! SparkContexData(name, appId, Some(webUi))
-            case ContexData(appId, None) => originator ! SparkContexData(name, appId, None)
+              originator ! SparkContexData(name, Some(appId), Some(webUi))
+            case ContexData(appId, None) => originator ! SparkContexData(name, Some(appId), None)
             case SparkContextDead =>
               logger.info("SparkContext {} is dead", name)
               originator ! NoSuchContext

--- a/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
@@ -364,15 +364,14 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
       supervisor ! AddContext("test-context10", configWithContextInfo)
       expectMsg(contextInitTimeout, ContextInitialized)
 
+      val cont = Await.result(dao.getContextInfoByName("test-context10"), (3 seconds)).get
+
       supervisor ! GetSparkContexData("test-context10")
-      expectMsg(SparkContexData("test-context10", "appId-dummy", Some("dummy-url")))
+      expectMsg(SparkContexData(cont, Some("appId-dummy"), Some("dummy-url")))
     }
 
-    it("should return NoSuchContext if the context is dead") {
-      supervisor ! AddContext("test-context11", contextConfig)
-      expectMsg(contextInitTimeout, ContextInitialized)
-
-      supervisor ! GetSparkContexData("test-context11")
+    it("should return NoSuchContext if the context does not exist") {
+      supervisor ! GetSparkContexData("test-context-does-not-exist")
       // JobManagerActor Stub by default return NoSuchContext
       expectMsg(NoSuchContext)
     }

--- a/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
@@ -137,6 +137,7 @@ class StubbedJobManagerActor(contextConfig: Config) extends Actor {
       val appId = Try(contextConfig.getString("manager.context.appId")).getOrElse("")
       val webUiUrl = Try(contextConfig.getString("manager.context.webUiUrl")).getOrElse("")
       (appId, webUiUrl) match {
+        case ("Error", _) => sender() ! new Throwable("Some Exception")
         case ("", "") => sender() ! JobManagerActor.SparkContextDead
         case (_, "") => sender() ! JobManagerActor.ContexData(appId, None)
         case (_, _) => sender() ! JobManagerActor.ContexData(appId, Some(webUiUrl))
@@ -364,10 +365,53 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
       supervisor ! AddContext("test-context10", configWithContextInfo)
       expectMsg(contextInitTimeout, ContextInitialized)
 
-      val cont = Await.result(dao.getContextInfoByName("test-context10"), (3 seconds)).get
+      val context = Await.result(dao.getContextInfoByName("test-context10"), (3 seconds)).get
 
       supervisor ! GetSparkContexData("test-context10")
-      expectMsg(SparkContexData(cont, Some("appId-dummy"), Some("dummy-url")))
+      expectMsg(SparkContexData(context, Some("appId-dummy"), Some("dummy-url")))
+    }
+
+    it("should return valid contextInfo, appId but no webUiUrl") {
+      val configWithContextInfo = ConfigFactory.parseString("manager.context.appId=appId-dummy")
+                .withFallback(contextConfig)
+      supervisor ! AddContext("test-context11", configWithContextInfo)
+      expectMsg(contextInitTimeout, ContextInitialized)
+
+      val context = Await.result(dao.getContextInfoByName("test-context11"), (3 seconds)).get
+
+      supervisor ! GetSparkContexData("test-context11")
+      expectMsg(SparkContexData(context, Some("appId-dummy"), None))
+    }
+
+    it("should return valid contextInfo and no appId or webUiUrl if SparkContextDead is received") {
+      val configWithContextInfo = ConfigFactory.parseString("")
+                .withFallback(contextConfig)
+      supervisor ! AddContext("test-context12", configWithContextInfo)
+      expectMsg(contextInitTimeout, ContextInitialized)
+
+      val context = Await.result(dao.getContextInfoByName("test-context12"), (3 seconds)).get
+
+      supervisor ! GetSparkContexData("test-context12")
+      expectMsg(SparkContexData(context, None, None))
+    }
+
+    it("should return valid contextInfo and no appId or webUiUrl if Expception occurs") {
+      val configWithContextInfo = ConfigFactory.parseString("manager.context.appId=Error")
+                .withFallback(contextConfig)
+      supervisor ! AddContext("test-context13", configWithContextInfo)
+      expectMsg(contextInitTimeout, ContextInitialized)
+
+      val context = Await.result(dao.getContextInfoByName("test-context13"), (3 seconds)).get
+
+      supervisor ! GetSparkContexData("test-context13")
+      expectMsg(SparkContexData(context, None, None))
+    }
+
+    it("should return UnexpectedError if a problem with db happens") {
+      supervisor ! StubbedAkkaClusterSupervisorActor.DisableDAOCommunication // Simulate DAO failure
+      supervisor ! GetSparkContexData("test-context14")
+      expectMsg(UnexpectedError)
+      supervisor ! StubbedAkkaClusterSupervisorActor.EnableDAOCommunication
     }
 
     it("should return NoSuchContext if the context does not exist") {

--- a/job-server/src/test/scala/spark/jobserver/WebApiMainRoutesSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiMainRoutesSpec.scala
@@ -515,7 +515,7 @@ class WebApiMainRoutesSpec extends WebApiSpec {
       Get("/contexts/context1") ~> sealRoute(routes) ~> check {
         status should be (OK)
         responseAs[Map[String, String]] should be (Map(
-            "context" -> "context1",
+            "name" -> "context1",
             "applicationId" -> "local-1337",
             "url" -> "http://spark:4040"))
       }
@@ -523,7 +523,7 @@ class WebApiMainRoutesSpec extends WebApiSpec {
     it("should return context information if context/id is called (without context UI url)") {
       Get("/contexts/context2") ~> sealRoute(routes) ~> check {
         status should be (OK)
-        responseAs[Map[String, String]] should be (Map("context" -> "context2", "applicationId" -> "local-1337"))
+        responseAs[Map[String, String]] should be (Map("name" -> "context2", "applicationId" -> "local-1337"))
       }
     }
   }

--- a/job-server/src/test/scala/spark/jobserver/WebApiMainRoutesSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiMainRoutesSpec.scala
@@ -4,7 +4,7 @@ import com.typesafe.config.ConfigFactory
 import spark.jobserver.io.BinaryType
 import spray.http.{MediaTypes, HttpHeaders, HttpHeader}
 import spray.http.StatusCodes._
-import spark.jobserver.io.JobStatus
+import spark.jobserver.io.{JobStatus, ContextStatus}
 import spark.jobserver.util.SparkJobUtils
 
 // Tests web response codes and formatting
@@ -35,9 +35,11 @@ class WebApiMainRoutesSpec extends WebApiSpec {
       }
     }
 
-    it("should respond with OK if jar uploaded successfully") {
+    it("should respond with OK and meaningful message if jar uploaded successfully") {
       Post("/jars/foobar", Array[Byte](0, 1, 2)) ~> sealRoute(routes) ~> check {
         status should be (OK)
+        val result = responseAs[Map[String, String]]
+        result(ResultKey) should equal("Jar uploaded")
       }
     }
 
@@ -329,9 +331,11 @@ class WebApiMainRoutesSpec extends WebApiSpec {
       }
     }
 
-    it("should respond with 404 Not Found from /jobs/<id> route if status of jobId does not exist") {
+    it("should respond with 404 Not Found and meaningful message if status of jobId does not exist") {
       Get("/jobs/_no_status") ~> sealRoute(routes) ~> check {
         status should be (NotFound)
+        val result = responseAs[Map[String, String]]
+        result(ResultKey) should startWith ("No such job ID ")
       }
     }
 
@@ -463,9 +467,54 @@ class WebApiMainRoutesSpec extends WebApiSpec {
       }
     }
 
-    it("should respond with 404 Not Found if stopping unknown context") {
-      Delete("/contexts/none", "") ~> sealRoute(routes) ~> check {
-        status should be (NotFound)
+    it("should return context information with context UI url (local mode)") {
+      Get("/contexts/context1") ~> sealRoute(routes) ~> check {
+        status should be (OK)
+        responseAs[Map[String, String]] should be (Map(
+            "name" -> "context1",
+            "applicationId" -> "local-1337",
+            "url" -> "http://spark:4040"))
+      }
+    }
+
+    it("should return context information without context UI url (local mode)") {
+      Get("/contexts/context2") ~> sealRoute(routes) ~> check {
+        status should be (OK)
+        responseAs[Map[String, String]] should be (Map(
+            "name" -> "context2",
+            "applicationId" -> "local-1337"))
+      }
+    }
+
+    it("should return valid contextInfo for running context (cluster/client mode)") {
+      Get("/contexts/contextWithInfo") ~> sealRoute(routes) ~> check {
+        status should be (OK)
+        responseAs[Map[String, String]] should be (Map("name" -> "contextWithInfo",
+                                                       "applicationId" -> "local-1337",
+                                                       "url" -> "http://spark:4040",
+                                                       "state" -> ContextStatus.Running,
+                                                       "id" -> "contextId",
+                                                       "endTime" -> "Empty",
+                                                       "startTime" -> "2013-05-29T00:00:00.000Z"))
+      }
+    }
+
+    it("should return valid contextInfo for finished context (cluster/client mode)") {
+      Get("/contexts/finishedContextWithInfo") ~> sealRoute(routes) ~> check {
+        status should be (OK)
+        responseAs[Map[String, String]] should be (Map("name" -> "finishedContextWithInfo",
+                                                       "state" -> ContextStatus.Finished,
+                                                       "id" -> "contextId",
+                                                       "endTime" -> "2013-05-29T00:05:00.000Z",
+                                                       "startTime" -> "2013-05-29T00:00:00.000Z"))
+      }
+    }
+
+    it("should respond with InternalServerError if unexpected error occurs at getting context") {
+      Get("/contexts/unexp-err", "") ~> sealRoute(routes) ~> check {
+        status should be (InternalServerError)
+        val result = responseAs[Map[String, Any]]
+        result(ResultKey) should equal("UNEXPECTED ERROR OCCURRED")
       }
     }
 
@@ -475,10 +524,36 @@ class WebApiMainRoutesSpec extends WebApiSpec {
         status should be(OK)
       }
     }
-    
+
     it("should return OK if stopping known context") {
       Delete("/contexts/one", "") ~> sealRoute(routes) ~> check {
         status should be (OK)
+        val result = responseAs[Map[String, String]]
+        result(ResultKey) should equal("Context stopped")
+      }
+    }
+
+    it("should respond with InternalServerError if timeout occurs on a delete request") {
+      Delete("/contexts/timeout-ctx", "") ~> sealRoute(routes) ~> check {
+        status should be (InternalServerError)
+        val result = responseAs[Map[String, Any]]
+        result(StatusKey) should equal("CONTEXT DELETE ERROR")
+      }
+    }
+
+    it("should respond with 404 Not Found if stopping unknown context") {
+      Delete("/contexts/none", "") ~> sealRoute(routes) ~> check {
+        status should be (NotFound)
+        val result = responseAs[Map[String, String]]
+        result(ResultKey) should equal("context none not found")
+      }
+    }
+
+    it("should respond with InternalServerError if unexpected error occurs at deleting context") {
+      Delete("/contexts/unexp-err", "") ~> sealRoute(routes) ~> check {
+        status should be (InternalServerError)
+        val result = responseAs[Map[String, Any]]
+        result(ResultKey) should equal("UNEXPECTED ERROR OCCURRED")
       }
     }
 
@@ -487,15 +562,20 @@ class WebApiMainRoutesSpec extends WebApiSpec {
         status should be (BadRequest)
         val result = responseAs[Map[String, String]]
         result(StatusKey) should equal(JobStatus.Error)
+        result(ResultKey) should equal("context one exists")
       }
     }
 
     it("should return OK if starting a new context") {
       Post("/contexts/meme?num-cpu-cores=3") ~> sealRoute(routes) ~> check {
         status should be (OK)
+        val result = responseAs[Map[String, String]]
+        result(ResultKey) should equal("Context initialized")
       }
       Post("/contexts/meme?num-cpu-cores=3&coarse-mesos-mode=true") ~> sealRoute(routes) ~> check {
         status should be (OK)
+        val result = responseAs[Map[String, String]]
+        result(ResultKey) should equal("Context initialized")
       }
     }
 
@@ -511,19 +591,19 @@ class WebApiMainRoutesSpec extends WebApiSpec {
       }
     }
 
-    it("should return context information if context/id is called (with context UI url)") {
-      Get("/contexts/context1") ~> sealRoute(routes) ~> check {
-        status should be (OK)
-        responseAs[Map[String, String]] should be (Map(
-            "name" -> "context1",
-            "applicationId" -> "local-1337",
-            "url" -> "http://spark:4040"))
+    it("should respond with InternalServerError if initialization error occurs") {
+      Post("/contexts/initError-ctx", "") ~> sealRoute(routes) ~> check {
+        status should be (InternalServerError)
+        val result = responseAs[Map[String, Any]]
+        result(StatusKey) should equal("CONTEXT INIT ERROR")
       }
     }
-    it("should return context information if context/id is called (without context UI url)") {
-      Get("/contexts/context2") ~> sealRoute(routes) ~> check {
-        status should be (OK)
-        responseAs[Map[String, String]] should be (Map("name" -> "context2", "applicationId" -> "local-1337"))
+
+    it("should respond with InternalServerError if unexpected error occurs at adding context") {
+      Post("/contexts/unexp-err", "") ~> sealRoute(routes) ~> check {
+        status should be (InternalServerError)
+        val result = responseAs[Map[String, Any]]
+        result(ResultKey) should equal("UNEXPECTED ERROR OCCURRED")
       }
     }
   }

--- a/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
@@ -70,6 +70,12 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
   val JobId = "jobId"
   val StatusKey = "status"
   val ResultKey = "result"
+
+  val contextInfo = ContextInfo("contextId", "contextWithInfo", "config", Some("address"), dt, None,
+      ContextStatus.Running, None)
+  val finishedContextInfo = contextInfo.copy(name = "finishedContextWithInfo",
+      endTime = Some(dt.plusMinutes(5)), state = ContextStatus.Finished)
+
   class DummyActor extends Actor {
 
     import CommonMessages._
@@ -131,8 +137,6 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
         }
       }
 
-
-
       case ListBinaries(Some(BinaryType.Jar)) =>
         sender ! Map("demo1" -> (BinaryType.Jar, dt), "demo2" -> (BinaryType.Jar, dt.plusHours(1)))
 
@@ -160,7 +164,7 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
 
       case ListContexts =>  sender ! Seq("context1", "context2")
       case StopContext("none") => sender ! NoSuchContext
-      case StopContext("timeout-ctx") => sender ! ContextStopError(new Throwable)
+      case StopContext("timeout-ctx") => sender ! ContextStopError(new Throwable("Some Throwable"))
       case StopContext("unexp-err") => sender ! UnexpectedError
       case StopContext(_)      => sender ! ContextStopped
       case AddContext("one", _) => sender ! ContextAlreadyExists
@@ -171,7 +175,7 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
         c.getInt("num-cpu-cores") should be(2)
         c.getInt("override_me") should be(3)
         sender ! ContextInitialized
-      case AddContext("initError-ctx", _) => sender ! ContextInitError(new Throwable)
+      case AddContext("initError-ctx", _) => sender ! ContextInitError(new Throwable("Some Throwable"))
       case AddContext("unexp-err", _) => sender ! UnexpectedError
       case AddContext(_, _)     => sender ! ContextInitialized
 
@@ -216,19 +220,13 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
       case GetSparkContexData("context1") => sender ! SparkContexData("context1", Some("local-1337"), Some("http://spark:4040"))
       case GetSparkContexData("context2") => sender ! SparkContexData("context2", Some("local-1337"), None)
       case GetSparkContexData("unexp-err") => sender ! UnexpectedError
-    }
-  }
 
-  private def unexpectedErrorHelpFunction(curlCommand: HttpRequest) {
-    val p = sendReceive ~> unmarshal[JobServerResponse]
-      val valid:Future[JobServerResponse] = p(curlCommand)
-      Await.ready(valid, Duration.create(1, TimeUnit.SECONDS)).value.get match {
-        case Success(_) => fail("Should return an exception")
-        case Failure(r: UnsuccessfulResponseException) =>
-          r.response.status.intValue shouldBe 500
-          r.response.status.isFailure shouldBe true
-        case Failure(_) => fail("Should return an UnsuccessfulResponseException")
-      }
+      // On a GetSparkContexData LocalContextSupervisorActor returns only name of the context, api and url,
+      // AkkaClusterSupervisorActor returns whole contextInfo instead.
+      // Adding extra cases to test both
+      case GetSparkContexData("contextWithInfo") => sender ! SparkContexData(contextInfo, Some("local-1337"), Some("http://spark:4040"))
+      case GetSparkContexData("finishedContextWithInfo") => sender ! SparkContexData(finishedContextInfo, None, None)
+    }
   }
 
   implicit override val patienceConfig =
@@ -246,60 +244,6 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
 
     val jsonContentType = HttpHeaders.`Content-Type`(ContentType(MediaTypes.`application/json`))
 
-    it ("Should return valid JSON when a jar is uploaded successfully") {
-      val p = sendReceive ~> unmarshal[JobServerResponse]
-      val valid:Future[JobServerResponse] = p(Post("http://127.0.0.1:9999/jars/test-app","valid"))
-      whenReady(valid) { r=>
-        r.isSuccess shouldBe true
-        r.status shouldBe "SUCCESS"
-        r.result shouldBe "Jar uploaded"
-      }
-    }
-
-    it ("Should return valid JSON when creating a context") {
-      val p = sendReceive ~> unmarshal[JobServerResponse]
-      val valid:Future[JobServerResponse] = p(Post("http://127.0.0.1:9999/contexts/test-ctx","{}"))
-      whenReady(valid) { r=>
-        r.isSuccess shouldBe true
-        r.status shouldBe "SUCCESS"
-        r.result shouldBe "Context initialized"
-      }
-    }
-
-    it ("Should return an error when actor returns ContextInitError") {
-      val p = sendReceive ~> unmarshal[JobServerResponse]
-      val valid:Future[JobServerResponse] = p(Post("http://127.0.0.1:9999/contexts/initError-ctx"))
-      Await.ready(valid, Duration.create(1, TimeUnit.SECONDS)).value.get match {
-        case Success(_) => fail("Should return an exception")
-        case Failure(r: UnsuccessfulResponseException) =>
-          r.response.status.intValue shouldBe 500
-          r.response.status.isFailure shouldBe true
-        case Failure(_) => fail("Should return an UnsuccessfulResponseException")
-      }
-    }
-
-    it ("Should return valid JSON when stopping a context") {
-      val p = sendReceive ~> unmarshal[JobServerResponse]
-      val valid:Future[JobServerResponse] = p(Delete("http://127.0.0.1:9999/contexts/test-ctx"))
-      whenReady(valid) { r=>
-        r.isSuccess shouldBe true
-        r.status shouldBe "SUCCESS"
-        r.result shouldBe "Context stopped"
-      }
-    }
-
-    it ("Should return an error when stopping a context times out") {
-      val p = sendReceive ~> unmarshal[JobServerResponse]
-      val valid:Future[JobServerResponse] = p(Delete("http://127.0.0.1:9999/contexts/timeout-ctx"))
-      Await.ready(valid, Duration.create(1, TimeUnit.SECONDS)).value.get match {
-        case Success(_) => fail("Should return an exception")
-        case Failure(r: UnsuccessfulResponseException) =>
-          r.response.status.intValue shouldBe 500
-          r.response.status.isFailure shouldBe true
-        case Failure(_) => fail("Should return an UnsuccessfulResponseException")
-      }
-    }
-
     it ("Should return valid JSON when resetting a context") {
       val p = sendReceive ~> unmarshal[JobServerResponse]
       val valid:Future[JobServerResponse] = p(Put("http://127.0.0.1:9999/contexts?reset=reboot"))
@@ -309,17 +253,6 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
         r.result shouldBe "Context reset"
       }
     }
-
-    it ("Should return an error when unexpected error occures at adding context") {
-      unexpectedErrorHelpFunction(Post("http://127.0.0.1:9999/contexts/unexp-err"))
-    }
-
-    it ("Should return an error when unexpected error occures at deleting context") {
-      unexpectedErrorHelpFunction(Delete("http://127.0.0.1:9999/contexts/unexp-err"))
-    }
-
-    it ("Should return an error when unexpected error occures at getting context") {
-      unexpectedErrorHelpFunction(Get("http://127.0.0.1:9999/contexts/unexp-err"))
-    }
   }
+
 }

--- a/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
@@ -213,8 +213,8 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
       case StoreJobConfig(_, _) => sender ! JobConfigStored
       case KillJob(jobId) => sender ! JobKilled(jobId, DateTime.now())
 
-      case GetSparkContexData("context1") => sender ! SparkContexData("context1", "local-1337", Some("http://spark:4040"))
-      case GetSparkContexData("context2") => sender ! SparkContexData("context2", "local-1337", None)
+      case GetSparkContexData("context1") => sender ! SparkContexData("context1", Some("local-1337"), Some("http://spark:4040"))
+      case GetSparkContexData("context2") => sender ! SparkContexData("context2", Some("local-1337"), None)
       case GetSparkContexData("unexp-err") => sender ! UnexpectedError
     }
   }


### PR DESCRIPTION
**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?
- [X] Docs have been added / updated (for bug fixes / features) ?

**New behavior :**
The response of GET context/<name> contains now the whole context object from the database except the context configuration.


**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1089)
<!-- Reviewable:end -->
