### PR TITLE
feat(akka-app): Expose mean duration of timers in metricz API endpoint

### DIFF
--- a/akka-app/src/main/scala/spark/jobserver/common/akka/web/CommonRoutes.scala
+++ b/akka-app/src/main/scala/spark/jobserver/common/akka/web/CommonRoutes.scala
@@ -89,7 +89,8 @@ object MetricsSerializer {
       case h: Histogram => Map("type" -> "histogram") ++ histogramToMap(h)
       case t: Timer =>
         Map("type" -> "timer", "rate" -> meterToMap(t),
-            "duration" -> (histogramToMap(t) ++ Map("units" -> t.durationUnit.toString.toLowerCase)))
+            "duration" -> (histogramToMap(t) ++ Map("units" -> t.durationUnit.toString.toLowerCase)
+                                             ++ Map("mean" -> t.mean())))
 
     }
   }

--- a/akka-app/src/test/scala/spark/jobserver/common/akka/web/CommonRoutesSpec.scala
+++ b/akka-app/src/test/scala/spark/jobserver/common/akka/web/CommonRoutesSpec.scala
@@ -14,7 +14,6 @@ import akka.actor.ActorSystem
 class CommonRoutesSpec extends FunSpec with Matchers with ScalatestRouteTest with CommonRoutes {
   def actorRefFactory: ActorSystem = system
 
-
   val metricCounter = Metrics.newCounter(getClass, "test-counter")
   val metricMeter = Metrics.newMeter(getClass, "test-meter", "requests", TimeUnit.SECONDS)
   val metricHistogram = Metrics.newHistogram(getClass, "test-hist")
@@ -31,7 +30,7 @@ class CommonRoutesSpec extends FunSpec with Matchers with ScalatestRouteTest wit
   val histMap = Map("type" -> "histogram", "median" -> 0.0, "p75" -> 0.0, "p95" -> 0.0,
     "p98" -> 0.0, "p99" -> 0.0, "p999" -> 0.0)
   val timerMap = Map("type" -> "timer", "rate" -> (meterMap - "type"),
-    "duration" -> (histMap ++ Map("units" -> "milliseconds") - "type"))
+    "duration" -> (histMap ++ Map("units" -> "milliseconds") ++ Map("mean" -> 0.0) - "type"))
 
   override def afterAll():Unit = {
     TestKit.shutdownActorSystem(system)


### PR DESCRIPTION
Expose mean additionaly to median and other percentiles since the mean provides more insight into the overall distribution of timer values.
This distribution is interesting especially for API request durations.

**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1192)
<!-- Reviewable:end -->
