### PR TITLE
fix(jobserver): Upgrade C* connector version

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -27,6 +27,5 @@ object Versions {
   lazy val spray = "1.3.3"
   lazy val sprayJson = "1.3.2"
   lazy val typeSafeConfig = if (isJavaAtLeast("1.8")) "1.3.0" else "1.2.1"
-  lazy val cassandraConnector = "2.0.5"
+  lazy val cassandraConnector = "2.3.2"
 }
-


### PR DESCRIPTION
As pointed by @TharinduAmila and confirmed by
version compatability metrics on
https://github.com/datastax/spark-cassandra-connector#version-compatibility
, the  version of C* connector should be 2.3
for Spark 2.3.2.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1170)
<!-- Reviewable:end -->
