### PR TITLE
feat(jobserver): Load config and jar from hadoop

### DIFF
--- a/bin/setenv.sh
+++ b/bin/setenv.sh
@@ -107,6 +107,6 @@ JAVA_OPTS_SERVER="${JAVA_OPTS_BASE} \
           -Dcom.sun.management.jmxremote.authenticate=false \
           -Dcom.sun.management.jmxremote.ssl=false"
 
-: ${MANAGER_JAR_FILE:="$appdir/spark-job-server.jar"}
-: ${MANAGER_CONF_FILE:="$conffile"}
+: ${MANAGER_JAR_FILE:="file:$appdir/spark-job-server.jar"}
+: ${MANAGER_CONF_FILE:="file:$conffile"}
 : ${MANAGER_LOGGING_OPTS:="-Dlog4j.configuration=file:$appdir/log4j-server.properties"}

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,8 @@ lazy val jobServer = Project(id = "job-server", base = file("job-server"))
   .settings(assembly := null.asInstanceOf[File])
   .settings(
     description := "Spark as a Service: a RESTful job server for Apache Spark",
-    libraryDependencies ++= sparkDeps ++ slickDeps ++ cassandraDeps ++ securityDeps ++ coreTestDeps,
+    libraryDependencies ++= sparkDeps ++ slickDeps ++ cassandraDeps ++
+    securityDeps ++ coreTestDeps ++ miscTestDeps,
     test in Test := (test in Test).dependsOn(packageBin in Compile in jobServerTestJar)
       .dependsOn(clean in Compile in jobServerTestJar)
       .dependsOn(buildPython in jobServerPython)

--- a/job-server/config/local.sh.template
+++ b/job-server/config/local.sh.template
@@ -2,6 +2,14 @@
 
 # Environment and deploy file
 # For use with bin/server_deploy, bin/server_package etc.
+# Note: This file is sourced 2 times
+# - ./bin/server_deploy sources this file to load environment variables. It only needs a few e.g. INSTALL_DIR.
+#    Variables like $appdir don't have value at this time. It is alright since, nobody is using it.
+# - ./bin/server_start sources this file after exporting conffile and appdir. So, these variables become available
+#    and correct MANAGER_* variables are placed in the env of jobserver master process. These same variables are
+#    also passed as env of driver processes launched through SparkLauncher (since driver processes are a fork of
+#    master process)
+
 DEPLOY_HOSTS="hostname1.net
               hostname2.net"
 
@@ -31,13 +39,14 @@ SPARK_EXECUTOR_URI=/home/spark/spark-1.6.0.tar.gz
 SCALA_VERSION=2.10.4 # or 2.11.6
 
 # optional:
-# REMOTE_JOBSERVER_DIR=file://... or hdfs://...
+#REMOTE_JOBSERVER_DIR=file://... or hdfs://...
 
-MANAGER_JAR_FILE="$appdir/spark-job-server.jar"
+REMOTE_JOBSERVER_DIR=file:$appdir
+MANAGER_JAR_FILE="$REMOTE_JOBSERVER_DIR/spark-job-server.jar"
 MANAGER_CONF_FILE="$conffile"
 MANAGER_EXTRA_JAVA_OPTIONS=
 MANAGER_EXTRA_SPARK_CONFS=
-MANAGER_LOGGING_OPTS="-Dlog4j.configuration=file:$appdir/log4j-server.properties"
+MANAGER_LOGGING_OPTS="-Dlog4j.configuration=$REMOTE_JOBSERVER_DIR/log4j-server.properties"
 SPARK_LAUNCHER_VERBOSE=0
 
 # For mesos/yarn use the following variables

--- a/job-server/src/main/scala/spark/jobserver/util/HadoopFSFacade.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/HadoopFSFacade.scala
@@ -1,0 +1,67 @@
+package spark.jobserver.util
+
+import java.io.{IOException, InputStreamReader, Reader}
+import java.net.URI
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.slf4j.LoggerFactory
+
+/**
+  * Facade to wrap hadoop filesystem operations.
+  * If no parameter is passed then config file is expected to be on the classpath
+  * otherwise inputs should be valid uri's with scheme.
+  */
+class HadoopFSFacade(hadoopConf: Configuration = new Configuration()) {
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  /**
+    * This function checks if file exists in any hadoop supported file system.
+    * Example file path formats
+    *   Local: /tmp/test.txt, file:/tmp/test.txt, file:///tmp/test.txt
+    *   HDFS: hdfs:///tmp/test.txt, hdfs://namenode:port/tmp/test, s3:///tmp/test.txt
+    * @param filePath path of jar file preferably with scheme
+    * @return true if exists, false otherwise
+    */
+  def isFile(filePath: String): Option[Boolean] = {
+    try {
+      val path = new Path(filePath)
+      val uri = getURI(path)
+      val fs = FileSystem.get(uri, hadoopConf)
+      Some(fs.isFile(path))
+    } catch {
+      case e @ (_: IllegalArgumentException | _: IOException) =>
+        logger.error(e.getMessage)
+        None
+    }
+  }
+
+  /**
+    * This function can read config file from all the supported protocols by HDFS
+    * @param filePath absolute path of config file with any supported protocol file/hdfs/s3
+    * @return file stream
+    */
+  def get(filePath: String): Option[Reader] = {
+    try {
+      val fs = FileSystem.get(getURI(filePath), hadoopConf)
+      val stream = fs.open(new Path(filePath))
+      Some(new InputStreamReader(stream))
+    } catch {
+      case e @ (_: IllegalArgumentException | _ : IOException) =>
+        logger.error(e.getMessage)
+        None
+    }
+  }
+
+  private def getURI(filePath: Path): URI = {
+    Option(filePath.toUri().getScheme()) match {
+      case None => new URI(s"file:${filePath.toString}")
+      case _ => filePath.toUri()
+    }
+  }
+
+  private def getURI(filePath: String): URI = {
+    val path = new Path(filePath)
+    getURI(path)
+  }
+}

--- a/job-server/src/main/scala/spark/jobserver/util/Launcher.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/Launcher.scala
@@ -1,8 +1,6 @@
 package spark.jobserver.util
 
 import scala.util.Try
-import scala.sys.process.{Process, ProcessLogger}
-import java.io.File
 import com.typesafe.config.Config
 import org.slf4j.LoggerFactory
 import org.apache.spark.launcher.SparkLauncher
@@ -67,12 +65,10 @@ abstract class Launcher(config: Config, sparkLauncher: SparkLauncher, enviornmen
     }
 
     protected def validate(): (Boolean, String) = {
-      if (!new File(sjsJarPath).isFile()) {
-        val errorMsg =
-          s"Environment error: job-server jar file doesn't exist. Path is $sjsJarPath"
-        logger.error(errorMsg)
-        return (false, errorMsg)
+      new HadoopFSFacade().isFile(sjsJarPath) match {
+        case Some(true) => (true, "")
+        case Some(false) => (false, s"job-server jar file doesn't exist at $sjsJarPath")
+        case None => (false, "Unexpected error occurred while reading file. Check logs")
       }
-      return (true, "")
     }
 }

--- a/job-server/src/test/scala/spark/jobserver/util/HDFSClusterLike.scala
+++ b/job-server/src/test/scala/spark/jobserver/util/HDFSClusterLike.scala
@@ -1,0 +1,44 @@
+package spark.jobserver.util
+
+import java.io.File
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.hdfs.MiniDFSCluster
+import org.apache.hadoop.test.PathUtils
+
+class HDFSCluster extends HDFSClusterLike
+
+trait HDFSClusterLike {
+  private var hdfsCluster: MiniDFSCluster = null
+
+  def startHDFS(): Unit = {
+    val baseDir = new File(PathUtils.getTestDir(getClass()), "miniHDFS")
+    val conf = new Configuration()
+    conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, baseDir.getAbsolutePath())
+
+    val builder = new MiniDFSCluster.Builder(conf)
+    hdfsCluster = builder.nameNodePort(8020).format(true).build()
+    hdfsCluster.waitClusterUp()
+  }
+
+  def getNameNodeURI(): String = {
+    "hdfs://localhost:" + hdfsCluster.getNameNodePort()
+  }
+
+  def writeFileToHDFS(srcFilePath: String, hdfsDestPath: String): Unit = {
+    val fs = FileSystem.get(getHDFSConf())
+    fs.mkdirs(new Path(hdfsDestPath))
+    fs.copyFromLocalFile(new Path(srcFilePath), new Path(hdfsDestPath))
+  }
+
+  def getHDFSConf(): Configuration = {
+    val hadoopConf = new Configuration()
+    hadoopConf.set("fs.defaultFS", getNameNodeURI())
+    hadoopConf
+  }
+
+  def shutdownHDFS(): Unit = {
+    hdfsCluster.shutdown()
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -77,6 +77,12 @@ object Dependencies {
     "org.cassandraunit" % "cassandra-unit" % cassandraUnit % Test
   )
 
+  lazy val miscTestDeps = Seq(
+    "org.apache.hadoop" % "hadoop-hdfs" % hadoop % Test classifier "tests",
+    "org.apache.hadoop" % "hadoop-common" % hadoop % Test classifier "tests",
+    "org.apache.hadoop" % "hadoop-minicluster" % hadoop % Test
+  )
+
   lazy val securityDeps = Seq(
     "org.apache.shiro" % "shiro-core" % shiro
   )


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Standalone cluster with cluster mode requires
users to provide config/jar file on each worker through
file system or hadoop supported filesystems.

According to spark documentation:
"If your application is launched through Spark submit,
then the application jar is automatically distributed
to all worker nodes"

The above statement is not correct.
* If the driver folder doesn't exist on the worker, then
spark will create the folder and download the jar file
from any method that user has provided (file/hdfs/s3).
* If the driver folder already exists then Spark will
just use the already existing jar.

Further, according the Spark documentation, the configuration
"spark.files" will place the files in the working
directory of executors.

Currently, jobserver was only capable of loading files
from local system in standalone mode.

Since we want to configuration file in driver, we cannot
use this option.



**New behavior :**
This change, allows user to specify any hadoop supported
filesystem path to be passed in MANAGER_CONF_FILE,
MANAGER_JAR_FILE environment variables. We pass the jar
file path directly to spark because it can handle loading
files from HDFS supported filesystems.

Driver will use hadoop APIs to read the config file at runtime.
The path that user specifies is passed (after basic
validation) to driver and at startup it loads the
config file.

Note: If HDFS is setup in HA mode then the nameservice will
handle the routing of request to active namenode.



**BREAKING CHANGES**


**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1136)
<!-- Reviewable:end -->
