### PR TITLE
Adapt test configurations to run on slow build system

### DIFF
--- a/job-server/src/test/scala/spark/jobserver/JobSpecBase.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobSpecBase.scala
@@ -38,6 +38,7 @@ trait JobSpecConfig {
       "spark.master" -> "local[*]",
       "context-factory" -> contextFactory,
       "spark.context-settings.test" -> "",
+      "akka.test.timefactor" -> 2,
       "spark.driver.allowMultipleContexts" -> true
     )
     ConfigFactory.parseMap(ConfigMap.asJava).withFallback(ConfigFactory.defaultOverrides())

--- a/job-server/src/test/scala/spark/jobserver/JobSpecBase.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobSpecBase.scala
@@ -38,6 +38,7 @@ trait JobSpecConfig {
       "spark.master" -> "local[*]",
       "context-factory" -> contextFactory,
       "spark.context-settings.test" -> "",
+      "akka.test.single-expect-default" -> "6s",
       "akka.test.timefactor" -> 2,
       "spark.driver.allowMultipleContexts" -> true
     )


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
Currently, the frequency of failing tests is high. Internally, we use tests which need to communicate with Akka messages and if some message don't arrive due to slow build system, the tests fail.


**New behavior :**
Should improve the situation. If it doesn't help then we need to look at individual tests to fix them.


**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1184)
<!-- Reviewable:end -->
