### PR TITLE
Refactor file caching

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/io/FileCacher.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/FileCacher.scala
@@ -27,11 +27,20 @@ trait FileCacher {
     appName + "-" + uploadTime.toString("yyyyMMdd_HHmmss_SSS") + s".${binaryType.extension}"
   }
 
-  // Cache the jar file into local file system.
+  protected def getPath(appName: String, binaryType: BinaryType, uploadTime: DateTime): Option[String] = {
+    val binFile = new File(rootDir, createBinaryName(appName, binaryType, uploadTime))
+    if(binFile.exists()) {
+      Some(binFile.getAbsolutePath)
+    } else {
+      None
+    }
+  }
+
+  // Cache the binary file into local file system.
   protected def cacheBinary(appName: String,
                             binaryType: BinaryType,
                             uploadTime: DateTime,
-                            binBytes: Array[Byte]) {
+                            binBytes: Array[Byte]): String = {
     val targetFullBinaryName = createBinaryName(appName, binaryType, uploadTime)
     val tempSuffix = ".tmp"
     val tempOutFile = File.createTempFile(targetFullBinaryName + "-", tempSuffix, new File(rootDir))
@@ -57,6 +66,8 @@ trait FileCacher {
         logger.warn("Could not delete the temporary file {}", tempOutFileName)
       }
     }
+
+    renamedFile.getAbsolutePath
   }
 
   protected def cleanCacheBinaries(appName: String): Unit = {
@@ -76,5 +87,4 @@ trait FileCacher {
       binaries.foreach(f => f.delete())
     }
   }
-
 }

