### PR TITLE
feat(pythonJob): Support HDFS pyFiles dependencies in cluster

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -1,7 +1,6 @@
 package spark.jobserver
 
 import java.nio.file.{Files, Paths}
-import java.nio.charset.Charset
 import java.util.concurrent.TimeUnit
 
 import akka.actor._
@@ -20,12 +19,10 @@ import spark.jobserver.common.akka.InstrumentedActor
 
 import scala.concurrent.Await
 import org.joda.time.DateTime
-import org.slf4j.LoggerFactory
 import spark.jobserver.JobManagerActor.{GetContexData, ContexData, SparkContextDead, RestartExistingJobs}
-import spark.jobserver.JobManagerActor.ContextTerminatedException
 import spark.jobserver.io.{JobDAOActor, ContextInfo, ContextStatus, JobStatus, ErrorData}
 import spark.jobserver.util.{InternalServerErrorException, NoCallbackFoundException,
-  ContextJVMInitializationTimeout, ContextForcefulKillTimeout}
+  ContextJVMInitializationTimeout}
 import com.google.common.annotations.VisibleForTesting
 
 object AkkaClusterSupervisorActor {
@@ -527,9 +524,8 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef,
     }.getOrElse(Files.createTempDirectory("jobserver"))
     logger.info("Created working directory {} for context {}", contextDir: Any, name)
 
-    val launcher = new ManagerLauncher(config, contextConfig,
-        selfAddress.toString, encodedContextName, contextActorName, contextDir.toString)
-
+    val launcher = ManagerLauncher(config, contextConfig,
+      selfAddress.toString, encodedContextName, contextActorName, contextDir.toString)
     launcher.start()
   }
 

--- a/job-server/src/main/scala/spark/jobserver/JobManager.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManager.scala
@@ -1,5 +1,6 @@
 package spark.jobserver
 
+import java.io.File
 import java.nio.file.Files
 import java.util.concurrent.TimeUnit
 
@@ -29,7 +30,9 @@ object JobManager {
   // Allow custom function to wait for termination. Useful in tests.
   def start(args: Array[String], makeSystem: Config => ActorSystem,
             waitForTermination: (ActorSystem, String, String) => Unit) {
-
+    sys.props.get("spark.jobserver.tmpDir").foreach{ tmpDir =>
+      FileUtils.forceDeleteOnExit(new File(tmpDir))
+    }
     val clusterAddress = AddressFromURIString.parse(args(0))
     val managerName = args(1)
     val loadedConfig = getConfFromFS(args(2)).getOrElse(exitJVM)

--- a/job-server/src/main/scala/spark/jobserver/util/HadoopFSFacade.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/HadoopFSFacade.scala
@@ -1,6 +1,6 @@
 package spark.jobserver.util
 
-import java.io.{InputStreamReader, Reader}
+import java.io.{File, InputStreamReader, Reader}
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
@@ -124,6 +124,26 @@ class HadoopFSFacade(hadoopConf: Configuration = new Configuration(),
       }
     }
     FileSystem.get(new Path(filePath).toUri, hadoopConf)
+  }
+
+
+  /**
+    * Download a file from the remote to a local temporary directory. If the input path points to
+    * a local path, returns it with no operation.
+    */
+  def downloadFile(path: String, dist: File): String = {
+    require(path != null, "path cannot be null.")
+    val uri = Utils.resolveURI(path)
+    uri.getScheme match {
+      case "file" | "local" =>
+        path
+      case _ =>
+        val fs = FileSystem.get(uri, hadoopConf)
+        val localFile = new File(dist, uri.getPath)
+        logger.info(s"Downloading ${uri.toString} to ${localFile.getAbsolutePath}.")
+        fs.copyToLocalFile(new Path(uri), new Path(localFile.getAbsolutePath))
+        Utils.resolveURI(localFile.getAbsolutePath).toString
+    }
   }
 }
 

--- a/job-server/src/main/scala/spark/jobserver/util/Launcher.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/Launcher.scala
@@ -3,71 +3,75 @@ package spark.jobserver.util
 import com.typesafe.config.Config
 import org.apache.spark.launcher.{SparkAppHandle, SparkLauncher}
 import org.slf4j.LoggerFactory
-
 import scala.util.Try
