### PR TITLE
feat(job-server): pass context name as appName when context is submitted

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -501,7 +501,7 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef,
     logger.info("Created working directory {} for context {}", contextDir: Any, name)
 
     val launcher = new ManagerLauncher(config, contextConfig,
-        selfAddress.toString, contextActorName, contextDir.toString)
+        selfAddress.toString, encodedContextName, contextActorName, contextDir.toString)
 
     launcher.start()
   }

--- a/job-server/src/main/scala/spark/jobserver/util/ManagerLauncher.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/ManagerLauncher.scala
@@ -20,8 +20,8 @@ object ManagerLauncher {
   }
 }
 
-class ManagerLauncher(systemConfig: Config, contextConfig: Config,
-                      masterAddress: String, contextActorName: String, contextDir: String,
+class ManagerLauncher(systemConfig: Config, contextConfig: Config, masterAddress: String,
+                      contextName: String, contextActorName: String, contextDir: String,
                       sparkLauncher: SparkLauncher = new SparkLauncher,
                       environment: Environment = new SystemEnvironment)
                       extends Launcher(systemConfig, sparkLauncher, environment) {
@@ -55,6 +55,10 @@ class ManagerLauncher(systemConfig: Config, contextConfig: Config,
       launcher.addSparkArg("--conf", s"spark.executor.extraJavaOptions=$loggingOpts")
       launcher.addSparkArg("--driver-java-options",
           s"$gcOPTS $baseJavaOPTS $loggingOpts $configOverloads $extraJavaOPTS")
+
+      if (!contextName.isEmpty) {
+        launcher.setAppName(contextName)
+      }
 
       if (useSuperviseMode) {
         launcher.addSparkArg("--supervise")

--- a/job-server/src/test/scala/spark/jobserver/util/ManagerLauncherSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/util/ManagerLauncherSpec.scala
@@ -16,7 +16,8 @@ class ManagerLauncherSpec extends FunSpec with Matchers with BeforeAndAfter {
     lazy val baseSystemConf = buildConfig(baseSystemConfMap)
     lazy val baseContextMap = Map("launcher.spark.driver.memory" -> "1g")
     lazy val baseContextConf = buildConfig(baseContextMap)
-    lazy val managerLauncherFunc = new ManagerLauncher(baseSystemConf, _:Config, "", "", "", stubbedSparkLauncher, environment)
+    lazy val managerLauncherFunc = new ManagerLauncher(
+      baseSystemConf, _: Config, "", "", "", "", stubbedSparkLauncher, environment)
 
     def resetStoredSettings() {
       environment.clear()
@@ -110,15 +111,16 @@ class ManagerLauncherSpec extends FunSpec with Matchers with BeforeAndAfter {
      it("should pass all application arguments to SparkLauncher") {
        environment.set("MANAGER_CONF_FILE", "conf-file")
 
-       val managerLauncher = new ManagerLauncher(baseSystemConf, baseContextConf, "master-address", "actor-name", "", stubbedSparkLauncher, environment)
+       val managerLauncher = new ManagerLauncher(baseSystemConf, baseContextConf, "master-address", "context-name", "actor-name", "", stubbedSparkLauncher, environment)
        managerLauncher.start()
 
        stubbedSparkLauncher.getLauncherConfig().containsValue(StubbedSparkLauncher.APP_ARGS, "master-address,actor-name,conf-file") should be (true)
+       stubbedSparkLauncher.getLauncherConfig().containsValue(StubbedSparkLauncher.APP_NAME, "context-name")
      }
 
      it("should fail if supervise mode is specified with client mode") {
        val baseConfWithSuperviseMode = baseSystemConfMap + ("spark.driver.supervise" -> "true")
-       val launcher = new ManagerLauncher(buildConfig(baseConfWithSuperviseMode), baseContextConf, "", "", "", stubbedSparkLauncher, environment)
+       val launcher = new ManagerLauncher(buildConfig(baseConfWithSuperviseMode), baseContextConf, "", "", "", "", stubbedSparkLauncher, environment)
 
        launcher.start() should be (false, "Supervise mode can only be used with cluster mode")
      }
@@ -134,7 +136,7 @@ class ManagerLauncherSpec extends FunSpec with Matchers with BeforeAndAfter {
      it("should fail if supervise mode is specified with yarn") {
        val systemConfMap = Map("spark.master" -> "yarn", "spark.submit.deployMode" -> "cluster", "spark.driver.supervise" -> "true")
 
-       val launcher = new ManagerLauncher(buildConfig(systemConfMap), baseContextConf, "", "", "", stubbedSparkLauncher, environment)
+       val launcher = new ManagerLauncher(buildConfig(systemConfMap), baseContextConf, "", "", "", "", stubbedSparkLauncher, environment)
 
        launcher.start() should be (false, "Supervise mode is only supported with spark standalone or Mesos")
      }
@@ -142,7 +144,7 @@ class ManagerLauncherSpec extends FunSpec with Matchers with BeforeAndAfter {
      it("should fail if supervise mode is specified (in context config) with yarn") {
        val systemConfMap = Map("spark.master" -> "yarn", "spark.submit.deployMode" -> "cluster")
        val contextConfMap = baseContextMap + (ManagerLauncher.CONTEXT_SUPERVISE_MODE_KEY -> "true")
-       val launcher = new ManagerLauncher(buildConfig(systemConfMap), buildConfig(contextConfMap), "", "", "", stubbedSparkLauncher, environment)
+       val launcher = new ManagerLauncher(buildConfig(systemConfMap), buildConfig(contextConfMap), "", "", "", "", stubbedSparkLauncher, environment)
 
        launcher.start() should be (false, "Supervise mode is only supported with spark standalone or Mesos")
      }
@@ -150,7 +152,7 @@ class ManagerLauncherSpec extends FunSpec with Matchers with BeforeAndAfter {
      it("should set supervise flag if system config and context config have supervise mode enabled") {
        val systemConfMap = Map("spark.master" -> "local[4]", "spark.submit.deployMode" -> "cluster", "spark.driver.supervise" -> "true")
        val contextConfMap = baseContextMap + (ManagerLauncher.CONTEXT_SUPERVISE_MODE_KEY -> "true")
-       val launcher = new ManagerLauncher(buildConfig(systemConfMap), buildConfig(contextConfMap), "", "", "", stubbedSparkLauncher, environment)
+       val launcher = new ManagerLauncher(buildConfig(systemConfMap), buildConfig(contextConfMap), "", "", "", "", stubbedSparkLauncher, environment)
 
        launcher.start()
 
@@ -162,7 +164,7 @@ class ManagerLauncherSpec extends FunSpec with Matchers with BeforeAndAfter {
      it("should set supervise flag if only context config has supervise mode enabled") {
        val systemConfMap = Map("spark.master" -> "local[4]", "spark.submit.deployMode" -> "cluster")
        val contextConfMap = baseContextMap + (ManagerLauncher.CONTEXT_SUPERVISE_MODE_KEY -> "true")
-       val launcher = new ManagerLauncher(buildConfig(systemConfMap), buildConfig(contextConfMap), "", "", "", stubbedSparkLauncher, environment)
+       val launcher = new ManagerLauncher(buildConfig(systemConfMap), buildConfig(contextConfMap), "", "", "", "", stubbedSparkLauncher, environment)
 
        launcher.start()
 
@@ -173,7 +175,7 @@ class ManagerLauncherSpec extends FunSpec with Matchers with BeforeAndAfter {
      it("should not set supervise flag if supervise mode is enabled in system config but context config doesn't have a value defined") {
        val systemConfMap = Map("spark.master" -> "local[4]", "spark.submit.deployMode" -> "cluster", ManagerLauncher.SJS_SUPERVISE_MODE_KEY -> "true")
        val contextConfMap = baseContextMap
-       val launcher = new ManagerLauncher(buildConfig(systemConfMap), buildConfig(contextConfMap), "", "", "", stubbedSparkLauncher, environment)
+       val launcher = new ManagerLauncher(buildConfig(systemConfMap), buildConfig(contextConfMap), "", "", "", "", stubbedSparkLauncher, environment)
 
        launcher.start()
 
@@ -184,7 +186,7 @@ class ManagerLauncherSpec extends FunSpec with Matchers with BeforeAndAfter {
      it("should not set supervise flag if supervise mode is disabled in system config and context config doesn't have a value defined") {
        val systemConfMap = Map("spark.master" -> "local[4]", "spark.submit.deployMode" -> "cluster", ManagerLauncher.SJS_SUPERVISE_MODE_KEY -> "false")
        val contextConfMap = baseContextMap
-       val launcher = new ManagerLauncher(buildConfig(systemConfMap), buildConfig(contextConfMap), "", "", "", stubbedSparkLauncher, environment)
+       val launcher = new ManagerLauncher(buildConfig(systemConfMap), buildConfig(contextConfMap), "", "", "", "", stubbedSparkLauncher, environment)
 
        launcher.start()
 
@@ -195,7 +197,7 @@ class ManagerLauncherSpec extends FunSpec with Matchers with BeforeAndAfter {
      it("should not set supervise flag if supervise mode is enabled in system config but disabled in context config") {
        val systemConfMap = Map("spark.master" -> "local[4]", "spark.submit.deployMode" -> "cluster", ManagerLauncher.SJS_SUPERVISE_MODE_KEY -> "true")
        val contextConfMap = baseContextMap + (ManagerLauncher.CONTEXT_SUPERVISE_MODE_KEY -> "false")
-       val launcher = new ManagerLauncher(buildConfig(systemConfMap), buildConfig(contextConfMap), "", "", "", stubbedSparkLauncher, environment)
+       val launcher = new ManagerLauncher(buildConfig(systemConfMap), buildConfig(contextConfMap), "", "", "", "", stubbedSparkLauncher, environment)
 
        launcher.start()
 
@@ -213,7 +215,7 @@ class ManagerLauncherSpec extends FunSpec with Matchers with BeforeAndAfter {
 
      it("should write gc logs to current execution directory in cluster/supervise mode") {
        val systemConfMap = Map("spark.master" -> "yarn", "spark.submit.deployMode" -> "cluster")
-       val launcher = new ManagerLauncher(buildConfig(systemConfMap), baseContextConf, "", "", "", stubbedSparkLauncher, environment)
+       val launcher = new ManagerLauncher(buildConfig(systemConfMap), baseContextConf, "", "", "", "", stubbedSparkLauncher, environment)
 
        launcher.start()
 
@@ -223,7 +225,7 @@ class ManagerLauncherSpec extends FunSpec with Matchers with BeforeAndAfter {
 
      it("should write gc logs to directory passed as argument (client mode scenario)") {
        val systemConfMap = Map("spark.master" -> "yarn", "spark.submit.deployMode" -> "client")
-       val launcher = new ManagerLauncher(buildConfig(systemConfMap), baseContextConf, "", "", "/test/directory", stubbedSparkLauncher, environment)
+       val launcher = new ManagerLauncher(buildConfig(systemConfMap), baseContextConf, "", "", "", "/test/directory", stubbedSparkLauncher, environment)
 
        launcher.start()
 
@@ -255,6 +257,7 @@ object StubbedSparkLauncher {
     final val DEPLOY_MODE = "fake.spark.submit.deployMode"
     final val APP_RESOURCES = "fake.spark.jar.path"
     final val MAIN_CLASS = "fake.spark.main.class"
+    final val APP_NAME = "fake.spark.app.name"
     final val APP_ARGS = "fake.spark.app.args"
     final val SPARK_ARGS = "fake.spark.conf"
     final val SPARK_DRIVER_SUPERVISE = "fake.spark.driver.supervise"
@@ -293,6 +296,11 @@ class StubbedSparkLauncher extends SparkLauncher {
 
       override def setMainClass(mainClass: String): SparkLauncher = {
         launcherConfig.put(StubbedSparkLauncher.MAIN_CLASS, mainClass)
+        null
+      }
+
+      override def setAppName(appName: String): SparkLauncher = {
+        launcherConfig.put(StubbedSparkLauncher.APP_NAME, appName)
         null
       }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1156)
<!-- Reviewable:end -->
