### PR TITLE
Remove old configs before new deployment

### DIFF
--- a/bin/server_deploy.sh
+++ b/bin/server_deploy.sh
@@ -55,6 +55,7 @@ fi
 for host in $DEPLOY_HOSTS; do
   # We assume that the deploy user is APP_USER and has permissions
   ssh -o StrictHostKeyChecking=no $ssh_key_to_use  ${APP_USER}@$host mkdir -p $INSTALL_DIR
+  ssh -o StrictHostKeyChecking=no $ssh_key_to_use  ${APP_USER}@$host rm $INSTALL_DIR/*.conf
   scp -o StrictHostKeyChecking=no $ssh_key_to_use  $FILES ${APP_USER}@$host:$INSTALL_DIR/
   scp -o StrictHostKeyChecking=no $ssh_key_to_use  "$CONFIG_DIR/$ENV.conf" ${APP_USER}@$host:$INSTALL_DIR/
   scp -o StrictHostKeyChecking=no $ssh_key_to_use  "$configFile" ${APP_USER}@$host:$INSTALL_DIR/settings.sh


### PR DESCRIPTION
- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format)
- [ ] Tests for the changes have been added
- [ ] Docs have been added

**Current behavior :**
When deploying jobserver with different configurations names,
previous configuration files are kept in deploy folder.
But server_start.sh script is taking just the first found configuration.

**New behavior :**
When uploading new deployment, remove old configuration files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1135)
<!-- Reviewable:end -->
