### PR TITLE
feat(jobserver): Handle DELETE /context gracefully

### DIFF
--- a/doc/job-server-flow.md
+++ b/doc/job-server-flow.md
@@ -209,6 +209,7 @@ Context routes
 
         user->WebApi: DELETE /contexts/<contextName>
         WebApi->AkkaClusterSupervisorActor: StopContext(contextName)
+        note right of AkkaClusterSupervisorActor:set context state=STOPPING
         AkkaClusterSupervisorActor->JobManagerActor: StopContextAndShutdown
         JobManagerActor->JobManagerActor: ContextStopScheduledMsgTimeout
         JobManagerActor->SparkContext: sc.stop()
@@ -219,6 +220,7 @@ Context routes
         JobManagerActor ->JobManagerActor: PoisonPill
         AkkaClusterSupervisorActor ->WebApi: ContextStopped
         DeathWatch ->AkkaClusterSupervisorActor: Terminated
+        note right of AkkaClusterSupervisorActor:set context state=FINISHED
         DeathWatch->ProductionReaper: Terminated
         ProductionReaper->ActorSystem: shutdown
         WebApi ->user: 200

--- a/doc/job-server-flow.md
+++ b/doc/job-server-flow.md
@@ -10,8 +10,11 @@
 
 (use http://websequencediagrams.com/ to visualize sequence diagrams)
 
-Jar routes
+LocalClusterSupervisor (context-per-jvm=false)
 ==========
+
+Jar routes
+----------
 - get a list of mapping from appName to uploadTime for all the known job jars:
 
         user->WebApi: GET /jars
@@ -31,7 +34,7 @@ Jar routes
         WebApi->user: 200
 
 Context routes
-==============
+----------
 - get a list of all known contextNames
 
         user->WebApi: GET /contexts
@@ -74,7 +77,7 @@ Context routes
 
 
 Job routes
-==========
+----------
 - get a list of JobInfo(jobId, contextName, JarInfo, classPath, startTime, Option(endTime), Option(Throwable)) of all known jobs
 
         user->WebApi: GET /jobs
@@ -193,3 +196,134 @@ Job routes
            JobInfoActor->WebApi: JobInfo
            WebApi->user: 200 + "ERROR"
         end
+
+AkkaClusterSupervisor (context-per-jvm=true)
+==========
+
+Context routes
+----------
+
+- Context delete route (Normal flow)
+
+        title DELETE /contexts (Normal flow)
+
+        user->WebApi: DELETE /contexts/<contextName>
+        WebApi->AkkaClusterSupervisorActor: StopContext(contextName)
+        AkkaClusterSupervisorActor->JobManagerActor: StopContextAndShutdown
+        JobManagerActor->JobManagerActor: ContextStopScheduledMsgTimeout
+        JobManagerActor->SparkContext: sc.stop()
+        SparkContext -> JobManagerActor: onApplicationEnd
+        JobManagerActor ->JobManagerActor: SparkContextStopped
+        JobManagerActor->JobManagerActor: ContextStopScheduledMsgTimeout.cancel()
+        JobManagerActor ->AkkaClusterSupervisorActor: SparkContextStopped
+        JobManagerActor ->JobManagerActor: PoisonPill
+        AkkaClusterSupervisorActor ->WebApi: ContextStopped
+        DeathWatch ->AkkaClusterSupervisorActor: Terminated
+        DeathWatch->ProductionReaper: Terminated
+        ProductionReaper->ActorSystem: shutdown
+        WebApi ->user: 200
+
+- Context delete route (time out flow)
+
+        title DELETE /contexts (stop context timed out)
+
+        user->WebApi: DELETE /contexts/<contextName>
+        WebApi->AkkaClusterSupervisorActor: StopContext(contextName)
+        note right of AkkaClusterSupervisorActor:set context state=STOPPING
+        AkkaClusterSupervisorActor->JobManagerActor: StopContextAndShutdown
+        JobManagerActor->Akka Scheduler: schedule(ContextStopScheduledMsgTimeout, timeout)
+        JobManagerActor->SparkContext: sc.stop()
+
+        space
+        space
+        space
+        Akka Scheduler ->JobManagerActor: ContextStopScheduledMsgTimeout
+        JobManagerActor ->AkkaClusterSupervisorActor: ContextStopInProgress
+        AkkaClusterSupervisorActor ->WebApi: ContextStopInProgress
+        WebApi ->user: 202 & Location Header
+
+        space
+        ==User request to url which is in location header to get the state of stop==
+
+        user->WebApi: GET /contexts/<contextName>
+        WebApi->AkkaClusterSupervisorActor: GetSparkContexData(contextName)
+        AkkaClusterSupervisorActor->JobManagerActor: GetContexData
+
+        opt if context is running:
+        JobManagerActor->SparkContext: applicationId/webUrl
+        SparkContext ->JobManagerActor:
+        JobManagerActor->AkkaClusterSupervisorActor: ContexData
+        AkkaClusterSupervisorActor->WebApi: SparkContexData(ctxInfo, appId, webUrl)
+        end
+
+        opt if context is not alive:
+        JobManagerActor->SparkContext: applicationId/webUrl
+        JobManagerActor->JobManagerActor: Exception
+        JobManagerActor->AkkaClusterSupervisorActor: SparkContextDead
+        AkkaClusterSupervisorActor->WebApi:SparkContexData(ctxInfo, None, None)
+        end
+
+        WebApi->user: 200 & json with current state
+
+        space
+
+        space
+        ==User can send more requests when context stop is in progress==
+        space
+
+        user->WebApi: DELETE /contexts/<contextName>
+        WebApi->AkkaClusterSupervisorActor: StopContext(contextName)
+        AkkaClusterSupervisorActor->JobManagerActor: StopContextAndShutdown
+        JobManagerActor ->AkkaClusterSupervisorActor: ContextStopInProgress
+        AkkaClusterSupervisorActor ->WebApi: ContextStopInProgress
+        WebApi ->user: 202 & Location Header
+
+        space
+        ==Finally when context will stop, the following flow will be followed==
+        space
+
+        SparkContext -> JobManagerActor: onApplicationEnd
+        JobManagerActor ->JobManagerActor: SparkContextStopped
+        JobManagerActor ->JobManagerActor: PoisonPill
+        DeathWatch ->AkkaClusterSupervisorActor: Terminated
+
+        note right of AkkaClusterSupervisorActor:set context state=FINISHED
+        DeathWatch->ProductionReaper: Terminated
+        ProductionReaper->ActorSystem: shutdown
+
+        space
+        ==Further requests will fail==
+        space
+
+        user->WebApi: GET /contexts/<contextName>
+        WebApi->AkkaClusterSupervisorActor: GetSparkContexData(contextName)
+        AkkaClusterSupervisorActor->WebApi: NoSuchContext
+        WebApi->user: 404
+
+
+- Adhoc Context Stop
+
+        title Adhoc contexts stop (Normal flow)
+
+        user->WebApi: POST /job/<params>
+        WebApi->AkkaClusterSupervisorActor: StartAdHocContext(classPath, contextConfig)
+        AkkaClusterSupervisorActor->WebApi: ActorRef
+        WebApi->JobManagerActor: StartJob(...)
+        space
+        note right of JobManagerActor:Normal flow of starting a job
+        space
+        space
+        note right of JobManagerActor:Job finished
+        JobManagerActor->JobStatusActor: JobFinished
+        JobStatusActor->WebApi: JobResult
+        WebApi->user: 200
+        JobManagerActor->JobManagerActor: StopContextAndShutdown
+        JobManagerActor->JobDAOActor: SaveContextInfo(..., STOPPING)
+        JobManagerActor->SparkContext: sc.stop()
+        SparkContext -> JobManagerActor: onApplicationEnd
+        JobManagerActor ->JobManagerActor: SparkContextStopped
+        JobManagerActor ->JobManagerActor: PoisonPill
+        DeathWatch ->AkkaClusterSupervisorActor: Terminated
+        note right of AkkaClusterSupervisorActor:set context state=FINISHED
+        DeathWatch->ProductionReaper: Terminated
+        ProductionReaper->ActorSystem: shutdown

--- a/job-server-extras/src/main/scala/spark/jobserver/StreamingTestJob.scala
+++ b/job-server-extras/src/main/scala/spark/jobserver/StreamingTestJob.scala
@@ -6,26 +6,44 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.streaming.StreamingContext
 
 import scala.collection.mutable
+import scala.util.Try
 
 @VisibleForTesting
 object StreamingTestJob extends SparkStreamingJob {
   def validate(ssc: StreamingContext, config: Config): SparkJobValidation = SparkJobValid
 
-
   def runJob(ssc: StreamingContext, config: Config): Any = {
+    val maxIterations = Try(config.getInt("streaming.test.job.maxIterations")).getOrElse(1)
+    val totalDelaySeconds = Try(config.getInt("streaming.test.job.totalDelaySeconds")).getOrElse(0)
+    val shouldPrintCount = Try(config.getBoolean("streaming.test.job.printCount")).getOrElse(true)
+
     val queue = mutable.Queue[RDD[String]]()
-    queue += ssc.sparkContext.makeRDD(Seq("123", "test", "test2"))
     val lines = ssc.queueStream(queue)
-    val words = lines.flatMap(_.split(" "))
+    val words = lines.flatMap{ l =>
+      Thread.sleep(totalDelaySeconds * 1000)
+      l.split(" ")
+    }
+
     val wordCounts = words.countByValue()
     //do something
     wordCounts.foreachRDD(rdd =>
-      try {
-        println(rdd.count())
+    try {
+        shouldPrintCount match {
+          case true => println(rdd.count())
+          case false => rdd.count()
+        }
       } catch {
         case _: InterruptedException => {}
       })
     ssc.start()
+    var totalIterations = 0
+    while(totalIterations < maxIterations) {
+      queue.synchronized {
+        queue += ssc.sparkContext.makeRDD(Seq("123", "test", "test2"))
+      }
+      totalIterations += 1
+      Thread.sleep(100)
+    }
     ssc.awaitTermination()
   }
 }

--- a/job-server-extras/src/test/scala/spark/jobserver/StreamingJobSpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/StreamingJobSpec.scala
@@ -1,11 +1,15 @@
 package spark.jobserver
 
 import akka.pattern._
+import akka.testkit.TestProbe
 
 import scala.concurrent.Await
 import com.typesafe.config.ConfigFactory
+import spark.jobserver.ContextSupervisor._
+import spark.jobserver.JobManagerActor.{ContexData, GetContexData, StartJob, StopContextAndShutdown}
 import spark.jobserver.context.StreamingContextFactory
 import spark.jobserver.io.{JobDAOActor, JobInfo, JobStatus}
+import spark.jobserver.util.SparkJobUtils
 
 /**
  * Test for Streaming Jobs.
@@ -29,6 +33,8 @@ class StreamingJobSpec extends JobSpecBase(StreamingJobSpec.getNewSystem) {
   val emptyConfig = ConfigFactory.parseMap(configMap.asJava)
   var jobId = ""
   val cfg = StreamingJobSpec.getContextConfig(false, StreamingJobSpec.contextConfig)
+  val cfgWithGracefulShutdown = StreamingJobSpec.getContextConfig(
+    false, StreamingJobSpec.contextConfigWithGracefulShutdown)
 
   before {
     dao = new InMemoryDAO
@@ -38,10 +44,17 @@ class StreamingJobSpec extends JobSpecBase(StreamingJobSpec.getNewSystem) {
 
   after {
     Await.result(gracefulStop(manager, 5 seconds), 5 seconds) // stop context
+    // Due to some reason, even though the context is stopped, starting a new one gives the following error
+    // org.apache.spark.SparkException: Only one SparkContext may be running in this JVM (see SPARK-2243)
+    // Thread.sleep() gives time to sc to stop fully
+    Thread.sleep(3000)
   }
 
   describe("Spark Streaming Jobs") {
-    it("should be able to process data using Streaming jobs") {
+    it("should be able to process data using Streaming jobs and stop it") {
+      val deathWatcher = TestProbe()
+      deathWatcher.watch(manager)
+
       manager ! JobManagerActor.Initialize(cfg, None, emptyActor)
       expectMsgClass(10 seconds, classOf[JobManagerActor.Initialized])
       uploadTestJar()
@@ -53,14 +66,55 @@ class StreamingJobSpec extends JobSpecBase(StreamingJobSpec.getNewSystem) {
           jobid
         }
       }
-      expectNoMsg()
+      expectNoMsg(2.seconds)
 
       Thread sleep 1000
       val jobInfo = Await.result(dao.getJobInfo(jobId), 60 seconds)
-      jobInfo.get match  {
+      jobInfo.get match {
         case JobInfo(_, _, _, _, _, state, _, _, _) if state == JobStatus.Running => {  }
         case e => fail("Unexpected JobInfo" + e)
       }
+
+      manager ! JobManagerActor.StopContextAndShutdown
+      expectMsg(SparkContextStopped)
+      deathWatcher.expectTerminated(manager)
+    }
+
+    it("should respond with stop in progress if stop times out and should eventually stop") {
+      val deathWatcher = TestProbe()
+      deathWatcher.watch(manager)
+      val streamingJobConfig = ConfigFactory.parseString(
+      """
+        |streaming.test.job.maxIterations = 2,
+        |streaming.test.job.totalDelaySeconds = 3,
+        |streaming.test.job.printCount = true
+      """.stripMargin.replace("\n", ""))
+
+      manager ! JobManagerActor.Initialize(cfgWithGracefulShutdown, None, emptyActor)
+      expectMsgClass(10 seconds, classOf[JobManagerActor.Initialized])
+      uploadTestJar()
+
+      manager ! JobManagerActor.StartJob("demo", streamingJob, streamingJobConfig, asyncEvents ++ errorEvents)
+      expectMsgType[JobStarted]
+
+      Thread.sleep(2000) // Allow the job to start processing data
+      manager ! JobManagerActor.StopContextAndShutdown
+
+      val expectedResponseTime =
+          (SparkJobUtils.getContextDeletionTimeout(StreamingJobSpec.config) - 2) + 1
+      expectMsg(expectedResponseTime.seconds, ContextStopInProgress)
+
+      manager ! GetContexData
+      expectMsgType[ContexData]
+
+      manager ! JobManagerActor.StartJob("demo", streamingJob, streamingJobConfig, asyncEvents ++ errorEvents)
+      expectMsg(ContextStopInProgress)
+
+      manager ! StopContextAndShutdown
+      expectMsg(ContextStopInProgress)
+
+      expectMsg(9.seconds, SparkContextStopped)
+      deathWatcher.expectTerminated(manager)
     }
   }
 }

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -197,7 +197,7 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef,
     case ListContexts =>
       val resp = getDataFromDAO[JobDAOActor.ContextInfos](
           JobDAOActor.GetContextInfos(None, Some(
-              Seq(ContextStatus.Running, ContextStatus.Restarting))))
+              Seq(ContextStatus.Running, ContextStatus.Restarting, ContextStatus.Stopping))))
       resp match {
         case Some(JobDAOActor.ContextInfos(contextInfos)) => sender ! contextInfos.map(_.name)
         case None => sender ! UnexpectedError

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -550,12 +550,10 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef,
 
   private def getActiveContextByName(name: String): (Boolean, Option[ContextInfo]) = {
     val resp = getContextByName(name)
-    val statesInWhichContextCanBeActive =
-      List(ContextStatus.Started, ContextStatus.Running, ContextStatus.Restarting)
     resp match {
       case None => (false, None)
       case Some(JobDAOActor.ContextResponse(Some(c)))
-        if statesInWhichContextCanBeActive.contains(c.state) => (true, Some(c))
+        if ContextStatus.getNonFinalStates().contains(c.state) => (true, Some(c))
       case Some(_) => (true, None)
     }
   }

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -291,7 +291,7 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef,
                   logger.info("Spark context stopped successfully. Shutting down the driver actor system")
                   originalSender ! ContextStopped
                 case Success(ContextStopInProgress) =>
-                  logger.info("Failed to stop context within in timeout. Stop is still in progress")
+                  logger.info("Failed to stop context within timeout. Stop is still in progress")
                   originalSender ! ContextStopInProgress
                 case Failure(t) =>
                   logger.error(s"Context stopped failed with message ${t.getMessage}")

--- a/job-server/src/main/scala/spark/jobserver/CommonMessages.scala
+++ b/job-server/src/main/scala/spark/jobserver/CommonMessages.scala
@@ -31,6 +31,7 @@ object CommonMessages {
   case class Unsubscribe(jobId: String, receiver: ActorRef) // all events for this jobId and receiving actor
 
   // errors
+  case object ContextStopping
   case object NoSuchJobId
   case object NoSuchApplication
   case object NoSuchClass

--- a/job-server/src/main/scala/spark/jobserver/JobServer.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobServer.scala
@@ -130,7 +130,7 @@ object JobServer {
     contextPerJvm match {
       case false =>
         val supervisor = system.actorOf(Props(classOf[LocalContextSupervisorActor],
-            daoActor, dataManager), "context-supervisor")
+            daoActor, dataManager), AkkaClusterSupervisorActor.ACTOR_NAME)
         supervisor ! ContextSupervisor.AddContextsFromConfig  // Create initial contexts
         startWebApi(system, supervisor, jobDAO, webApiPF)
       case true =>

--- a/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
@@ -20,6 +20,7 @@ import spark.jobserver.io.ContextInfo
 
 /** Messages common to all ContextSupervisors */
 object ContextSupervisor {
+  sealed trait StopContextResponse
   // Messages/actions
   case object AddContextsFromConfig // Start up initial contexts
   case object ListContexts
@@ -32,11 +33,13 @@ object ContextSupervisor {
   case class RestartOfTerminatedJobsFailed(contextId: String)
   case class ForkedJVMInitTimeout(contextActorName: String, contextInfo: ContextInfo)
   case class RegainWatchOnExistingContexts(actorRefs: Seq[ActorRef])
+  case object SparkContextStopped extends StopContextResponse
 
   // Errors/Responses
   case object ContextInitialized
   case class ContextInitError(t: Throwable)
   case class ContextStopError(t: Throwable)
+  case object ContextStopInProgress extends StopContextResponse
   case object ContextAlreadyExists
   case object NoSuchContext
   case object ContextStopped

--- a/job-server/src/main/scala/spark/jobserver/io/JobDAOActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobDAOActor.scala
@@ -56,8 +56,10 @@ object JobDAOActor {
 
   case object InvalidJar extends JobDAOResponse
   case object JarStored extends JobDAOResponse
-  case object SavedSuccessfully extends JobDAOResponse
-  case class SaveFailed(error: Throwable) extends JobDAOResponse
+
+  sealed trait SaveResponse
+  case object SavedSuccessfully extends SaveResponse
+  case class SaveFailed(error: Throwable) extends SaveResponse
 
   def props(dao: JobDAO): Props = Props(classOf[JobDAOActor], dao)
 }

--- a/job-server/src/main/scala/spark/jobserver/io/JobDAOActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobDAOActor.scala
@@ -73,7 +73,10 @@ class JobDAOActor(dao: JobDAO) extends InstrumentedActor {
 
   def wrappedReceive: Receive = {
     case SaveBinary(appName, binaryType, uploadTime, jarBytes) =>
-      sender ! SaveBinaryResult(Try(dao.saveBinary(appName, binaryType, uploadTime, jarBytes)))
+      val recipient = sender()
+      Future {
+        dao.saveBinary(appName, binaryType, uploadTime, jarBytes)
+      }.onComplete(recipient ! SaveBinaryResult(_))
 
     case DeleteBinary(appName) =>
       sender ! DeleteBinaryResult(Try(dao.deleteBinary(appName)))

--- a/job-server/src/main/scala/spark/jobserver/io/JobSqlDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobSqlDAO.scala
@@ -23,6 +23,11 @@ import spark.jobserver.JobManagerActor.ContextTerminatedException
 import spray.http.ErrorInfo
 import spark.jobserver.util.NoSuchBinaryException
 
+/**
+  * Multiple threads can access the functions in this class at the same.
+  * Don't use mutable objects as it will compromise thread safety.
+  * @param config config of jobserver
+  */
 class JobSqlDAO(config: Config) extends JobDAO with FileCacher {
   val slickDriverClass = config.getString("spark.jobserver.sqldao.slick-driver")
   val jdbcDriverClass = config.getString("spark.jobserver.sqldao.jdbc-driver")

--- a/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
@@ -128,7 +128,7 @@ class StubbedAkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: Ac
   }
 
   override def wrappedReceive: Receive = {
-    super.wrappedReceive orElse(stubbedWrappedReceive)
+    stubbedWrappedReceive.orElse(super.wrappedReceive)
   }
 
   def stubbedWrappedReceive: Receive = {
@@ -143,14 +143,27 @@ class StubbedAkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: Ac
       daoCommunicationDisabled = false
     case StubbedAkkaClusterSupervisorActor.DummyTerminated(actorRef) =>
       handleTerminatedEvent(actorRef)
+      sender ! "Executed"
     case StubbedAkkaClusterSupervisorActor.UnWatchContext(actorRef) =>
       context.unwatch(actorRef)
+    case Terminated(actorRef) =>
+      handleTerminatedEvent(actorRef)
+      managerProbe.ref ! "Executed"
   }
 
   override def getDataFromDAO[T: ClassTag](msg: JobDAOActor.JobDAORequest): Option[T] = {
     daoCommunicationDisabled match {
       case true => None
       case false => super.getDataFromDAO[T](msg)
+    }
+  }
+
+  override def leaveCluster(actorRef: ActorRef): Unit = {
+    actorRef.path.address.toString match {
+      case "akka://test" =>
+      // If we use TestProbe and leave the cluster then the master itself leaves the cluster.
+      // For such cases, we don't do anything. For other normal cases, we leave the cluster.
+      case _ => cluster.down(actorRef.path.address)
     }
   }
 }
@@ -225,6 +238,7 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
       supervisor ! StopContext(contextName.toString())
       expectMsg(3.seconds.dilated, ContextStopped)
       managerProbe.expectMsgClass(classOf[Terminated])
+      managerProbe.expectMsg("Executed")
     }
 
     supervisor ! ListContexts
@@ -305,6 +319,7 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
       supervisor ! StopContext("test-context4")
       expectMsg(ContextStopped)
       managerProbe.expectMsgClass(classOf[Terminated])
+      managerProbe.expectMsg("Executed")
     }
 
     it("context stop should be able to handle case when no context is present") {
@@ -670,6 +685,22 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
       val updatedContext = Await.result(dao.getContextInfoByName(contextName), daoTimeout)
       updatedContext.get.state should be(ContextStatus.Killed)
     }
+
+    it("should not change final state to non-final within the Terminated event") {
+      val contextId = "ctxFinalState"
+
+      val finalStateContext = saveContextInSomeState(contextId, ContextStatus.getFinalStates().last)
+      val managerProbe = system.actorOf(Props.empty, s"jobManager-$contextId")
+      val daoProbe = TestProbe()
+
+      supervisor ! StubbedAkkaClusterSupervisorActor.DummyTerminated(managerProbe)
+
+      expectMsg("Executed")
+      daoActor ! JobDAOActor.GetContextInfo(contextId)
+      val msg = expectMsgType[JobDAOActor.ContextResponse]
+      msg.contextInfo.get.state should be(ContextStatus.getFinalStates().last)
+      msg.contextInfo.get.endTime should be(finalStateContext.endTime)
+    }
   }
 
   describe("Supervise mode tests") {
@@ -783,29 +814,38 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
 
       supervisor ! StubbedAkkaClusterSupervisorActor.DummyTerminated(managerProbe)
 
-      Thread.sleep(3000)
-      val updatedContextInfo = Await.result(dao.getContextInfo(contextId), daoTimeout)
-      updatedContextInfo.get.state should be(ContextStatus.Restarting)
+      expectMsg("Executed")
+      daoActor ! JobDAOActor.GetContextInfo(contextId)
+      val msg = expectMsgType[JobDAOActor.ContextResponse]
+      msg.contextInfo.get.state should be(ContextStatus.Restarting)
 
-      dao.saveContextInfo(updatedContextInfo.get.copy(state = ContextStatus.Finished)) //cleanup
+      //cleanup
+      daoActor ! JobDAOActor.SaveContextInfo(msg.contextInfo.get.copy(state = ContextStatus.Finished))
+      expectMsg(JobDAOActor.SavedSuccessfully)
     }
 
     it("should set state killed for context which was terminated unexpectedly and supervise mode disabled") {
       val contextId = "testid2"
       val convertedContextConfig = contextConfig.root().render(ConfigRenderOptions.concise())
 
-      val runningContext = ContextInfo(contextId, "c", convertedContextConfig, None, DateTime.now(), None, ContextStatus.Running, None)
-      dao.saveContextInfo(runningContext)
+      val runningContext = ContextInfo(contextId, "c", convertedContextConfig, None, DateTime.now(),
+        None, ContextStatus.Running, None)
+      daoActor ! JobDAOActor.SaveContextInfo(runningContext)
+      expectMsg(JobDAOActor.SavedSuccessfully)
+
       val managerProbe = system.actorOf(Props.empty, s"jobManager-$contextId")
       val daoProbe = TestProbe()
 
       supervisor ! StubbedAkkaClusterSupervisorActor.DummyTerminated(managerProbe)
 
-      Thread.sleep(3000)
-      val updatedContextInfo = Await.result(dao.getContextInfo(contextId), daoTimeout)
-      updatedContextInfo.get.state should be(ContextStatus.Killed)
+      expectMsg("Executed")
+      daoActor ! JobDAOActor.GetContextInfo(contextId)
+      val msg = expectMsgType[JobDAOActor.ContextResponse]
+      msg.contextInfo.get.state should be(ContextStatus.Killed)
 
-      dao.saveContextInfo(updatedContextInfo.get.copy(state = ContextStatus.Finished)) //cleanup
+      //cleanup
+      daoActor ! JobDAOActor.SaveContextInfo(msg.contextInfo.get.copy(state = ContextStatus.Finished))
+      expectMsg(JobDAOActor.SavedSuccessfully)
     }
   }
 }

