### PR TITLE
Update response of JAR Upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,10 @@ Then go ahead and start the job server using the instructions above.
 Let's upload the jar:
 
     curl --data-binary @job-server-tests/target/scala-2.10/job-server-tests-$VER.jar localhost:8090/jars/test
-    OK⏎
+    {
+      "status": "SUCCESS",
+      "result": "Jar uploaded"
+    }
 
 #### Ad-hoc Mode - Single, Unrelated Jobs (Transient Context)
 The above jar is uploaded as app `test`.  Next, let's start an ad-hoc word count job, meaning that the job


### PR DESCRIPTION
Previously only 200 OK was mentioned in the README which is not an accurate response for uploading a JAR. Changed it based on my recent observation of response.

**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1139)
<!-- Reviewable:end -->