--- a/job-server/src/main/scala/spark/jobserver/io/JobDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobDAO.scala
@@ -143,7 +143,7 @@ object JobDAO {
  */
 trait JobDAO {
   /**
-   * Persist a jar.
+   * Persist a binary data.
    *
    * @param appName
    * @param uploadTime
@@ -152,7 +152,7 @@ trait JobDAO {
   def saveBinary(appName: String, binaryType: BinaryType, uploadTime: DateTime, binaryBytes: Array[Byte])
 
   /**
-    * Delete a jar.
+    * Delete a binary data.
     * @param appName
     */
   def deleteBinary(appName: String)
@@ -171,7 +171,7 @@ trait JobDAO {
    * @param uploadTime
    * @return the local file path of the retrieved binary file.
    */
-  def retrieveBinaryFile(appName: String, binaryType: BinaryType, uploadTime: DateTime): String
+  def getBinaryFilePath(appName: String, binaryType: BinaryType, uploadTime: DateTime): String
 
   /**
    * Persist a context info.

--- a/job-server/src/main/scala/spark/jobserver/io/JobDAOActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobDAOActor.scala
@@ -87,7 +87,7 @@ class JobDAOActor(dao: JobDAO) extends InstrumentedActor {
         pipeTo(sender)
 
     case GetBinaryPath(appName, binType, uploadTime) =>
-      sender() ! BinaryPath(dao.retrieveBinaryFile(appName, binType, uploadTime))
+      sender() ! BinaryPath(dao.getBinaryFilePath(appName, binType, uploadTime))
 
     case SaveContextInfo(contextInfo) =>
       saveContextAndRespond(sender, contextInfo)

--- a/job-server/src/main/scala/spark/jobserver/io/JobFileDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobFileDAO.scala
@@ -26,8 +26,8 @@ class JobFileDAO(config: Config) extends JobDAO {
   // jobId to its Config
   private val configs = mutable.HashMap.empty[String, Config]
 
-  private val rootDir = config.getString("spark.jobserver.filedao.rootdir")
-  private val rootDirFile = new File(rootDir)
+  val rootDir = config.getString("spark.jobserver.filedao.rootdir")
+  val rootDirFile = new File(rootDir)
   logger.info("rootDir is " + rootDirFile.getAbsolutePath)
 
   private val jarsFile = new File(rootDirFile, "jars.data")
@@ -57,7 +57,6 @@ class JobFileDAO(config: Config) extends JobDAO {
         }
       } catch {
         case e: EOFException => // do nothing
-
       } finally {
         in.close()
       }
@@ -151,7 +150,7 @@ class JobFileDAO(config: Config) extends JobDAO {
     }.toMap
   }
 
-  override def retrieveBinaryFile(appName: String, binaryType: BinaryType, uploadTime: DateTime): String =
+  override def getBinaryFilePath(appName: String, binaryType: BinaryType, uploadTime: DateTime): String =
     new File(rootDir, createJarName(appName, uploadTime) + s".${binaryType.extension}").getAbsolutePath
 
   private def createJarName(appName: String, uploadTime: DateTime): String =

--- a/job-server/src/test/scala/spark/jobserver/InMemoryDAO.scala
+++ b/job-server/src/test/scala/spark/jobserver/InMemoryDAO.scala
@@ -4,7 +4,7 @@ import java.io.{BufferedOutputStream, FileOutputStream}
 
 import com.typesafe.config.Config
 import org.joda.time.DateTime
-import spark.jobserver.io.{BinaryType, JobDAO, JobInfo, JobStatus, ContextInfo, ContextStatus}
+import spark.jobserver.io.{BinaryType, ContextInfo, JobDAO, JobInfo, JobStatus}
 
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -33,7 +33,7 @@ class InMemoryDAO extends JobDAO {
     }
   }
 
-  override def retrieveBinaryFile(appName: String, binaryType: BinaryType, uploadTime: DateTime): String = {
+  override def getBinaryFilePath(appName: String, binaryType: BinaryType, uploadTime: DateTime): String = {
     // Write the jar bytes to a temporary file
     val outFile = java.io.File.createTempFile("InMemoryDAO", s".${binaryType.extension}")
     outFile.deleteOnExit()

--- a/job-server/src/test/scala/spark/jobserver/io/JobCassandraDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/JobCassandraDAOSpec.scala
@@ -132,7 +132,7 @@ class JobCassandraDAOSpec extends TestJarFinder with FunSpecLike with Matchers w
       jarFile.exists() should equal (false)
 
       // retrieve the jar file
-      val jarFilePath: String = dao.retrieveBinaryFile(jarInfo.appName, jarInfo.binaryType, jarInfo.uploadTime)
+      val jarFilePath: String = dao.getBinaryFilePath(jarInfo.appName, jarInfo.binaryType, jarInfo.uploadTime)
 
       // test
       jarFile.exists() should equal (true)

--- a/job-server/src/test/scala/spark/jobserver/io/JobDAOActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/JobDAOActorSpec.scala
@@ -23,7 +23,6 @@ object JobDAOActorSpec {
   val spyProbe = TestProbe()(system)
 
   object DummyDao extends JobDAO{
-
     override def saveBinary(appName: String, binaryType: BinaryType,
                             uploadTime: DateTime, binaryBytes: Array[Byte]): Unit = {
       appName match {
@@ -39,8 +38,8 @@ object JobDAOActorSpec {
         "app2" -> (BinaryType.Egg, dtplus1)
       ))
 
-    override def retrieveBinaryFile(appName: String,
-                                    binaryType: BinaryType, uploadTime: DateTime): String = ???
+    override def getBinaryFilePath(appName: String,
+                                   binaryType: BinaryType, uploadTime: DateTime): String = ???
 
     override def saveContextInfo(contextInfo: ContextInfo): Unit = {
       contextInfo.id match {

--- a/job-server/src/test/scala/spark/jobserver/io/JobSqlDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/JobSqlDAOSpec.scala
@@ -152,7 +152,7 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
       jarFile.exists() should equal (false)
 
       // retrieve the jar file
-      val jarFilePath: String = dao.retrieveBinaryFile(jarInfo.appName, BinaryType.Jar, jarInfo.uploadTime)
+      val jarFilePath: String = dao.getBinaryFilePath(jarInfo.appName, BinaryType.Jar, jarInfo.uploadTime)
 
       // test
       jarFile.exists() should equal (true)
@@ -184,7 +184,7 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
       eggFile.exists() should equal (false)
 
       // retrieve the jar file
-      val eggFilePath: String = dao.retrieveBinaryFile(eggInfo.appName, BinaryType.Egg, eggInfo.uploadTime)
+      val eggFilePath: String = dao.getBinaryFilePath(eggInfo.appName, BinaryType.Egg, eggInfo.uploadTime)
       // test
       eggFile.exists() should equal (true)
       eggFilePath should equal (eggFile.getAbsolutePath)


### PR DESCRIPTION
**Pull Request checklist**
- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) 

**Current behavior :** 
RetrieveBinaryFile, FetchAndCacheBinFile function are in JobSqlDAO and in JobCassandraDAO. 
RetrieveBinaryFile checks for the file path and if doesn't find a file, then caches and fetches it using FetchAndCacheBinFile.

**New behavior :**
- Add getPath function to FileCacher and decide on cache based on it (also adds a layer of abstraction). Remove FetchAndCacheBinFile.
- Rename retrieveBinaryFile to getBinaryFilePath

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1137)
<!-- Reviewable:end -->
