### PR TITLE
fix(jobserver): Fix unlimited cluster.join request

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/JobServer.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobServer.scala
@@ -134,7 +134,7 @@ object JobServer {
 
         // Check if all contexts marked as running are still available and get the ActorRefs
         val existingManagerActorRefs = getExistingManagerActorRefs(system, daoActor)
-        joinAkkaCluster(cluster, existingManagerActorRefs.headOption)
+        joinAkkaCluster(cluster, existingManagerActorRefs)
         // We don't want to read all the old events that happened in the cluster
         // So, we remove the initialStateMode parameter
         cluster.registerOnMemberUp {
@@ -160,15 +160,15 @@ object JobServer {
     webApiPF(supervisor, jobInfo).start()
   }
 
-  private def joinAkkaCluster(cluster: Cluster, initialSeedNode: Option[ActorRef]) {
-    initialSeedNode match {
-      case None =>
-        val selfAddress = cluster.selfAddress
-        logger.info(s"Joining newly created cluster at ${selfAddress}")
-        cluster.join(selfAddress)
-      case Some(actorRef) =>
-        logger.info(s"Joining existing cluster at ${actorRef.path.address.toString}")
-        cluster.join(actorRef.path.address)
+  private def joinAkkaCluster(cluster: Cluster, seedNodes: List[ActorRef]) {
+    if (seedNodes.isEmpty) {
+      val selfAddress = cluster.selfAddress
+      logger.info(s"Joining newly created cluster at ${selfAddress}")
+      cluster.join(selfAddress)
+    } else {
+      val addressList = seedNodes.map(_.path.address)
+      logger.info(s"Joining existing cluster at one of: ${addressList.mkString("{", ", ", "}")}")
+      cluster.joinSeedNodes(addressList)
     }
   }
 


### PR DESCRIPTION
**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?

**Current behavior :** 
Example:
In cluster mode, if a to-be-joined actor is picked that goes down shortly after the jobserver sees it as UP, things issues like #1157 can occur.

**New behavior :**
When the master joins an existing cluster on an unreachable node, a retry on other nodes (that were also seen as UP during startup) is possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1193)
<!-- Reviewable:end -->
