### PR TITLE
misc(all): Update sbt to 1.1.6 and update sbt plugins

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -5,9 +5,7 @@ USER root
 
 RUN echo 'deb http://dl.bintray.com/sbt/debian /' > /etc/apt/sources.list.d/sbt.list && \
     apt-get -qq update && \
-    apt-get install -y --force-yes python3 python3-pip python-pip sbt=0.13.8 && \
-    sbt
-# running sbt downloads some of its internals, speed up sebsequent sbt runs
+    apt-get install -y --force-yes python3 python3-pip python-pip sbt=1.1.6
 
 WORKDIR /usr/src/app/
 

--- a/doc/EMR.md
+++ b/doc/EMR.md
@@ -54,7 +54,7 @@ InstanceCount=10,BidPrice=2.99,Name=sparkSlave,InstanceGroupType=CORE,InstanceTy
 
 ### Build spark-jobserver distribution
 
-1. Install sbt 0.13.9 as described here http://www.scala-sbt.org/0.13/tutorial/Manual-Installation.html
+1. Install sbt as described here https://www.scala-sbt.org/download.html
 2. Install jdk 1.7.0 and git
  ```
  sudo yum install java-1.7.0-openjdk-devel git

--- a/project/Assembly.scala
+++ b/project/Assembly.scala
@@ -7,11 +7,11 @@ object Assembly {
     assemblyJarName in assembly := "spark-job-server.jar",
       // uncomment below to exclude tests
     // test in assembly := {},
-    assemblyExcludedJars in assembly <<= (fullClasspath in assembly) map { _ filter { cp =>
+    assemblyExcludedJars in assembly := (fullClasspath in assembly).map(_.filter { cp =>
       List("servlet-api", "guice-all", "junit", "uuid",
         "jetty", "jsp-api-2.0", "antlr", "avro", "slf4j-log4j", "log4j-1.2",
         "scala-actors", "commons-cli", "stax-api", "mockito").exists(cp.data.getName.startsWith(_))
-    } },
+    }).value,
     // We don't need the Scala library, Spark already includes it
     assembleArtifact in assemblyPackageScala := false,
     assemblyMergeStrategy in assembly := {

--- a/project/ExclusionRules.scala
+++ b/project/ExclusionRules.scala
@@ -5,7 +5,7 @@ object ExclusionRules {
   val excludeJackson = ExclusionRule(organization = "org.codehaus.jackson")
   val excludeScalaTest = ExclusionRule(organization = "org.scalatest")
   val excludeScala = ExclusionRule(organization = "org.scala-lang")
-  val excludeNettyIo = ExclusionRule(organization = "io.netty", artifact = "netty-all")
+  val excludeNettyIo = ExclusionRule(organization = "io.netty").withArtifact("netty-all")
   val excludeAsm = ExclusionRule(organization = "asm")
   val excludeQQ = ExclusionRule(organization = "org.scalamacros")
 }

--- a/project/Release.scala
+++ b/project/Release.scala
@@ -1,32 +1,9 @@
-import sbt._
-import Keys._
 import sbtrelease.ReleasePlugin.autoImport._
 import ReleaseTransformations._
 
-object JobServerRelease {
+object Release {
 
-  import ls.Plugin._
-  import LsKeys._
-
-  lazy val implicitlySettings = {
-    lsSettings ++ Seq(
-      homepage := Some(url("https://github.com/spark-jobserver/spark-jobserver")),
-      tags in lsync := Seq("spark", "akka", "rest"),
-      description in lsync := "REST job server for Apache Spark",
-      externalResolvers in lsync := Seq("Job Server Bintray" at "http://dl.bintray.com/spark-jobserver/maven"),
-      ghUser in lsync := Some("spark-jobserver"),
-      ghRepo in lsync := Some("spark-jobserver"),
-      ghBranch in lsync := Some("master")
-    )
-  }
-
-  val syncWithLs = (ref: ProjectRef) => ReleaseStep(
-    check = releaseStepTaskAggregated(LsKeys.writeVersion in lsync in ref),
-    action = releaseStepTaskAggregated(lsync in lsync in ref)
-  )
-
-  lazy val ourReleaseSettings = Seq(
-
+  lazy val settings = Seq(
     releaseProcess := Seq(
       checkSnapshotDependencies,
       runClean,
@@ -36,8 +13,6 @@ object JobServerRelease {
       commitReleaseVersion,
       tagRelease,
       publishArtifacts,
-      // lsync seems broken, always returning: Error synchronizing project libraries Unexpected response status: 404
-      // syncWithLs(thisProjectRef.value),
       setNextVersion,
       commitNextVersion,
       pushChanges

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=1.1.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,21 +1,19 @@
 resolvers += Classpaths.sbtPluginReleases
 
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.10")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.4")
 
-addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")       // For quick restarts for web development
+addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")       // For quick restarts for web development
 
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.7")
 
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.3.5")
+addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.5.1")
 
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
 
-addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.3")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
-
-addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.4.1")
+addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.5.0")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [x] Docs have been added / updated (for bug fixes / features) ?


I noticed that the current version of sbt in this project was 0.13.12, which is very old. In this pull request, I updated sbt to the latest 1.1.6 version. Some additional points:
* All deprecation warnings were fixed.
* Docs was updated.
* Build scripts were updated.

Also, I updated all sbt plugins to the latest versions. Most of the updates didn't require additional work. But some did:
* `"me.lessis" % "bintray-sbt"` was renamed to `"org.foundweekends" % "sbt-bintray"`
* I completely removed `ls-sbt`, because all implicitly stuff is abandoned now. After this deletion `JobServerRelease` object has only `ourReleaseSettings` field. And I decided to rename `JobServerRelease.ourReleaseSettings` to `Release.settings` because it's less verbose and more clear IMO.
* I added `skip in publish := true` setting in the `noPublishSettings`. This is a recommended way to skip publishing now.

I think some extra improvements could be done with the sbt code after this updates, but I decided to make this pull request as small as possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1099)
<!-- Reviewable:end -->
