### PR TITLE
fix(jobserver): Align GetSparkContexData query timeouts

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -210,7 +210,7 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef,
         case Some(JobDAOActor.ContextResponse(Some(contextInfo))) =>
           val contextActorRef = getActorRef(contextInfo)
           contextActorRef match {
-            case Some(ref) => val future = (ref ? GetContexData)(30.seconds)
+            case Some(ref) => val future = (ref ? GetContexData)(10.seconds)
               future.collect {
                 case ContexData(appId, Some(webUi)) =>
                   originator ! SparkContexData(contextInfo, Some(appId), Some(webUi))

--- a/job-server/src/main/scala/spark/jobserver/WebApi.scala
+++ b/job-server/src/main/scala/spark/jobserver/WebApi.scala
@@ -373,7 +373,7 @@ class WebApi(system: ActorSystem,
     authenticate(authenticator) { authInfo =>
       (get & path(Segment)) { (contextName) =>
         respondWithMediaType(MediaTypes.`application/json`) { ctx =>
-          val future = (supervisor ? GetSparkContexData(contextName))
+          val future = (supervisor ? GetSparkContexData(contextName))(15.seconds)
           future.map {
             case SparkContexData(context, appId, url) =>
               val stcode = 200;


### PR DESCRIPTION
* Increase timeout for GetSparkContexData in WebAPI from default
  short Timeout to 15 seconds. The short default timeout resulted
  in a status code 500 (AskTimeoutException) sometimes when querying
  stopped contexts.
* Decrease timeout for GetContextData in AkkaClusterSupervisorActor
  from 30 seconds to 10 seconds (seemed very generous before)

**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?

**Current behavior :** 
Querying a stopped context (sometimes taking additional time because it queries the spark backend) can result in an unnecessary status code 500 because of the tight timing. Timeouts in the internal logics are set higher anyways.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1194)
<!-- Reviewable:end -->
