### PR TITLE
Introduce rejoin logic to form only one akka cluster

### DIFF
--- a/job-server-api/src/main/scala/spark/jobserver/util/SparkJobUtils.scala
+++ b/job-server-api/src/main/scala/spark/jobserver/util/SparkJobUtils.scala
@@ -150,4 +150,8 @@ object SparkJobUtils {
     getContextTimeout(config, "spark.jobserver.yarn-context-deletion-timeout",
       "spark.jobserver.context-deletion-timeout")
   }
+
+  def getForkedJVMInitTimeout(config: Config): Long = {
+    config.getDuration("spark.context-settings.forked-jvm-init-timeout", TimeUnit.SECONDS)
+  }
 }

--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -149,6 +149,9 @@ spark {
     # uris of jars to be loaded into the classpath for this context. Uris is a string list, or a string separated by commas ','
     # dependent-jar-uris = ["file:///some/path/present/in/each/mesos/slave/somepackage.jar"]
 
+    # Timeout for forked JVM to spin up and acquire resources
+    forked-jvm-init-timeout = 30s
+
     # Timeout for SupervisorActor to wait for forked (separate JVM) contexts to initialize
     context-init-timeout = 60s
 

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -309,6 +309,12 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef,
         case None =>
       }
     }
+
+    case RegainWatchOnExistingContexts(actorRefs) =>
+      actorRefs.map { ref =>
+        logger.info(s"Regaining watch on existing context with address ${ref.path.address.toString}")
+        context.watch(ref)
+      }
   }
 
   protected def handleTerminatedEvent(actorRef: ActorRef) {

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -27,6 +27,7 @@ import spark.jobserver.JobManagerActor.ContextTerminatedException
 import spark.jobserver.io.{JobDAOActor, ContextInfo, ContextStatus, JobStatus, ErrorData}
 import spark.jobserver.util.{InternalServerErrorException, NoCallbackFoundException,
   ContextJVMInitializationTimeout}
+import com.google.common.annotations.VisibleForTesting
 
 object AkkaClusterSupervisorActor {
   val MANAGER_ACTOR_PREFIX = "jobManager-"
@@ -144,8 +145,8 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef,
             getDataFromDAO[JobDAOActor.ContextResponse](JobDAOActor.GetContextInfo(contextId))
           val callbacks = contextInitInfos.remove(actorName)
           (contextFromDAO, callbacks) match {
-            case (Some(JobDAOActor.ContextResponse(Some(contextInfo))), Some((_, _, _)))
-                if isContextErroredOut(contextInfo) =>
+            case (Some(JobDAOActor.ContextResponse(Some(contextInfo))), _)
+                if isContextInFinalState(contextInfo) =>
               logger.info(s"Context forked JVM (${contextInfo.name}) already errored out. Killing it.")
               actorRef ! PoisonPill
             case (Some(JobDAOActor.ContextResponse(Some(contextInfo))),
@@ -275,7 +276,7 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef,
       resp match {
         case Some(JobDAOActor.ContextResponse(Some(c))) =>
           logger.info("Shutting down context {}", name)
-          val state = if (FINAL_STATES contains c.state) c.state else ContextStatus.Stopping
+          val state = if (ContextStatus.getFinalStates() contains c.state) c.state else ContextStatus.Stopping
           val contextInfo = ContextInfo(c.id, c.name, c.config, c.actorAddress, c.startTime,
             c.endTime, state, c.error)
           daoActor ! JobDAOActor.SaveContextInfo(contextInfo)
@@ -566,10 +567,8 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef,
     logger.info(s"Scheduled message has been cancelled: ${cancelHandler.isCancelled.toString()}")
   }
 
-  private def isContextErroredOut(contextInfo: ContextInfo): Boolean = {
-    contextInfo.state match {
-      case ContextStatus.Error => true
-      case _ => false
-    }
+  @VisibleForTesting
+  protected def isContextInFinalState(contextInfo: ContextInfo): Boolean = {
+    ContextStatus.getFinalStates().contains(contextInfo.state)
   }
 }

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -9,6 +9,7 @@ import akka.pattern.ask
 import akka.cluster.Cluster
 import akka.cluster.ClusterEvent.{MemberUp, CurrentClusterState}
 import akka.util.Timeout
+
 import com.typesafe.config.{Config, ConfigFactory, ConfigRenderOptions}
 import spark.jobserver.util.{SparkJobUtils, ManagerLauncher}
 
@@ -24,7 +25,8 @@ import org.slf4j.LoggerFactory
 import spark.jobserver.JobManagerActor.{GetContexData, ContexData, SparkContextDead, RestartExistingJobs}
 import spark.jobserver.JobManagerActor.ContextTerminatedException
 import spark.jobserver.io.{JobDAOActor, ContextInfo, ContextStatus, JobStatus, ErrorData}
-import spark.jobserver.util.{InternalServerErrorException, NoCallbackFoundException}
+import spark.jobserver.util.{InternalServerErrorException, NoCallbackFoundException,
+  ContextJVMInitializationTimeout}
 
 object AkkaClusterSupervisorActor {
   val MANAGER_ACTOR_PREFIX = "jobManager-"
@@ -51,13 +53,15 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef,
   val defaultContextConfig = config.getConfig("spark.context-settings")
   val contextInitTimeout = config.getDuration("spark.context-settings.context-init-timeout",
                                                 TimeUnit.SECONDS)
+  val forkedJVMInitTimeout = SparkJobUtils.getForkedJVMInitTimeout(config)
   val contextDeletionTimeout = SparkJobUtils.getContextDeletionTimeout(config)
   val daoAskTimeout = Timeout(config.getDuration("spark.jobserver.dao-timeout",
                                                 TimeUnit.SECONDS).second)
 
   import context.dispatcher
 
-  protected val contextInitInfos = mutable.HashMap.empty[String, (ActorRef => Unit, Throwable => Unit)]
+  protected val contextInitInfos = mutable.HashMap.empty[String,
+    (ActorRef => Unit, Throwable => Unit, Cancellable)]
 
   // actor name -> ResultActor ref
   private val resultActorRefs = mutable.HashMap.empty[String, ActorRef]
@@ -140,8 +144,13 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef,
             getDataFromDAO[JobDAOActor.ContextResponse](JobDAOActor.GetContextInfo(contextId))
           val callbacks = contextInitInfos.remove(actorName)
           (contextFromDAO, callbacks) match {
+            case (Some(JobDAOActor.ContextResponse(Some(contextInfo))), Some((_, _, _)))
+                if isContextErroredOut(contextInfo) =>
+              logger.info(s"Context forked JVM (${contextInfo.name}) already errored out. Killing it.")
+              actorRef ! PoisonPill
             case (Some(JobDAOActor.ContextResponse(Some(contextInfo))),
-                Some((successCallback, failureCallback))) =>
+                Some((successCallback, failureCallback, timeoutMsgCancelHandler))) =>
+              cancelScheduledMessage(timeoutMsgCancelHandler)
               initContext(contextInfo, actorName, actorRef, false)(successCallback, failureCallback)
             case (Some(JobDAOActor.ContextResponse(None)), _) =>
               logger.error(
@@ -167,7 +176,8 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef,
                   daoActor ! JobDAOActor.SaveContextInfo(contextInfo.copy(
                       state = ContextStatus.Error, endTime = Some(DateTime.now()), error = Some(exception)))
               }
-            case (None, Some((_, failureCallback))) =>
+            case (None, Some((_, failureCallback, timeoutMsgCancelHandler))) =>
+              cancelScheduledMessage(timeoutMsgCancelHandler)
               val exception = InternalServerErrorException(contextId)
               logger.error(exception.getMessage, exception)
               actorRef ! PoisonPill
@@ -289,6 +299,16 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef,
 
     case Terminated(actorRef) =>
       handleTerminatedEvent(actorRef)
+
+    case ForkedJVMInitTimeout(contextActorName, contextInfo: ContextInfo) => {
+      contextInitInfos.get(contextActorName) match {
+        case Some((successFunc, failureFunc, _)) =>
+          logger.warn(s"Context forked JVM failed to initialize for actor $contextActorName")
+          daoActor ! JobDAOActor.SaveContextInfo(contextInfo)
+          failureFunc(ContextJVMInitializationTimeout())
+        case None =>
+      }
+    }
   }
 
   protected def handleTerminatedEvent(actorRef: ActorRef) {
@@ -443,8 +463,23 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef,
         failureFunc(e)
         daoActor ! JobDAOActor.SaveContextInfo(contextInfo(ContextStatus.Error, Some(e)))
       case (true, _) =>
-        contextInitInfos(contextActorName) = (successFunc, failureFunc)
-        daoActor ! JobDAOActor.SaveContextInfo(contextInfo(ContextStatus.Started, None))
+        val timeoutMsg = ForkedJVMInitTimeout(contextActorName,
+             contextInfo(ContextStatus.Error, Some(ContextJVMInitializationTimeout())))
+        // Scheduler can throw IllegalStateException
+        Try(context.system.scheduler.scheduleOnce(forkedJVMInitTimeout.seconds, self, timeoutMsg)) match {
+          case Success(timeoutMsgCancelHandler) =>
+            logger.info("Scheduling a time out message for forked JVM")
+            daoActor ! JobDAOActor.SaveContextInfo(contextInfo(ContextStatus.Started, None))
+            contextInitInfos(contextActorName) = (successFunc, failureFunc, timeoutMsgCancelHandler)
+          case Failure(e) =>
+            logger.error("Failed to schedule a time out message for forked JVM", e)
+            daoActor ! JobDAOActor.SaveContextInfo(contextInfo(ContextStatus.Error, Some(e)))
+            val unusedCancellable = new Cancellable {
+              def cancel(): Boolean = { return false }
+              def isCancelled: Boolean = { return false }
+            }
+            contextInitInfos(contextActorName) = (successFunc, failureFunc, unusedCancellable)
+        }
     }
   }
 
@@ -518,5 +553,17 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef,
     val isAdhoc = contextConfig.getBoolean("is-adhoc")
     initContext(contextConfig, actorName,
            actorRef, contextInitTimeout, isRestartScenario)(isAdhoc, successCallback, failureCallback)
+  }
+
+  private def cancelScheduledMessage(cancelHandler: Cancellable) {
+    cancelHandler.cancel()
+    logger.info(s"Scheduled message has been cancelled: ${cancelHandler.isCancelled.toString()}")
+  }
+
+  private def isContextErroredOut(contextInfo: ContextInfo): Boolean = {
+    contextInfo.state match {
+      case ContextStatus.Error => true
+      case _ => false
+    }
   }
 }

--- a/job-server/src/main/scala/spark/jobserver/JobServer.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobServer.scala
@@ -4,6 +4,10 @@ import akka.actor.{ActorSystem, ActorRef, ActorContext, Props}
 
 import akka.util.Timeout
 import akka.pattern.ask
+import akka.cluster.Cluster
+import akka.cluster.ClusterEvent.{InitialStateAsEvents, MemberEvent}
+import akka.actor.AddressFromURIString
+
 import com.typesafe.config.{ConfigValueFactory, Config, ConfigFactory}
 import java.io.File
 import java.util.concurrent.TimeUnit
@@ -116,35 +120,68 @@ object JobServer {
     val dataFileDAO = new DataFileDAO(config)
     val dataManager = system.actorOf(Props(classOf[DataManagerActor], dataFileDAO), "data-manager")
     val binManager = system.actorOf(Props(classOf[BinaryManager], daoActor), "binary-manager")
-    val supervisor =
-      system.actorOf(Props(
-        if (contextPerJvm) {
-          classOf[AkkaClusterSupervisorActor]
-        } else {
-          classOf[LocalContextSupervisorActor]
-        },
-        daoActor, dataManager), "context-supervisor")
-    val jobInfo = system.actorOf(Props(classOf[JobInfoActor], jobDAO, supervisor), "job-info")
 
     // Add initial job JARs, if specified in configuration.
     storeInitialBinaries(config, binManager)
 
-    // Check if all contexts marked as running are still available
-    updateContextStatus(system, daoActor);
+    val webApiPF = new WebApi(system, config, port, binManager, dataManager, _: ActorRef, _: ActorRef)
+    contextPerJvm match {
+      case false =>
+        val supervisor = system.actorOf(Props(classOf[LocalContextSupervisorActor],
+            daoActor, dataManager), "context-supervisor")
+        supervisor ! ContextSupervisor.AddContextsFromConfig  // Create initial contexts
+        startWebApi(system, supervisor, jobDAO, webApiPF)
+      case true =>
+        val cluster = Cluster(system)
 
-    // Create initial contexts
-    supervisor ! ContextSupervisor.AddContextsFromConfig
-    new WebApi(system, config, port, binManager, dataManager, supervisor, jobInfo).start()
+        // Check if all contexts marked as running are still available and get the Akka address of
+        // one of the nodes which is already part of Akka cluster
+        val initialSeedNode = updateContextStatus(system, daoActor)
+        joinAkkaCluster(cluster, initialSeedNode)
+        // We don't want to read all the old events that happened in the cluster
+        // So, we remove the initialStateMode parameter
+        cluster.registerOnMemberUp {
+          val supervisor = system.actorOf(Props(classOf[AkkaClusterSupervisorActor],
+            daoActor, dataManager, cluster), "context-supervisor")
+
+          logger.info("Subscribing to MemberUp event")
+          cluster.subscribe(supervisor, classOf[MemberEvent])
+
+          supervisor ! ContextSupervisor.AddContextsFromConfig  // Create initial contexts
+          startWebApi(system, supervisor, jobDAO, webApiPF)
+        }
+    }
   }
 
-  def validateContext(
-      contextInfo: ContextInfo, system: ActorSystem, jobDaoActor: ActorRef)(implicit e: ExecutionContext) {
+  def startWebApi(system: ActorSystem, supervisor: ActorRef, jobDAO: JobDAO,
+      webApiPF: (ActorRef, ActorRef) => WebApi) {
+    val jobInfo = system.actorOf(Props(classOf[JobInfoActor], jobDAO, supervisor), "job-info")
+    webApiPF(supervisor, jobInfo).start()
+  }
+
+  def joinAkkaCluster(cluster: Cluster, initialSeedNode: Option[String]) {
+    initialSeedNode match {
+      case None =>
+        val selfAddress = cluster.selfAddress
+        logger.info(s"Joining newly created cluster at ${selfAddress}")
+        cluster.join(selfAddress)
+      case Some(address) =>
+        logger.info(s"Joining existing cluster at ${address}")
+        cluster.join(AddressFromURIString(address))
+    }
+  }
+
+  def validateContext(contextInfo: ContextInfo, system: ActorSystem,
+      jobDaoActor: ActorRef)(implicit e: ExecutionContext): Option[String] = {
     val finiteDuration = FiniteDuration(3, SECONDS)
-    val address = contextInfo.actorAddress.get + "/user/" + AkkaClusterSupervisorActor.MANAGER_ACTOR_PREFIX +
+    val clusterAddress = contextInfo.actorAddress.get
+    val address = clusterAddress + "/user/" + AkkaClusterSupervisorActor.MANAGER_ACTOR_PREFIX +
         contextInfo.id
     val actorFut = Await.ready(system.actorSelection(address).resolveOne(finiteDuration), finiteDuration)
     actorFut.value.get match {
-      case Success(actorRef) => logger.info(s"Found context ${contextInfo.name} -> reconnect is possible")
+      case Success(actorRef) =>
+        logger.info(s"Found context ${contextInfo.name} -> reconnect is possible")
+        Some(clusterAddress)
       case Failure(ex) => {
         val c = contextInfo
         val ctxName = c.name
@@ -174,13 +211,18 @@ object JobServer {
 
   val ec = scala.concurrent.ExecutionContext.Implicits.global
   @VisibleForTesting
-  def updateContextStatus(system: ActorSystem, jobDaoActor: ActorRef) {
+  def updateContextStatus(system: ActorSystem, jobDaoActor: ActorRef): Option[String] = {
     val config = system.settings.config
     val daoAskTimeout = Timeout(config.getDuration("spark.jobserver.dao-timeout", TimeUnit.SECONDS).second)
     val resp = Await.result(
         (jobDaoActor ? JobDAOActor.GetContextInfos(None, Some(Seq(ContextStatus.Running))))(daoAskTimeout).
         mapTo[JobDAOActor.ContextInfos], daoAskTimeout.duration)
-    resp.contextInfos.foreach(ci => validateContext(ci, system, jobDaoActor)(ec))
+    val initialSeedNode = resp.contextInfos.map(ci =>
+      validateContext(ci, system, jobDaoActor)(ec)).find(_ != None)
+    initialSeedNode match {
+      case None => None
+      case Some(seedNodeAddress) => seedNodeAddress
+    }
   }
 
   private def parseInitialBinaryConfig(key: String, config: Config): Map[String, String] = {

--- a/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
@@ -16,6 +16,7 @@ import spark.jobserver.common.akka.InstrumentedActor
 import akka.pattern.gracefulStop
 import org.joda.time.DateTime
 import spark.jobserver.io.JobDAOActor.CleanContextJobInfos
+import spark.jobserver.io.ContextInfo
 
 /** Messages common to all ContextSupervisors */
 object ContextSupervisor {
@@ -29,6 +30,7 @@ object ContextSupervisor {
   case class StopContext(name: String)
   case class GetSparkContexData(name: String)
   case class RestartOfTerminatedJobsFailed(contextId: String)
+  case class ForkedJVMInitTimeout(contextActorName: String, contextInfo: ContextInfo)
 
   // Errors/Responses
   case object ContextInitialized

--- a/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
@@ -31,6 +31,7 @@ object ContextSupervisor {
   case class GetSparkContexData(name: String)
   case class RestartOfTerminatedJobsFailed(contextId: String)
   case class ForkedJVMInitTimeout(contextActorName: String, contextInfo: ContextInfo)
+  case class RegainWatchOnExistingContexts(actorRefs: Seq[ActorRef])
 
   // Errors/Responses
   case object ContextInitialized

--- a/job-server/src/main/scala/spark/jobserver/io/JobDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobDAO.scala
@@ -83,6 +83,7 @@ object JobStatus {
   val Started = "STARTED"
   val Killed = "KILLED"
   val Restarting = "RESTARTING"
+  def getFinalStates(): Seq[String] = Seq(Error, Finished, Killed)
   def getNonFinalStates(): Seq[String] = Seq(Started, Running, Restarting)
 }
 
@@ -94,6 +95,8 @@ object ContextStatus {
   val Started = "STARTED"
   val Killed = "KILLED"
   val Restarting = "RESTARTING"
+  def getFinalStates(): Seq[String] = Seq(Error, Finished, Killed)
+  def getNonFinalStates(): Seq[String] = Seq(Started, Running, Stopping, Restarting)
 }
 
 object JobDAO {

--- a/job-server/src/main/scala/spark/jobserver/util/CustomException.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/CustomException.scala
@@ -21,3 +21,4 @@ final case class ContextJVMInitializationTimeout() extends
 
 final case class ContextReconnectFailedException() extends
   Exception("Reconnect failed after Jobserver restart")
+

--- a/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
@@ -82,6 +82,7 @@ object StubbedAkkaClusterSupervisorActor {
   case object DisableDAOCommunication
   case object EnableDAOCommunication
   case class DummyTerminated(actorRef: ActorRef)
+  case class UnWatchContext(actorRef: ActorRef)
 }
 
 class StubbedAkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef, managerProbe: TestProbe, cluster: Cluster)
@@ -133,6 +134,8 @@ class StubbedAkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: Ac
       daoCommunicationDisabled = false
     case StubbedAkkaClusterSupervisorActor.DummyTerminated(actorRef) =>
       handleTerminatedEvent(actorRef)
+    case StubbedAkkaClusterSupervisorActor.UnWatchContext(actorRef) =>
+      context.unwatch(actorRef)
   }
 
   override def getDataFromDAO[T: ClassTag](msg: JobDAOActor.JobDAORequest): Option[T] = {
@@ -534,6 +537,31 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
       val timedOutContext = Await.result(dao.getContextInfoByName(failingContextName), daoTimeout)
       timedOutContext.get.state should be(ContextStatus.Error)
       timedOutContext.get.error.get.getMessage should be(timeoutExceptionMessage)
+    }
+
+    it("should raise Terminated event even if the watch was added through RegainWatchOnExistingContexts message") {
+      val contextName = "ctxRunning"
+
+      supervisor ! AddContext(contextName, contextConfig)
+      expectMsg(contextInitTimeout, ContextInitialized)
+
+      val runningContextInfo = Await.result(dao.getContextInfoByName(contextName), daoTimeout)
+      val runningContextActorRef = JobServer.getManagerActorRef(runningContextInfo.get, system).get
+      runningContextActorRef should not be(None)
+
+      // Mimic SJS restart, where it loses all the watches
+      supervisor ! StubbedAkkaClusterSupervisorActor.UnWatchContext(runningContextActorRef)
+
+      supervisor ! RegainWatchOnExistingContexts(List(runningContextActorRef))
+
+      val deathWatcher = TestProbe()
+      deathWatcher.watch(runningContextActorRef)
+      runningContextActorRef ! PoisonPill
+      deathWatcher.expectTerminated(runningContextActorRef)
+
+      Thread.sleep(3000)
+      val updatedContext = Await.result(dao.getContextInfoByName(contextName), daoTimeout)
+      updatedContext.get.state should be(ContextStatus.Killed)
     }
   }
 

--- a/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
@@ -4,6 +4,7 @@ import akka.actor._
 import akka.cluster.Cluster
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import akka.testkit._
+import akka.cluster.ClusterEvent.MemberEvent
 
 import spark.jobserver.common.akka.AkkaTestUtils
 import spark.jobserver.io.{JobDAO, JobDAOActor, ContextInfo, ContextStatus, JobInfo, JobStatus, BinaryInfo, BinaryType}
@@ -80,8 +81,13 @@ object StubbedAkkaClusterSupervisorActor {
   case class DummyTerminated(actorRef: ActorRef)
 }
 
-class StubbedAkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef, managerProbe: TestProbe)
-        extends AkkaClusterSupervisorActor(daoActor, dataManagerActor) {
+class StubbedAkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef, managerProbe: TestProbe, cluster: Cluster)
+        extends AkkaClusterSupervisorActor(daoActor, dataManagerActor, cluster) {
+
+  override def preStart(): Unit = {
+    cluster.join(selfAddress)
+    cluster.subscribe(self, classOf[MemberEvent])
+  }
 
   var daoCommunicationDisabled = false
   def createSlaveClusterWithJobManager(contextName: String, contextConfig: Config): (Cluster, ActorRef) = {
@@ -162,7 +168,8 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
   override def beforeAll() {
     dao = new InMemoryDAO
     daoActor = system.actorOf(JobDAOActor.props(dao))
-    supervisor = system.actorOf(Props(classOf[StubbedAkkaClusterSupervisorActor], daoActor, TestProbe().ref, managerProbe), "supervisor")
+    val cluster = Cluster(system)
+    supervisor = system.actorOf(Props(classOf[StubbedAkkaClusterSupervisorActor], daoActor, TestProbe().ref, managerProbe, cluster), "supervisor")
   }
 
   override def afterAll() = {

--- a/job-server/src/test/scala/spark/jobserver/JobServerSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobServerSpec.scala
@@ -158,19 +158,28 @@ class JobServerSpec extends TestKit(JobServerSpec.system) with FunSpecLike with 
       Await.result(system.actorSelection("/user/job-info").resolveOne, 2 seconds) shouldBe a[ActorRef]
     }
 
-    def createContext(name: String, status: String, genActor: Boolean): ContextInfo = {
+    def createContext(name: String, status: String, genActor: Boolean): (ContextInfo, Option[ActorRef]) = {
       val uuid = UUID.randomUUID().toString()
-      var address = "invalidAddress"
-      if(genActor) {
-        val actor = system.actorOf(Props.empty, name = AkkaClusterSupervisorActor.MANAGER_ACTOR_PREFIX + uuid)
-        address = actor.path.address.toString
+      val ContextInfoPF = ContextInfo(uuid, name, "", _: Option[String], DateTime.now(), None, status, None)
+
+      genActor match {
+        case true =>
+          val actor = system.actorOf(Props.empty, name = AkkaClusterSupervisorActor.MANAGER_ACTOR_PREFIX + uuid)
+          (ContextInfoPF(Some(actor.path.address.toString)), Some(actor))
+        case false =>
+          (ContextInfoPF(Some("invalidAddress")), None)
       }
-      return ContextInfo(uuid, name, "", Some(address), DateTime.now(), None, status, None)
+    }
+
+    def genJob(jobId: String, ctx: ContextInfo, status: String) = {
+      val dt = DateTime.parse("2013-05-29T00Z")
+      JobInfo(jobId, ctx.id, ctx.name, BinaryInfo("demo", BinaryType.Jar, dt), "com.abc.meme",
+          status, dt, None, None)
     }
 
     it("should write error state for contexts and jobs if reconnect failed") {
-      val ctxRunning = createContext("ctxRunning", ContextStatus.Running, true)
-      val ctxToBeTerminated = createContext("ctxTerminated", ContextStatus.Running, false)
+      val (ctxRunning, ctxRunningActorRef) = createContext("ctxRunning", ContextStatus.Running, true)
+      val (ctxToBeTerminated, _) = createContext("ctxTerminated", ContextStatus.Running, false)
 
       def genJob(jobId: String, ctx: ContextInfo, status: String) = {
         val dt = DateTime.parse("2013-05-29T00Z")
@@ -203,8 +212,11 @@ class JobServerSpec extends TestKit(JobServerSpec.system) with FunSpecLike with 
         }
       })
 
-      JobServer.updateContextStatus(system, daoProbe.ref)
+      val existingManagerActorRefs = JobServer.getExistingManagerActorRefs(system, daoProbe.ref)
       latch.await()
+
+      existingManagerActorRefs.length should be(1)
+      existingManagerActorRefs(0) should be(ctxRunningActorRef.get)
 
       ctxTerminated.state should be(ContextStatus.Error)
       ctxTerminated.error.get should be(ContextReconnectFailedException())
@@ -213,23 +225,49 @@ class JobServerSpec extends TestKit(JobServerSpec.system) with FunSpecLike with 
       jobTerminated.error.get.message should be(ContextReconnectFailedException().getMessage)
     }
 
-    it("should return None if no context is available to reconnect") {
+    it("should return empty list if no context is available to reconnect") {
       val daoActor = system.actorOf(JobDAOActor.props(new InMemoryDAO))
 
-      val existingClusterAddress = JobServer.updateContextStatus(system, daoActor)
-      existingClusterAddress should be(None)
+      val existingManagerActorRefs = JobServer.getExistingManagerActorRefs(system, daoActor)
+      existingManagerActorRefs should be(List())
     }
 
-    it("should return actor address (only 1) for actors state running during reconnect") {
-      val daoActor = system.actorOf(JobDAOActor.props(new InMemoryDAO))
-      val ctxRunning = createContext("ctxRunning", ContextStatus.Running, true)
-      val ctxRunning2 = createContext("ctxRunning2", ContextStatus.Running, true)
+    it("should update the status of context and jobs if reconnection failed") {
+      val daoActorProbe = TestProbe()
 
-      daoActor ! JobDAOActor.SaveContextInfo(ctxRunning)
-      daoActor ! JobDAOActor.SaveContextInfo(ctxRunning2)
+      val (ctxRunning, _) = createContext("ctxRunning", ContextStatus.Running, true)
+      JobServer.setReconnectionFailedForContextAndJobs(ctxRunning, daoActorProbe.ref)
 
-      val existingClusterAddress = JobServer.updateContextStatus(system, daoActor)
-      existingClusterAddress.get should be(ctxRunning.actorAddress.get)
+      // Check if context is updated correctly
+      val saveContextMsg = daoActorProbe.expectMsgType[JobDAOActor.SaveContextInfo]
+      saveContextMsg.contextInfo.id should be(ctxRunning.id)
+      saveContextMsg.contextInfo.state should be(ContextStatus.Error)
+      saveContextMsg.contextInfo.error.get.getMessage should be(ContextReconnectFailedException().getMessage)
+
+      // Check if job is updated correctly
+      val runningJobInfo = genJob("jid1", ctxRunning, JobStatus.Running)
+      val runningJobInfo2 = genJob("jid2", ctxRunning, JobStatus.Running)
+      daoActorProbe.expectMsgType[JobDAOActor.GetJobInfosByContextId]
+      daoActorProbe.reply(JobDAOActor.JobInfos(Seq(runningJobInfo, runningJobInfo2)))
+
+      val saveJobMsg = daoActorProbe.expectMsgType[JobDAOActor.SaveJobInfo]
+      saveJobMsg.jobInfo.state should be(JobStatus.Error)
+      saveJobMsg.jobInfo.error.get.message should be(ContextReconnectFailedException().getMessage)
+
+      val saveJobMsg2 = daoActorProbe.expectMsgType[JobDAOActor.SaveJobInfo]
+      saveJobMsg2.jobInfo.state should be(JobStatus.Error)
+      saveJobMsg2.jobInfo.error.get.message should be(ContextReconnectFailedException().getMessage)
+    }
+
+    it("should resolve valid actor reference correctly") {
+      val (ctxRunning, ctxRunningActorRef) = createContext("ctxRunning", ContextStatus.Running, true)
+      val (ctxInvalidAddress, ctxInvalidAddressRef) = createContext("ctxInvalidAddress", ContextStatus.Running, false)
+      val actorRef = JobServer.getManagerActorRef(ctxRunning, system)
+
+      actorRef should not be(None)
+      actorRef.get.actorRef.path.address.toString should be(ctxRunningActorRef.get.path.address.toString)
+
+      JobServer.getManagerActorRef(ctxInvalidAddress, system) should be(None)
     }
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?
- [X] Docs have been added / updated (for bug fixes / features) ?

**New behavior :**
Due to the extensive commit messages, I will only post excerpts here, for the full description have a look into the specific commit message.

- feat(jobserver): Add watch on existing context upon SJS restart
  Due to SJS Master restart, AkkaClusterSupervisorActor can
  lose all the watches. This patch adds a check on SJS startup
  to figure out which contexts JVMs are reconnectable and send
  then a message to AkkaClusterSupervisorActor which contains
  the related ActorRef. AkkaClusterSupervisorActor then adds a
  watch to old JVMs and is able to receive the Terminated
  event again.

- feat(jobserver): Detect and handle forked JVM init failure
  This patch introduces a timeout for forked JVM with a
  default of 30s. Within this time, if the JVM doesn't
  respond back then a timeout message is sent to the
  user and ERROR state with a message is inserted in the
  database for the context. It is possible that later at
  some point, the JVM gets resources and tries to connect
  back to SJS. At this point, we kill the JVM because
  user does not know about this context anymore.

- feat(jobserver): After SJS restart rejoin old cluster
  In cluster mode, after SJS restart, SJS Master JVM forms
  its own cluster and all the exisiting slaves form
  their own cluster. So, after each restart of SJS, a new
  Akka cluster is formed.
  
  This patch fixes the above problem and after restart
  we join the existing cluster (if available).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1092)
<!-- Reviewable:end -->