--- a/job-server/src/test/scala/spark/jobserver/JobSpecBase.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobSpecBase.scala
@@ -24,10 +24,12 @@ trait JobSpecConfig {
   val MemoryPerNode = "512m"
   val MaxJobsPerContext = Integer.valueOf(2)
   def contextFactory: String = classOf[DefaultSparkContextFactory].getName
+
   lazy val config = {
     val ConfigMap = Map(
       "spark.jobserver.job-result-cache-size" -> JobResultCacheSize,
       "spark.jobserver.dao-timeout" -> "3s",
+      "spark.jobserver.context-deletion-timeout" -> "5s",
       "num-cpu-cores" -> NumCpuCores,
       "memory-per-node" -> MemoryPerNode,
       "spark.jobserver.max-jobs-per-context" -> MaxJobsPerContext,
@@ -35,7 +37,8 @@ trait JobSpecConfig {
       "akka.log-dead-letters" -> Integer.valueOf(0),
       "spark.master" -> "local[*]",
       "context-factory" -> contextFactory,
-      "spark.context-settings.test" -> ""
+      "spark.context-settings.test" -> "",
+      "spark.driver.allowMultipleContexts" -> true
     )
     ConfigFactory.parseMap(ConfigMap.asJava).withFallback(ConfigFactory.defaultOverrides())
   }
@@ -53,6 +56,12 @@ trait JobSpecConfig {
       "streaming.stopSparkContext" -> Boolean.box(true)
     )
     ConfigFactory.parseMap(ConfigMap.asJava).withFallback(ConfigFactory.defaultOverrides())
+  }
+
+  lazy val contextConfigWithGracefulShutdown = {
+    val configMap = Map(
+      "streaming.stopGracefully" -> Boolean.box(true))
+    ConfigFactory.parseMap(configMap.asJava).withFallback(contextConfig)
   }
 
   def getNewSystem: ActorSystem = ActorSystem("test", config)

--- a/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
@@ -166,6 +166,7 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
       case StopContext("none") => sender ! NoSuchContext
       case StopContext("timeout-ctx") => sender ! ContextStopError(new Throwable("Some Throwable"))
       case StopContext("unexp-err") => sender ! UnexpectedError
+      case StopContext("ctx-stop-in-progress") => sender ! ContextStopInProgress
       case StopContext(_)      => sender ! ContextStopped
       case AddContext("one", _) => sender ! ContextAlreadyExists
       case AddContext("custom-ctx", c) =>
@@ -209,7 +210,7 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
         val result = "\"1, 2, 3, 4, 5, 6\"".getBytes().toStream
         if (events.contains(classOf[JobResult])) sender ! JobResult("foo.stream", result)
         statusActor ! Unsubscribe("foo.stream", sender)
-
+      case StartJob("context-already-stopped", _, _, _, _) =>  sender ! ContextStopInProgress
 
       case GetJobConfig("badjobid") => sender ! NoSuchJobId
       case GetJobConfig(_)          => sender ! config

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -80,7 +80,7 @@
  </check>
  <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
   <parameters>
-   <parameter name="maxTypes"><![CDATA[30]]></parameter>
+   <parameter name="maxTypes"><![CDATA[32]]></parameter>
   </parameters>
  </check>
  <check level="error" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="false">

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -80,7 +80,7 @@
  </check>
  <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
   <parameters>
-   <parameter name="maxTypes"><![CDATA[32]]></parameter>
+   <parameter name="maxTypes"><![CDATA[33]]></parameter>
   </parameters>
  </check>
  <check level="error" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="false">


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

This PR is divided into 6 commits for easy review. Each commit contains details in the commit message.

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
Summary:
If a user submits DELETE /context/<name> and the context is stuck or stop is still in progress, the DELETE /context request timesout. Jobserver loses control of this JVM and user has no way to figure out though SJS api what happened.

**New behavior :**
With this change, we introduce a more graceful method of deletion. If the context stops within the timeout, the same behavior is kept i.e. 200 response code with message saying "Context Stopped". If the request times out, we send back 202 Accepted response back with a URL in location header where user can query for the current state of context. Whenever context is finally deleted, the state is changed from STOPPING to FINISHED.

This change also contains sequence diagrams with the new flow of SJS to help users and reviewers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1116)
<!-- Reviewable:end -->
