### PR TITLE
 Minor fixes in gitignore and scripts shebang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ config/*.conf
 config/*.sh
 config/*.ini
 job-server/config/*.conf
+job-server/config/*.sh
 job-server/config/*.ini
 job-server-extras/spark-warehouse/
 metastore_db/

--- a/bin/ec2_deploy.sh
+++ b/bin/ec2_deploy.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -e
+set -u
 bin=`dirname "${BASH_SOURCE-$0}"`
 bin=`cd "$bin"; pwd`
 

--- a/bin/ec2_destroy.sh
+++ b/bin/ec2_destroy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 bin=`dirname "${BASH_SOURCE-$0}"`
 bin=`cd "$bin"; pwd`
 

--- a/bin/kill-process-tree.sh
+++ b/bin/kill-process-tree.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "$(which pgrep)" == "" ]; then
     echo "pgrep is not available" >&2

--- a/bin/server_deploy.sh
+++ b/bin/server_deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Script for deploying the job server to a host
 ENV=$1
 if [ -z "$ENV" ]; then

--- a/bin/server_host_setup.sh
+++ b/bin/server_host_setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Script for setting up folders for job server deployment
 ENV=$1
 if [ -z "$ENV" ]; then

--- a/bin/server_package.sh
+++ b/bin/server_package.sh
@@ -1,5 +1,7 @@
-#!/bin/bash -ue
+#!/usr/bin/env bash
 # Script for packaging all the job server files to .tar.gz for Mesos or other single-image deploys
+set -u
+set -e
 WORK_DIR=/tmp/job-server
 
 if [ "$#" -ne 1 ]; then

--- a/bin/server_start.sh
+++ b/bin/server_start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Script to start the job server
 # Extra arguments will be spark-submit options, for example
 #  ./server_start.sh --jars cassandra-spark-connector.jar

--- a/bin/server_stop.sh
+++ b/bin/server_stop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Script to stop the job server
 
 get_abs_script_path() {

--- a/bin/setenv.sh
+++ b/bin/setenv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) 

**New behavior :**

- Use shebang with env (#!/usr/bin/env searches PATH for bash, which may be not /bin/bash)
- Ignore job-server .sh configs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1168)
<!-- Reviewable:end -->
