### PR TITLE
fix(jobserver): ensure job cleanup after fatal error - ref #1161

### DIFF
--- a/job-server-tests/src/main/scala/spark/jobserver/SparkTestJobs.scala
+++ b/job-server-tests/src/main/scala/spark/jobserver/SparkTestJobs.scala
@@ -15,6 +15,13 @@ class MyErrorJob extends SparkTestJob {
   }
 }
 
+/** @see [[scala.util.control.NonFatal]] */
+class MyFatalErrorJob extends SparkTestJob {
+  def runJob(sc: SparkContext, config: Config): Any = {
+    throw new OutOfMemoryError("this is a fatal error")
+  }
+}
+
 class ConfigCheckerJob extends SparkTestJob {
   import scala.collection.JavaConverters._
 

--- a/job-server/src/test/scala/spark/jobserver/JobManagerActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobManagerActorSpec.scala
@@ -225,6 +225,16 @@ class JobManagerActorSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) 
       errorMsg.err.getClass should equal (classOf[IllegalArgumentException])
     }
 
+    it("should return error if job throws a fatal error") {
+      manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
+      expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
+
+      uploadTestJar()
+      manager ! JobManagerActor.StartJob("demo", classPrefix + "MyFatalErrorJob", emptyConfig, errorEvents)
+      val errorMsg = expectMsgClass(startJobWait, classOf[JobErroredOut])
+      errorMsg.err.getClass should equal (classOf[OutOfMemoryError])
+    }
+
     it("job should get jobConfig passed in to StartJob message") {
       val jobConfig = ConfigFactory.parseString("foo.bar.baz = 3")
       manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)


### PR DESCRIPTION
`Future` only completes on success or when encountering a `NonFatal`
error; when encountering a fatal error, the future does not complete at
all and the error is passed to the execution context.

This change wraps all `Throwable` so the `Future` can complete and the
`Failure` handlers can cleanup the job and properly mark it as failed.

**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

#1161 

**New behavior :**

When a fatal error occurs in a job, the `JobManagerActor` is now able to properly mark it as failed and cleanup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1190)
<!-- Reviewable:end -->
