### PR TITLE
fix(core): Update Spark version to 2.3.2

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -22,7 +22,7 @@ RUN sbt update
 # add the rest of the code
 COPY . .
 
-ENV SPARK_HOME /tmp/spark-2.2.0-bin-hadoop2.7
+ENV SPARK_HOME /tmp/spark-2.3.2-bin-hadoop2.7
 ENV JAVA_OPTIONS "-Xmx1500m -XX:MaxPermSize=512m -Dakka.test.timefactor=3"
 
 CMD ["/usr/src/app/run_tests.sh"]

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Spark Job Server is now included in Datastax Enterprise 4.8!
 | 0.6.2       | 1.6.1         |
 | 0.7.0       | 1.6.2         |
 | 0.8.0       | 2.2.0    |
-| 0.8.1-SNAPSHOT | 2.2.0 |
+| 0.8.1-SNAPSHOT | 2.3.2 |
 
 For release notes, look in the `notes/` directory.
 

--- a/ci/install-spark.sh
+++ b/ci/install-spark.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
-curl -L -o /tmp/spark.tgz http://d3kbcqa49mib13.cloudfront.net/spark-2.2.0-bin-hadoop2.7.tgz
+curl -L -o /tmp/spark.tgz http://apache.lauf-forum.at/spark/spark-2.3.2/spark-2.3.2-bin-hadoop2.7.tgz
 tar -xvzf /tmp/spark.tgz -C /tmp

