### PR TITLE
feat(pythonJob): Support HDFS pyFiles dependencies in cluster

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -527,7 +527,7 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef,
     }.getOrElse(Files.createTempDirectory("jobserver"))
     logger.info("Created working directory {} for context {}", contextDir: Any, name)
 
-    val launcher = new ManagerLauncher(config, contextConfig,
+    val launcher = ManagerLauncher(config, contextConfig,
         selfAddress.toString, encodedContextName, contextActorName, contextDir.toString)
 
     launcher.start()

--- a/job-server/src/main/scala/spark/jobserver/JobManager.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManager.scala
@@ -1,6 +1,6 @@
 package spark.jobserver
 
-import java.io.InputStreamReader
+import java.io.{File, InputStreamReader}
 import java.nio.file.Files
 import java.util.concurrent.TimeUnit
 
@@ -31,6 +31,9 @@ object JobManager {
   def start(args: Array[String], makeSystem: Config => ActorSystem,
             waitForTermination: (ActorSystem, String, String) => Unit) {
 
+    sys.props.get("spark.jobserver.tmpDir").foreach{ tmpDir =>
+      FileUtils.forceDeleteOnExit(new File(tmpDir))
+    }
     val clusterAddress = AddressFromURIString.parse(args(0))
     val managerName = args(1)
     val loadedConfig = getConfFromFS(args(2)).getOrElse(exitJVM)

--- a/job-server/src/main/scala/spark/jobserver/util/ManagerLauncher.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/ManagerLauncher.scala
@@ -1,22 +1,72 @@
 package spark.jobserver.util
 
 import java.io.File
+import java.nio.file.Files
+
 import scala.util.Try
 import collection.JavaConverters._
 import com.typesafe.config.Config
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.yarn.api.ApplicationConstants
 import org.slf4j.LoggerFactory
 import org.apache.spark.launcher.SparkLauncher
+import spark.jobserver.util.ManagerLauncher.getStringSeq
+
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
 
 object ManagerLauncher {
   final val SJS_SUPERVISE_MODE_KEY = "spark.driver.supervise"
   final val CONTEXT_SUPERVISE_MODE_KEY = "launcher.spark.driver.supervise"
 
   def shouldSuperviseModeBeEnabled(sjsSupervisorMode: Boolean,
-      contextSupervisorMode: Option[Boolean]): Boolean = {
+                                   contextSupervisorMode: Option[Boolean]): Boolean = {
     (sjsSupervisorMode, contextSupervisorMode) match {
       case (_, Some(contextSupervisorMode)) => contextSupervisorMode
       case (_, None) => sjsSupervisorMode
     }
+  }
+
+  def getStringSeq(conf: Config, key: String): Seq[String] = {
+    Try(conf.getStringList(key).asScala).
+      orElse(Try(conf.getString(key).split(",").toSeq)).getOrElse(Nil)
+  }
+
+  def apply(config: Config, contextConfig: Config, masterAddress: String,
+            contextName: String, contextActorName: String, contextDir: String): ManagerLauncher = {
+
+    // Here we pre-add pyFiles to the PYTHONPATH of the spark-submit process
+    val environment: Environment = new SystemEnvironment
+    val env = mutable.Map[String, String]()
+
+    val contextSparkMaster = Try(contextConfig.getString("launcher.spark.master"))
+      .getOrElse(SparkMasterProvider.fromConfig(config).getSparkMaster(config))
+    if (contextConfig.hasPath("context-factory") &&
+      contextConfig.getString("context-factory").contains("python")) {
+      // On YARN mode, the following preprocessed PYTHONPATH will be added to the PYTHONPATH
+      // of the YARN container processes
+      if (contextSparkMaster.contains("yarn")) {
+        val pythonPath = new ListBuffer[String]()
+        getStringSeq(contextConfig, "launcher.py-files").foreach { path =>
+          val uri = Utils.resolveURI(path)
+          val fname = new Path(uri).getName
+          if (!fname.endsWith(".py")) {
+            if (uri.getScheme != "local") {
+              pythonPath += ApplicationConstants.Environment.PWD.$$() + Path.SEPARATOR + fname
+            } else {
+              pythonPath += uri.getPath
+            }
+          }
+        }
+        env.put("PYTHONPATH", pythonPath.mkString(ApplicationConstants.CLASS_PATH_SEPARATOR))
+      }
+      // If the Spark driver is not in cluster, use the PYTHONPATH of client process
+      val sjsPythonPath = environment.get("PYTHONPATH", "")
+      env.put("SJSPYTHONPATH", sjsPythonPath)
+    }
+    val sparkLauncher = new SparkLauncher(env.asJava)
+    new ManagerLauncher(config, contextConfig, masterAddress,
+      contextName, contextActorName, contextDir.toString, sparkLauncher)
   }
 }
 
@@ -24,7 +74,7 @@ class ManagerLauncher(systemConfig: Config, contextConfig: Config, masterAddress
                       contextName: String, contextActorName: String, contextDir: String,
                       sparkLauncher: SparkLauncher = new SparkLauncher,
                       environment: Environment = new SystemEnvironment)
-                      extends Launcher(systemConfig, sparkLauncher, environment) {
+  extends Launcher(systemConfig, sparkLauncher, environment) {
   val logger = LoggerFactory.getLogger("spark-context-launcher")
 
   var loggingOpts = getEnvironmentVariable("MANAGER_LOGGING_OPTS")
@@ -35,76 +85,99 @@ class ManagerLauncher(systemConfig: Config, contextConfig: Config, masterAddress
   lazy val contextSuperviseModeEnabled: Option[Boolean] = Try(Some(
     contextConfig.getBoolean(ManagerLauncher.CONTEXT_SUPERVISE_MODE_KEY))).getOrElse(None)
   lazy val useSuperviseMode = ManagerLauncher.shouldSuperviseModeBeEnabled(
-      defaultSuperviseModeEnabled, contextSuperviseModeEnabled)
+    defaultSuperviseModeEnabled, contextSuperviseModeEnabled)
 
   override def addCustomArguments() {
-      val gcFileName = getEnvironmentVariable("GC_OUT_FILE_NAME", "gc.out")
-      if (deployMode == "client") {
-        val gcFilePath = new File(contextDir, gcFileName).toString()
-        loggingOpts += s" -DLOG_DIR=$contextDir"
-        gcOPTS += s" -Xloggc:$gcFilePath"
-      } else {
-        gcOPTS += s" -Xloggc:$gcFileName"
-      }
-
-      val contextSparkMaster = Try(contextConfig.getString("launcher.spark.master"))
-        .getOrElse(SparkMasterProvider.fromConfig(systemConfig).getSparkMaster(systemConfig))
-      launcher.setMaster(contextSparkMaster)
-      launcher.setMainClass("spark.jobserver.JobManager")
-      launcher.addAppArgs(masterAddress, contextActorName, getEnvironmentVariable("MANAGER_CONF_FILE"))
-      launcher.addSparkArg("--conf", s"spark.executor.extraJavaOptions=$loggingOpts")
-      launcher.addSparkArg("--driver-java-options",
-          s"$gcOPTS $baseJavaOPTS $loggingOpts $configOverloads $extraJavaOPTS")
-
-      if (!contextName.isEmpty) {
-        launcher.setAppName(contextName)
-      }
-
-      if (useSuperviseMode) {
-        launcher.addSparkArg("--supervise")
-      }
-
-      if (contextConfig.hasPath(SparkJobUtils.SPARK_PROXY_USER_PARAM)) {
-         launcher.addSparkArg("--proxy-user", contextConfig.getString(SparkJobUtils.SPARK_PROXY_USER_PARAM))
-      }
-
-      for (e <- Try(contextConfig.getConfig("launcher"))) {
-         e.entrySet().asScala.map { c =>
-           // Supervise mode was already handled above, no need to do it here again
-           if (c.getKey != "spark.driver.supervise") {
-            launcher.addSparkArg("--conf", s"${c.getKey}=${c.getValue.unwrapped.toString}")
-           }
-         }
-      }
-
-      parseExtraSparkConfigurations() match {
-        case Some(configs) =>
-          configs.filter(conf => conf.contains("=")).foreach(conf => launcher.addSparkArg("--conf", conf))
-        case None =>
-      }
-
-      val submitOutputFile = new File(contextDir, "spark-job-server.out")
-      // This function was introduced in 2.1.0 Spark version, for older versions, it will
-      // break with MethodNotFound exception.
-      launcher.redirectOutput(submitOutputFile)
-      launcher.redirectError(submitOutputFile)
+    val gcFileName = getEnvironmentVariable("GC_OUT_FILE_NAME", "gc.out")
+    if (deployMode == "client") {
+      val gcFilePath = new File(contextDir, gcFileName).toString()
+      loggingOpts += s" -DLOG_DIR=$contextDir"
+      gcOPTS += s" -Xloggc:$gcFilePath"
+    } else {
+      gcOPTS += s" -Xloggc:$gcFileName"
     }
 
+    val contextSparkMaster = Try(contextConfig.getString("launcher.spark.master"))
+      .getOrElse(SparkMasterProvider.fromConfig(systemConfig).getSparkMaster(systemConfig))
+    launcher.setMaster(contextSparkMaster)
+    launcher.setMainClass("spark.jobserver.JobManager")
+    launcher.addAppArgs(masterAddress, contextActorName, getEnvironmentVariable("MANAGER_CONF_FILE"))
+    launcher.addSparkArg("--conf", s"spark.executor.extraJavaOptions=$loggingOpts")
+    launcher.addSparkArg("--driver-java-options",
+      s"$gcOPTS $baseJavaOPTS $loggingOpts $configOverloads $extraJavaOPTS")
+
+    if (!contextName.isEmpty) {
+      launcher.setAppName(contextName)
+    }
+
+    if (useSuperviseMode) {
+      launcher.addSparkArg("--supervise")
+    }
+
+    if (contextConfig.hasPath(SparkJobUtils.SPARK_PROXY_USER_PARAM)) {
+      launcher.addSparkArg("--proxy-user", contextConfig.getString(SparkJobUtils.SPARK_PROXY_USER_PARAM))
+    }
+
+    getStringSeq(contextConfig, "jars").foreach(launcher.addJar)
+    getStringSeq(contextConfig, "files").foreach(launcher.addFile)
+
+    if (contextConfig.hasPath("context-factory") &&
+      contextConfig.getString("context-factory").contains("python")) {
+      // Since `--py-files` in not available in Java applications,
+      // we distribute pyFiles to cluster var `--files`
+      launcher.setConf("spark.yarn.isPython", "true")
+      val pyFiles = getStringSeq(contextConfig, "launcher.py-files")
+      pyFiles.foreach(launcher.addFile)
+
+      // If Spark driver is local, we need to download the remote pyFiles.
+      // Ignoring pyFiles in yarn and mesos cluster mode, these two modes support dealing
+      // with remote pyFiles, they could distribute and add pyiles locally.
+      if (deployMode != "cluster" || !master.startsWith("yarn")) {
+        val hdfs = new HadoopFSFacade()
+        val tmpDir = Files.createTempDirectory(s"jobserver-$contextName")
+        val localPyFiles = pyFiles.map(f => hdfs.downloadFile(f, tmpDir.toFile))
+        launcher.setConf("spark.jobserver.tmpDir", tmpDir.toString)
+        launcher.setConf("spark.submit.pyFiles", localPyFiles.mkString(","))
+      }
+    }
+
+    for (e <- Try(contextConfig.getConfig("launcher"))) {
+      e.entrySet().asScala.map { c =>
+        // Supervise mode was already handled above, no need to do it here again
+        if (c.getKey.startsWith("spark") && c.getKey != "spark.driver.supervise") {
+          launcher.addSparkArg("--conf", s"${c.getKey}=${c.getValue.unwrapped.toString}")
+        }
+      }
+    }
+
+    parseExtraSparkConfigurations() match {
+      case Some(configs) =>
+        configs.filter(conf => conf.contains("=")).foreach(conf => launcher.addSparkArg("--conf", conf))
+      case None =>
+    }
+
+    val submitOutputFile = new File(contextDir, "spark-job-server.out")
+    // This function was introduced in 2.1.0 Spark version, for older versions, it will
+    // break with MethodNotFound exception.
+    launcher.redirectOutput(submitOutputFile)
+    launcher.redirectError(submitOutputFile)
+  }
+
   override def validate(): (Boolean, String) = {
-     super.validate() match {
-       case (true, _) =>
-         if (!validateMemory(contextConfig.getString("launcher.spark.driver.memory"))) {
-           (false,
-             "Context error: spark.driver.memory has invalid value. Accepted formats 1024k, 2g, 512m")
-         } else if (deployMode == "client" && useSuperviseMode) {
-           (false, "Supervise mode can only be used with cluster mode")
-         } else if (master.startsWith("yarn") && useSuperviseMode) {
-           (false, "Supervise mode is only supported with spark standalone or Mesos")
-         } else {
-           (true, "")
-         }
-       case (false, error) => (false, error)
-     }
+    super.validate() match {
+      case (true, _) =>
+        if (!validateMemory(contextConfig.getString("launcher.spark.driver.memory"))) {
+          (false,
+            "Context error: spark.driver.memory has invalid value. Accepted formats 1024k, 2g, 512m")
+        } else if (deployMode == "client" && useSuperviseMode) {
+          (false, "Supervise mode can only be used with cluster mode")
+        } else if (master.startsWith("yarn") && useSuperviseMode) {
+          (false, "Supervise mode is only supported with spark standalone or Mesos")
+        } else {
+          (true, "")
+        }
+      case (false, error) => (false, error)
+    }
   }
 
   private def parseExtraSparkConfigurations(): Option[Array[String]] = {

--- a/job-server/src/main/scala/spark/jobserver/util/Utils.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/Utils.scala
@@ -1,6 +1,7 @@
 package spark.jobserver.util
 
 import java.io.{Closeable, File}
+import java.net.{URI, URISyntaxException}
 
 object Utils {
   def usingResource[A <: Closeable, B](resource: A)(f: A => B): B = {
@@ -22,5 +23,31 @@ object Utils {
         throw new RuntimeException(s"Could not create directory $folder")
       }
     }
+  }
+
+
+  /**
+    * Return a well-formed URI for the file described by a user input string.
+    *
+    * If the supplied path does not contain a scheme, or is a relative path, it will be
+    * converted into an absolute path with a file:// scheme.
+    */
+  def resolveURI(path: String): URI = {
+    try {
+      val uri = new URI(path)
+      if (uri.getScheme() != null) {
+        return uri
+      }
+      // make sure to handle if the path has a fragment (applies to yarn
+      // distributed cache)
+      if (uri.getFragment() != null) {
+        val absoluteURI = new File(uri.getPath()).getAbsoluteFile().toURI()
+        return new URI(absoluteURI.getScheme(), absoluteURI.getHost(), absoluteURI.getPath(),
+          uri.getFragment())
+      }
+    } catch {
+      case e: URISyntaxException =>
+    }
+    new File(path).getAbsoluteFile().toURI()
   }
 }

--- a/job-server/src/test/scala/spark/jobserver/util/ManagerLauncherSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/util/ManagerLauncherSpec.scala
@@ -95,14 +95,14 @@ class ManagerLauncherSpec extends FunSpec with Matchers with BeforeAndAfter with
        stubbedSparkLauncher.getLauncherConfig().containsValue("--conf","spark.driver.memory=1000000") should be (true)
      }
 
-     it("should pass any spark configuration specified in launcher section to SparkLauncher") {
+     it("should pass any spark configuration specified which 'key' must start with 'spark.' in launcher section to SparkLauncher") {
        val contextConfMap = baseContextMap + ("launcher.test.spark.config" -> "dummy")
 
        val launcher = managerLauncherFunc(buildConfig(contextConfMap))
 
        launcher.start()._1 should be (true)
        stubbedSparkLauncher.getLauncherConfig().containsValue("--conf", "spark.driver.memory=1g") should be (true)
-       stubbedSparkLauncher.getLauncherConfig().containsValue("--conf", "test.spark.config=dummy") should be (true)
+       stubbedSparkLauncher.getLauncherConfig().containsValue("--conf", "test.spark.config=dummy") should be (false)
      }
 
      it("should pass spark.proxy.user to SparkLauncher if specified") {


### PR DESCRIPTION
On the cluster side, PythonJob dependencies need to be installed
into the python instance to be used for running the jobs,
or added to the list of paths in config, This change supports
pythonJob HDFS type dependencies use config:
spark.context-settings.launcher.py-files.

**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1180)
<!-- Reviewable:end -->