+
 /**
- * This class aims to eliminate the need to call spark-submit
- * through scripts.
- *
- * When server_start.sh is executed it sources the setenv.sh
- * script. set -a flag enables exporting the variables to
- * environment. Launcher uses those environment variables to
- * start context JVMs using SparkLauncher class.
- */
+  * This class aims to eliminate the need to call spark-submit
+  * through scripts.
+  *
+  * When server_start.sh is executed it sources the setenv.sh
+  * script. set -a flag enables exporting the variables to
+  * environment. Launcher uses those environment variables to
+  * start context JVMs using SparkLauncher class.
+  */
 abstract class Launcher(config: Config, sparkLauncher: SparkLauncher, enviornment: Environment) {
-    private val logger = LoggerFactory.getLogger("spark-launcher")
-    private var handler: SparkAppHandle = null
+  private val logger = LoggerFactory.getLogger("spark-launcher")
+  private var handler: SparkAppHandle = null
 
-    protected final val master = config.getString("spark.master")
-    protected final val defaultSuperviseModeEnabled = Try(
-        config.getBoolean(ManagerLauncher.SJS_SUPERVISE_MODE_KEY)).getOrElse(false)
-    protected final val deployMode = config.getString("spark.submit.deployMode")
-    protected final val sjsJarPath = getEnvironmentVariable("MANAGER_JAR_FILE")
-    protected final val baseGCOPTS = getEnvironmentVariable("GC_OPTS_BASE")
-    protected final val baseJavaOPTS = getEnvironmentVariable("JAVA_OPTS_BASE")
-    protected val launcher = sparkLauncher
+  protected final val master = config.getString("spark.master")
+  protected final val defaultSuperviseModeEnabled = Try(
+    config.getBoolean(ManagerLauncher.SJS_SUPERVISE_MODE_KEY)).getOrElse(false)
+  protected final val deployMode = config.getString("spark.submit.deployMode")
+  protected final val sjsJarPath = getEnvironmentVariable("MANAGER_JAR_FILE")
+  protected final val baseGCOPTS = getEnvironmentVariable("GC_OPTS_BASE")
+  protected final val baseJavaOPTS = getEnvironmentVariable("JAVA_OPTS_BASE")
+  protected val launcher = sparkLauncher
 
-    protected def addCustomArguments()
+  protected def addCustomArguments()
 
-    final def start(): (Boolean, String) = {
-      validate() match {
-        case (false, error) => return (false, error)
-        case _ =>
-      }
-
-      initSparkLauncher()
-
-      try {
-        logger.info("Adding custom arguments to launcher")
-        addCustomArguments()
-
-        logger.info("Start launcher application")
-        handler = launcher.startApplication()
-        (true, "")
-      } catch {
-        case err: Exception =>
-          logger.error("Failed to launch", err);
-          (false, err.getMessage)
-      }
+  final def start(): (Boolean, String) = {
+    validate() match {
+      case (false, error) => return (false, error)
+      case _ =>
     }
 
-    protected def getEnvironmentVariable(name: String, default: String = ""): String = {
-      enviornment.get(name, default)
-    }
+    initSparkLauncher()
 
-    private def initSparkLauncher() {
-      logger.info("Initializing spark launcher")
-      launcher.setSparkHome(getEnvironmentVariable("SPARK_HOME"))
-      launcher.setDeployMode(deployMode)
-      launcher.setAppResource(sjsJarPath)
-      launcher.setVerbose((getEnvironmentVariable("SPARK_LAUNCHER_VERBOSE") == "1"))
-    }
+    try {
+      logger.info("Adding custom arguments to launcher")
+      addCustomArguments()
 
-    protected def validate(): (Boolean, String) = {
-      new HadoopFSFacade(defaultFS = "file:///").isFile(sjsJarPath) match {
-        case Some(true) => (true, "")
-        case Some(false) => (false, s"job-server jar file doesn't exist at $sjsJarPath")
-        case None => (false, "Unexpected error occurred while reading file. Check logs")
-      }
+      logger.info("Start launcher application")
+      handler = launcher.startApplication()
+      (true, "")
+    } catch {
+      case err: Exception =>
+        logger.error("Failed to launch", err);
+        (false, err.getMessage)
     }
+  }
+
+  protected def getEnvironmentVariable(name: String, default: String = ""): String = {
+    enviornment.get(name, default)
+  }
+
+  private def initSparkLauncher() {
+    logger.info("Initializing spark launcher")
+    launcher.setSparkHome(getEnvironmentVariable("SPARK_HOME"))
+    launcher.setDeployMode(deployMode)
+    launcher.setAppResource(sjsJarPath)
+    launcher.setVerbose((getEnvironmentVariable("SPARK_LAUNCHER_VERBOSE") == "1"))
+  }
+
+  protected def validate(): (Boolean, String) = {
+    new HadoopFSFacade(defaultFS = "file:///").isFile(sjsJarPath) match {
+      case Some(true) => (true, "")
+      case Some(false) => (false, s"job-server jar file doesn't exist at $sjsJarPath")
+      case None => (false, "Unexpected error occurred while reading file. Check logs")
+    }
+  }
+
+
+
+
 }

--- a/job-server/src/main/scala/spark/jobserver/util/ManagerLauncher.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/ManagerLauncher.scala
@@ -120,7 +120,8 @@ class ManagerLauncher(systemConfig: Config, contextConfig: Config, masterAddress
     getStringSeq(contextConfig, "jars").foreach(launcher.addJar)
     getStringSeq(contextConfig, "files").foreach(launcher.addFile)
 
-    if (contextConfig.getString("context-factory").contains("python")) {
+    if (contextConfig.hasPath("context-factory") &&
+      contextConfig.getString("context-factory").contains("python")){
       // Since `--py-files` in not available in Java applications,
       // we distribute pyFiles to cluster var `--files`
       launcher.setConf("spark.yarn.isPython", "true")
@@ -141,7 +142,7 @@ class ManagerLauncher(systemConfig: Config, contextConfig: Config, masterAddress
     for (e <- Try(contextConfig.getConfig("launcher"))) {
       e.entrySet().asScala.map { c =>
         // Supervise mode was already handled above, no need to do it here again
-        if (c.getKey.startsWith("spark") && c.getKey != "spark.driver.supervise") {
+        if (c.getKey != "spark.driver.supervise") {
           launcher.addSparkArg("--conf", s"${c.getKey}=${c.getValue.unwrapped.toString}")
         }
       }

--- a/job-server/src/main/scala/spark/jobserver/util/ManagerLauncher.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/ManagerLauncher.scala
@@ -64,7 +64,6 @@ object ManagerLauncher {
       env.put("SJSPYTHONPATH", sjsPythonPath)
     }
     val sparkLauncher = new SparkLauncher(env.asJava)
-    sparkLauncher.setMaster(contextSparkMaster)
     new ManagerLauncher(config, contextConfig, masterAddress,
       contextName, contextActorName, contextDir.toString, sparkLauncher)
   }
@@ -97,6 +96,9 @@ class ManagerLauncher(systemConfig: Config, contextConfig: Config, masterAddress
       gcOPTS += s" -Xloggc:$gcFileName"
     }
 
+    val contextSparkMaster = Try(contextConfig.getString("launcher.spark.master"))
+      .getOrElse(SparkMasterProvider.fromConfig(systemConfig).getSparkMaster(systemConfig))
+    launcher.setMaster(contextSparkMaster)
     launcher.setMainClass("spark.jobserver.JobManager")
     launcher.addAppArgs(masterAddress, contextActorName, getEnvironmentVariable("MANAGER_CONF_FILE"))
     launcher.addSparkArg("--conf", s"spark.executor.extraJavaOptions=$loggingOpts")

--- a/job-server/src/main/scala/spark/jobserver/util/ManagerLauncher.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/ManagerLauncher.scala
@@ -1,22 +1,72 @@
 package spark.jobserver.util
 
 import java.io.File
+import java.nio.file.Files
+
 import scala.util.Try
 import collection.JavaConverters._
 import com.typesafe.config.Config
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.yarn.api.ApplicationConstants
 import org.slf4j.LoggerFactory
 import org.apache.spark.launcher.SparkLauncher
+import spark.jobserver.util.ManagerLauncher.getStringSeq
+
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
 
 object ManagerLauncher {
   final val SJS_SUPERVISE_MODE_KEY = "spark.driver.supervise"
   final val CONTEXT_SUPERVISE_MODE_KEY = "launcher.spark.driver.supervise"
 
   def shouldSuperviseModeBeEnabled(sjsSupervisorMode: Boolean,
-      contextSupervisorMode: Option[Boolean]): Boolean = {
+                                   contextSupervisorMode: Option[Boolean]): Boolean = {
     (sjsSupervisorMode, contextSupervisorMode) match {
       case (_, Some(contextSupervisorMode)) => contextSupervisorMode
       case (_, None) => sjsSupervisorMode
     }
+  }
+
+  def getStringSeq(conf: Config, key: String): Seq[String] = {
+    Try(conf.getStringList(key).asScala).
+      orElse(Try(conf.getString(key).split(",").toSeq)).getOrElse(Nil)
+  }
+
+  def apply(config: Config, contextConfig: Config, masterAddress: String,
+            contextName: String, contextActorName: String, contextDir: String): ManagerLauncher = {
+
+    // Here we pre-add pyFiles to the PYTHONPATH of the spark-submit process
+    val environment: Environment = new SystemEnvironment
+    val env = mutable.Map[String, String]()
+
+    val contextSparkMaster = Try(contextConfig.getString("launcher.spark.master"))
+      .getOrElse(SparkMasterProvider.fromConfig(config).getSparkMaster(config))
+    if (contextConfig.getString("context-factory").contains("python")) {
+      // On YARN mode, the following preprocessed PYTHONPATH will be added to the PYTHONPATH
+      // of the YARN container processes
+      if (contextSparkMaster.contains("yarn")) {
+        val pythonPath = new ListBuffer[String]()
+        getStringSeq(contextConfig, "launcher.py-files").foreach { path =>
+          val uri = Utils.resolveURI(path)
+          val fname = new Path(uri).getName
+          if (!fname.endsWith(".py")) {
+            if (uri.getScheme != "local") {
+              pythonPath += ApplicationConstants.Environment.PWD.$$() + Path.SEPARATOR + fname
+            } else {
+              pythonPath += uri.getPath
+            }
+          }
+        }
+        env.put("PYTHONPATH", pythonPath.mkString(ApplicationConstants.CLASS_PATH_SEPARATOR))
+      }
+      // If the Spark driver is not in cluster, use the PYTHONPATH of client process
+      val sjsPythonPath = environment.get("PYTHONPATH", "")
+      env.put("SJSPYTHONPATH", sjsPythonPath)
+    }
+    val sparkLauncher = new SparkLauncher(env.asJava)
+    sparkLauncher.setMaster(contextSparkMaster)
+    new ManagerLauncher(config, contextConfig, masterAddress,
+      contextName, contextActorName, contextDir.toString, sparkLauncher)
   }
 }
 
@@ -24,7 +74,7 @@ class ManagerLauncher(systemConfig: Config, contextConfig: Config, masterAddress
                       contextName: String, contextActorName: String, contextDir: String,
                       sparkLauncher: SparkLauncher = new SparkLauncher,
                       environment: Environment = new SystemEnvironment)
-                      extends Launcher(systemConfig, sparkLauncher, environment) {
+  extends Launcher(systemConfig, sparkLauncher, environment) {
   val logger = LoggerFactory.getLogger("spark-context-launcher")
 
   var loggingOpts = getEnvironmentVariable("MANAGER_LOGGING_OPTS")
@@ -35,76 +85,94 @@ class ManagerLauncher(systemConfig: Config, contextConfig: Config, masterAddress
   lazy val contextSuperviseModeEnabled: Option[Boolean] = Try(Some(
     contextConfig.getBoolean(ManagerLauncher.CONTEXT_SUPERVISE_MODE_KEY))).getOrElse(None)
   lazy val useSuperviseMode = ManagerLauncher.shouldSuperviseModeBeEnabled(
-      defaultSuperviseModeEnabled, contextSuperviseModeEnabled)
+    defaultSuperviseModeEnabled, contextSuperviseModeEnabled)
 
   override def addCustomArguments() {
-      val gcFileName = getEnvironmentVariable("GC_OUT_FILE_NAME", "gc.out")
-      if (deployMode == "client") {
-        val gcFilePath = new File(contextDir, gcFileName).toString()
-        loggingOpts += s" -DLOG_DIR=$contextDir"
-        gcOPTS += s" -Xloggc:$gcFilePath"
-      } else {
-        gcOPTS += s" -Xloggc:$gcFileName"
-      }
-
-      val contextSparkMaster = Try(contextConfig.getString("launcher.spark.master"))
-        .getOrElse(SparkMasterProvider.fromConfig(systemConfig).getSparkMaster(systemConfig))
-      launcher.setMaster(contextSparkMaster)
-      launcher.setMainClass("spark.jobserver.JobManager")
-      launcher.addAppArgs(masterAddress, contextActorName, getEnvironmentVariable("MANAGER_CONF_FILE"))
-      launcher.addSparkArg("--conf", s"spark.executor.extraJavaOptions=$loggingOpts")
-      launcher.addSparkArg("--driver-java-options",
-          s"$gcOPTS $baseJavaOPTS $loggingOpts $configOverloads $extraJavaOPTS")
-
-      if (!contextName.isEmpty) {
-        launcher.setAppName(contextName)
-      }
-
-      if (useSuperviseMode) {
-        launcher.addSparkArg("--supervise")
-      }
-
-      if (contextConfig.hasPath(SparkJobUtils.SPARK_PROXY_USER_PARAM)) {
-         launcher.addSparkArg("--proxy-user", contextConfig.getString(SparkJobUtils.SPARK_PROXY_USER_PARAM))
-      }
-
-      for (e <- Try(contextConfig.getConfig("launcher"))) {
-         e.entrySet().asScala.map { c =>
-           // Supervise mode was already handled above, no need to do it here again
-           if (c.getKey != "spark.driver.supervise") {
-            launcher.addSparkArg("--conf", s"${c.getKey}=${c.getValue.unwrapped.toString}")
-           }
-         }
-      }
-
-      parseExtraSparkConfigurations() match {
-        case Some(configs) =>
-          configs.filter(conf => conf.contains("=")).foreach(conf => launcher.addSparkArg("--conf", conf))
-        case None =>
-      }
-
-      val submitOutputFile = new File(contextDir, "spark-job-server.out")
-      // This function was introduced in 2.1.0 Spark version, for older versions, it will
-      // break with MethodNotFound exception.
-      launcher.redirectOutput(submitOutputFile)
-      launcher.redirectError(submitOutputFile)
+    val gcFileName = getEnvironmentVariable("GC_OUT_FILE_NAME", "gc.out")
+    if (deployMode == "client") {
+      val gcFilePath = new File(contextDir, gcFileName).toString()
+      loggingOpts += s" -DLOG_DIR=$contextDir"
+      gcOPTS += s" -Xloggc:$gcFilePath"
+    } else {
+      gcOPTS += s" -Xloggc:$gcFileName"
     }
 
+    launcher.setMainClass("spark.jobserver.JobManager")
+    launcher.addAppArgs(masterAddress, contextActorName, getEnvironmentVariable("MANAGER_CONF_FILE"))
+    launcher.addSparkArg("--conf", s"spark.executor.extraJavaOptions=$loggingOpts")
+    launcher.addSparkArg("--driver-java-options",
+      s"$gcOPTS $baseJavaOPTS $loggingOpts $configOverloads $extraJavaOPTS")
+
+    if (!contextName.isEmpty) {
+      launcher.setAppName(contextName)
+    }
+
+    if (useSuperviseMode) {
+      launcher.addSparkArg("--supervise")
+    }
+
+    if (contextConfig.hasPath(SparkJobUtils.SPARK_PROXY_USER_PARAM)) {
+      launcher.addSparkArg("--proxy-user", contextConfig.getString(SparkJobUtils.SPARK_PROXY_USER_PARAM))
+    }
+
+    getStringSeq(contextConfig, "jars").foreach(launcher.addJar)
+    getStringSeq(contextConfig, "files").foreach(launcher.addFile)
+
+    if (contextConfig.getString("context-factory").contains("python")) {
+      // Since `--py-files` in not available in Java applications,
+      // we distribute pyFiles to cluster var `--files`
+      launcher.setConf("spark.yarn.isPython", "true")
+      val pyFiles = getStringSeq(contextConfig, "launcher.py-files")
+      pyFiles.foreach(launcher.addFile)
+      // If Spark driver is local, we need to download the remote pyFiles.
+      // Ignoring pyFiles in yarn and mesos cluster mode, these two modes support dealing
+      // with remote pyFiles, they could distribute and add pyiles locally.
+      if (deployMode != "cluster" || !master.startsWith("yarn")) {
+        val hdfs = new HadoopFSFacade()
+        val tmpDir = Files.createTempDirectory(s"jobserver-$contextName")
+        val localPyFiles = pyFiles.map(f => hdfs.downloadFile(f, tmpDir.toFile))
+        launcher.setConf("spark.jobserver.tmpDir", tmpDir.toString)
+        launcher.setConf("spark.submit.pyFiles", localPyFiles.mkString(","))
+      }
+    }
+
+    for (e <- Try(contextConfig.getConfig("launcher"))) {
+      e.entrySet().asScala.map { c =>
+        // Supervise mode was already handled above, no need to do it here again
+        if (c.getKey.startsWith("spark") && c.getKey != "spark.driver.supervise") {
+          launcher.addSparkArg("--conf", s"${c.getKey}=${c.getValue.unwrapped.toString}")
+        }
+      }
+    }
+
+    parseExtraSparkConfigurations() match {
+      case Some(configs) =>
+        configs.filter(conf => conf.contains("=")).foreach(conf => launcher.addSparkArg("--conf", conf))
+      case None =>
+    }
+
+    val submitOutputFile = new File(contextDir, "spark-job-server.out")
+    // This function was introduced in 2.1.0 Spark version, for older versions, it will
+    // break with MethodNotFound exception.
+    launcher.redirectOutput(submitOutputFile)
+    launcher.redirectError(submitOutputFile)
+  }
+
   override def validate(): (Boolean, String) = {
-     super.validate() match {
-       case (true, _) =>
-         if (!validateMemory(contextConfig.getString("launcher.spark.driver.memory"))) {
-           (false,
-             "Context error: spark.driver.memory has invalid value. Accepted formats 1024k, 2g, 512m")
-         } else if (deployMode == "client" && useSuperviseMode) {
-           (false, "Supervise mode can only be used with cluster mode")
-         } else if (master.startsWith("yarn") && useSuperviseMode) {
-           (false, "Supervise mode is only supported with spark standalone or Mesos")
-         } else {
-           (true, "")
-         }
-       case (false, error) => (false, error)
-     }
+    super.validate() match {
+      case (true, _) =>
+        if (!validateMemory(contextConfig.getString("launcher.spark.driver.memory"))) {
+          (false,
+            "Context error: spark.driver.memory has invalid value. Accepted formats 1024k, 2g, 512m")
+        } else if (deployMode == "client" && useSuperviseMode) {
+          (false, "Supervise mode can only be used with cluster mode")
+        } else if (master.startsWith("yarn") && useSuperviseMode) {
+          (false, "Supervise mode is only supported with spark standalone or Mesos")
+        } else {
+          (true, "")
+        }
+      case (false, error) => (false, error)
+    }
   }
 
   private def parseExtraSparkConfigurations(): Option[Array[String]] = {

--- a/job-server/src/main/scala/spark/jobserver/util/Utils.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/Utils.scala
@@ -36,7 +36,7 @@ object Utils {
     }
     new File(path).getAbsoluteFile().toURI()
   }
-  
+
   def createDirectory(folderPath: String): Unit = {
     val folder = new File(folderPath)
     createDirectory(folder)

--- a/job-server/src/main/scala/spark/jobserver/util/Utils.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/Utils.scala
@@ -1,6 +1,7 @@
 package spark.jobserver.util
 
-import java.io.Closeable
+import java.io.{Closeable, File}
+import java.net.{URI, URISyntaxException}
 
 object Utils {
   def usingResource[A <: Closeable, B](resource: A)(f: A => B): B = {
@@ -9,5 +10,30 @@ object Utils {
     } finally {
       resource.close()
     }
+  }
+
+  /**
+    * Return a well-formed URI for the file described by a user input string.
+    *
+    * If the supplied path does not contain a scheme, or is a relative path, it will be
+    * converted into an absolute path with a file:// scheme.
+    */
+  def resolveURI(path: String): URI = {
+    try {
+      val uri = new URI(path)
+      if (uri.getScheme() != null) {
+        return uri
+      }
+      // make sure to handle if the path has a fragment (applies to yarn
+      // distributed cache)
+      if (uri.getFragment() != null) {
+        val absoluteURI = new File(uri.getPath()).getAbsoluteFile().toURI()
+        return new URI(absoluteURI.getScheme(), absoluteURI.getHost(), absoluteURI.getPath(),
+          uri.getFragment())
+      }
+    } catch {
+      case e: URISyntaxException =>
+    }
+    new File(path).getAbsoluteFile().toURI()
   }
 }


### PR DESCRIPTION
On the cluster side, PythonJob dependencies need to be installed
into the python instance to be used for running the jobs,
or added to the list of paths in config, This change supports
pythonJob HDFS type dependencies use config:
spark.context-settings.launcher.py-files.

**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1174)
<!-- Reviewable:end -->
