### PR TITLE
fix(job-server): use 24h format for cached binary file name

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/io/FileCacher.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/FileCacher.scala
@@ -24,7 +24,7 @@ trait FileCacher {
   val Pattern = "\\d{8}_\\d{6}_\\d{3}".r
 
   def createBinaryName(appName: String, binaryType: BinaryType, uploadTime: DateTime): String = {
-    appName + "-" + uploadTime.toString("yyyyMMdd_hhmmss_SSS") + s".${binaryType.extension}"
+    appName + "-" + uploadTime.toString("yyyyMMdd_HHmmss_SSS") + s".${binaryType.extension}"
   }
 
   // Cache the jar file into local file system.

--- a/job-server/src/test/scala/spark/jobserver/io/FileCacherSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/FileCacherSpec.scala
@@ -11,8 +11,8 @@ class FileCacherSpec extends FileCacher with FunSpecLike with Matchers {
   override val rootDirFile: File = new File(rootDir)
 
   it("produces binary name") {
-    val appName = createBinaryName("job", BinaryType.Jar, DateTime.parse("2016-10-10T01:00:00Z"))
-    appName should be("job-20161010_010000_000.jar")
+    val appName = createBinaryName("job", BinaryType.Jar, DateTime.parse("2016-10-10T13:00:00Z"))
+    appName should be("job-20161010_130000_000.jar")
   }
 
   it("clean cache binaries") {

--- a/job-server/src/test/scala/spark/jobserver/io/JobCassandraDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/JobCassandraDAOSpec.scala
@@ -30,7 +30,7 @@ class JobCassandraDAOSpec extends TestJarFinder with FunSpecLike with Matchers w
   val jarBytes: Array[Byte] = Files.toByteArray(testJar)
   var jarFile: File = new File(
     config.getString("spark.jobserver.sqldao.rootdir"),
-    jarInfo.appName + "-" + jarInfo.uploadTime.toString("yyyyMMdd_hhmmss_SSS") + ".jar"
+    jarInfo.appName + "-" + jarInfo.uploadTime.toString("yyyyMMdd_HHmmss_SSS") + ".jar"
   )
 
   // jobInfo test data; order is important

--- a/job-server/src/test/scala/spark/jobserver/io/JobSqlDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/JobSqlDAOSpec.scala
@@ -30,13 +30,13 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
   val jarBytes: Array[Byte] = Files.toByteArray(testJar)
   var jarFile: File = new File(
       config.getString("spark.jobserver.sqldao.rootdir"),
-      jarInfo.appName + "-" + jarInfo.uploadTime.toString("yyyyMMdd_hhmmss_SSS") + ".jar"
+      jarInfo.appName + "-" + jarInfo.uploadTime.toString("yyyyMMdd_HHmmss_SSS") + ".jar"
   )
 
   val eggBytes: Array[Byte] = Files.toByteArray(emptyEgg)
   val eggInfo: BinaryInfo = BinaryInfo("myEggBinary", BinaryType.Egg, time)
   val eggFile: File = new File(config.getString("spark.jobserver.sqldao.rootdir"),
-    eggInfo.appName + "-" + jarInfo.uploadTime.toString("yyyyMMdd_hhmmss_SSS") + ".egg")
+    eggInfo.appName + "-" + jarInfo.uploadTime.toString("yyyyMMdd_HHmmss_SSS") + ".egg")
 
   // jobInfo test data
   val jobInfoNoEndNoErr:JobInfo = genJobInfo(jarInfo, false, JobStatus.Running)


### PR DESCRIPTION
**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**

File name for cached binaries currently uses 12h format for the hour part of the timestamp, e.g. `job-20161010_010000_000.jar` for timestamp "2016-10-10T13:00:00Z".

**New behavior :**

File name for cached binaries now uses 24h format for the hour part of the timestamp, e.g. `job-20161010_130000_000.jar` for timestamp "2016-10-10T13:00:00Z".

**BREAKING CHANGES**

Not breaking per se, though worth noting: after upgrading, cached binaries for binaries uploaded in the afternoon will no longer be found and will be re-cached.

**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1130)
<!-- Reviewable:end -->
