### PR TITLE
Remove netty-all exclusion rule

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,19 +28,17 @@ object Dependencies {
   )
 
   lazy val sparkDeps = Seq(
-    "org.apache.spark" %% "spark-core" % spark % "provided" excludeAll(excludeNettyIo, excludeQQ),
-    // Force netty version.  This avoids some Spark netty dependency problem.
-    "io.netty" % "netty-all" % netty
+    "org.apache.spark" %% "spark-core" % spark % "provided" excludeAll excludeQQ
   )
 
   lazy val sparkExtraDeps = Seq(
-    "org.apache.derby" % "derby" % derby % Provided excludeAll(excludeNettyIo, excludeQQ),
-    "org.apache.hadoop" % "hadoop-client" % hadoop % Provided excludeAll(excludeNettyIo, excludeQQ),
-    "org.apache.spark" %% "spark-mllib" % spark % Provided excludeAll(excludeNettyIo, excludeQQ),
-    "org.apache.spark" %% "spark-sql" % spark % Provided excludeAll(excludeNettyIo, excludeQQ),
-    "org.apache.spark" %% "spark-streaming" % spark % Provided excludeAll(excludeNettyIo, excludeQQ),
+    "org.apache.derby" % "derby" % derby % Provided excludeAll excludeQQ,
+    "org.apache.hadoop" % "hadoop-client" % hadoop % Provided excludeAll excludeQQ,
+    "org.apache.spark" %% "spark-mllib" % spark % Provided excludeAll excludeQQ,
+    "org.apache.spark" %% "spark-sql" % spark % Provided excludeAll excludeQQ,
+    "org.apache.spark" %% "spark-streaming" % spark % Provided excludeAll excludeQQ,
     "org.apache.spark" %% "spark-hive" % spark % Provided excludeAll(
-      excludeNettyIo, excludeQQ, excludeScalaTest
+      excludeQQ, excludeScalaTest
       )
   )
 

--- a/project/ExclusionRules.scala
+++ b/project/ExclusionRules.scala
@@ -5,7 +5,6 @@ object ExclusionRules {
   val excludeJackson = ExclusionRule(organization = "org.codehaus.jackson")
   val excludeScalaTest = ExclusionRule(organization = "org.scalatest")
   val excludeScala = ExclusionRule(organization = "org.scala-lang")
-  val excludeNettyIo = ExclusionRule(organization = "io.netty").withArtifact("netty-all")
   val excludeAsm = ExclusionRule(organization = "asm")
   val excludeQQ = ExclusionRule(organization = "org.scalamacros")
   val excludeJpountz = ExclusionRule(organization = "net.jpountz.lz4", name = "lz4")

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -17,7 +17,6 @@ object Versions {
   lazy val logback = "1.0.7"
   lazy val mesos = sys.env.getOrElse("MESOS_VERSION", "1.0.0-2.0.89.ubuntu1404")
   lazy val metrics = "2.2.0"
-  lazy val netty = "4.1.17.Final"
   lazy val postgres = "9.4.1209"
   lazy val mysql = "5.1.42"
   lazy val py4j = "0.10.7"


### PR DESCRIPTION
**Pull Request checklist**
- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format)

**Current behavior :** 
* The rule is excluding and adding the same version of the library (Spark 2.3.2 depends on netty-all 4.1.17: https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.11/2.3.2)
* ExclusionRule seem to be broken (using artifact property instead of name)

**New behavior :**
Remove exclusion rule at all


**Other information**:
https://github.com/spark-jobserver/spark-jobserver/issues/1150

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1152)
<!-- Reviewable:end -->
