### PR TITLE
feat(job-server): revert wrapping all exceptions in the RuntimeException

### DIFF
--- a/job-server/src/test/scala/spark/jobserver/JavaJobSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JavaJobSpec.scala
@@ -69,7 +69,7 @@ class JavaJobSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) {
       uploadTestJar()
       manager ! JobManagerActor.StartJob("demo", failedJob, config, errorEvents)
       expectMsgPF(6 seconds, "Gets correct exception"){
-        case JobErroredOut(_, _, ex) => ex.getMessage should equal("java.lang.RuntimeException: fail")
+        case JobErroredOut(_, _, ex) => ex.getMessage should equal("fail")
       }
     }
   }

--- a/job-server/src/test/scala/spark/jobserver/JobManagerActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobManagerActorSpec.scala
@@ -194,7 +194,7 @@ class JobManagerActorSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) 
       uploadTestJar()
       manager ! JobManagerActor.StartJob("demo", classPrefix + "MyErrorJob", emptyConfig, errorEvents)
       val errorMsg = expectMsgClass(startJobWait, classOf[JobErroredOut])
-      errorMsg.err.getClass should equal (classOf[RuntimeException])
+      errorMsg.err.getClass should equal (classOf[IllegalArgumentException])
     }
 
     it("job should get jobConfig passed in to StartJob message") {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

**Current behavior:**

Every job exceptions wrap in the RuntimeException.

**New behavior:**

Exception remains unchanged.

**Other information**:

This is the fix for #989 All changes are just revert of #408 In the issue I asked about motivation behind #408, but I got no answer. So, I assume that I could just revert this changes, If there is no real motivation behind them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1091)
<!-- Reviewable:end -->