--- a/job-server-extras/src/test/scala/spark/jobserver/python/PythonSparkContextFactorySpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/python/PythonSparkContextFactorySpec.scala
@@ -70,7 +70,7 @@ object PythonSparkContextFactorySpec {
   lazy val jobServerAPIExamplePath = jobServerPaths.find(_.getAbsolutePath.contains("examples"))
 
   lazy val pysparkPath = sys.env.get("SPARK_HOME").map(d => s"$d/python/lib/pyspark.zip")
-  lazy val py4jPath = sys.env.get("SPARK_HOME").map(d => s"$d/python/lib/py4j-0.10.4-src.zip")
+  lazy val py4jPath = sys.env.get("SPARK_HOME").map(d => s"$d/python/lib/py4j-0.10.7-src.zip")
   lazy val originalPythonPath = sys.env.get("PYTHONPATH")
 
   case object DummyJobCache extends JobCache {

--- a/job-server-python/src/python/run-tests.sh
+++ b/job-server-python/src/python/run-tests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-PYTHONPATH=.:$SPARK_HOME/python/lib/pyspark.zip:$SPARK_HOME/python/lib/py4j-0.10.4-src.zip:$PYTHONPATH python test/apitests.py
+PYTHONPATH=.:$SPARK_HOME/python/lib/pyspark.zip:$SPARK_HOME/python/lib/py4j-0.10.7-src.zip:$PYTHONPATH python test/apitests.py
 exitCode=$?
 #This sleep is here so that all of Spark's shutdown stdout if written before we exit,
 #so that we return cleanly to the command prompt.

--- a/job-server-python/src/test/scala/spark/jobserver/python/SubprocessSpec.scala
+++ b/job-server-python/src/test/scala/spark/jobserver/python/SubprocessSpec.scala
@@ -34,10 +34,10 @@ object SubprocessSpec {
   lazy val jobServerPath = getPythonDir("src/python")
 
   lazy val pysparkPath = sys.env.get("SPARK_HOME").map(d => s"$d/python/lib/pyspark.zip")
-  lazy val py4jPath = sys.env.get("SPARK_HOME").map(d => s"$d/python/lib/py4j-0.10.4-src.zip")
+  lazy val py4jPath = sys.env.get("SPARK_HOME").map(d => s"$d/python/lib/py4j-0.10.7-src.zip")
   lazy val sparkPaths = sys.env.get("SPARK_HOME").map{sh =>
     val pysparkPath = s"$sh/python/lib/pyspark.zip"
-    val py4jPath = s"$sh/python/lib/py4j-0.10.4-src.zip"
+    val py4jPath = s"$sh/python/lib/py4j-0.10.7-src.zip"
     Seq(pysparkPath, py4jPath)
   }.getOrElse(Seq())
   lazy val originalPythonPath = sys.env.get("PYTHONPATH")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -74,7 +74,7 @@ object Dependencies {
     scalaTestDep,
     "com.typesafe.akka" %% "akka-testkit" % akka % Test,
     "io.spray" %% "spray-testkit" % spray % Test,
-    "org.cassandraunit" % "cassandra-unit" % cassandraUnit % Test
+    "org.cassandraunit" % "cassandra-unit" % cassandraUnit % Test excludeAll(excludeJpountz)
   )
 
   lazy val miscTestDeps = Seq(

--- a/project/ExclusionRules.scala
+++ b/project/ExclusionRules.scala
@@ -8,4 +8,5 @@ object ExclusionRules {
   val excludeNettyIo = ExclusionRule(organization = "io.netty").withArtifact("netty-all")
   val excludeAsm = ExclusionRule(organization = "asm")
   val excludeQQ = ExclusionRule(organization = "org.scalamacros")
+  val excludeJpountz = ExclusionRule(organization = "net.jpountz.lz4", name = "lz4")
 }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,7 +1,7 @@
 import scala.util.Properties.isJavaAtLeast
 
 object Versions {
-  lazy val spark = sys.env.getOrElse("SPARK_VERSION", "2.2.0")
+  lazy val spark = sys.env.getOrElse("SPARK_VERSION", "2.3.2")
 
   lazy val akka = "2.4.9"
   lazy val cassandra = "3.3.0"
@@ -17,10 +17,10 @@ object Versions {
   lazy val logback = "1.0.7"
   lazy val mesos = sys.env.getOrElse("MESOS_VERSION", "1.0.0-2.0.89.ubuntu1404")
   lazy val metrics = "2.2.0"
-  lazy val netty = "4.0.44.Final"
+  lazy val netty = "4.1.17.Final"
   lazy val postgres = "9.4.1209"
   lazy val mysql = "5.1.42"
-  lazy val py4j = "0.10.4"
+  lazy val py4j = "0.10.7"
   lazy val scalaTest = "3.0.1"
   lazy val scalatic = "3.0.1"
   lazy val shiro = "1.2.4"
@@ -30,3 +30,4 @@ object Versions {
   lazy val typeSafeConfig = if (isJavaAtLeast("1.8")) "1.3.0" else "1.2.1"
   lazy val cassandraConnector = "2.0.5"
 }
+


### PR DESCRIPTION
Note: Currently, docker part is not verified.

Due to update, multiple testcases failed with
NoSuchMethodError with following errors
- io.netty.buffer.PooledByteBufAllocator.metric()
  Netty was updated to fix this.
- net.jpountz.lz4.LZ4BlockInputStream.<init>
  cassandra-unit dependency was bringing old version
  of lz4 which was 1.3.0. Spark upgraded this library
  in new version and cannot work without 1.4.0. So,
  excluded the 1.3.0 from cassandra-unit.
  https://issues.apache.org/jira/browse/SPARK-21276
- ImportError: No module named py4j.java_gateway
  Updated the py4j version to 0.10.7, the hint for
  this version comes from what Spark package internally
  uses. Inside spark 2.3.2 package, the right py4j
  version can be figured out by going to
  spark_package_dir/python/lib/

Tests:
Executed a simple Kafka spark job (compiled against
Spark 2.3.2) to verify if everything is ok.
If we don't recompile then we get java.lang.AbstractMethodError.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
Currently jobserver supports 2.2.0


**New behavior :**
Supports 2.3.0 without K8s


**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1145)
<!-- Reviewable:end -->
