### PR TITLE
feat(jobserver): Add counters for API requests

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/WebApi.scala
+++ b/job-server/src/main/scala/spark/jobserver/WebApi.scala
@@ -30,6 +30,7 @@ import spray.routing.{HttpService, RequestContext, Route}
 
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.Try
+import spark.jobserver.util.MeteredHttpService
 
 object WebApi {
   val StatusKey = "status"
@@ -136,7 +137,7 @@ class WebApi(system: ActorSystem,
              dataManager: ActorRef,
              supervisor: ActorRef,
              jobInfoActor: ActorRef)
-    extends HttpService with CommonRoutes with DataRoutes with SJSAuthenticator with CORSSupport
+    extends MeteredHttpService with CommonRoutes with DataRoutes with SJSAuthenticator with CORSSupport
                         with ChunkEncodedStreamingSupport {
   import CommonMessages._
   import ContextSupervisor._

--- a/job-server/src/main/scala/spark/jobserver/util/MeteredHttpService.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/MeteredHttpService.scala
@@ -1,0 +1,54 @@
+package spark.jobserver.util
+
+import spray.routing.{HttpService, Directive0}
+import spark.jobserver.common.akka.metrics.YammerMetrics
+
+trait MeteredHttpService extends HttpService with YammerMetrics {
+
+  private val totalReadRequests = counter("total-read-requests")
+  private val totalWriteRequests = counter("total-write-requests")
+
+  /*
+   * Count read requests
+   */
+
+  override def get : Directive0 = {
+    totalReadRequests.inc()
+    super.get
+  }
+
+  override def head : Directive0 = {
+    totalReadRequests.inc()
+    super.head
+  }
+
+  override def options : Directive0 = {
+    totalReadRequests.inc()
+    super.options
+  }
+
+  /*
+   * Count write requests
+   */
+
+  override def post : Directive0 = {
+    totalWriteRequests.inc()
+    super.post
+  }
+
+  override def delete : Directive0 = {
+    totalWriteRequests.inc()
+    super.delete
+  }
+
+  override def put : Directive0 = {
+    totalWriteRequests.inc()
+    super.put
+  }
+
+  override def patch : Directive0 = {
+    totalWriteRequests.inc()
+    super.patch
+  }
+
+}


### PR DESCRIPTION
This very small PR gives a bit more insight into the usage of the WebAPI, here specifically tracking the amount of read/write requests. Also makes it easier to add similar things for the WebAPI in the future.

* Add MeteredHttpService that tracks metrics for number of read/write requests
* Let WebAPI extend new MeteredHttpService

**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1178)
<!-- Reviewable:end -->
