### PR TITLE
fix(jobserver): keeping unused binaries

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/io/JobSqlDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobSqlDAO.scala
@@ -127,20 +127,33 @@ class JobSqlDAO(config: Config, sqlCommon: SqlCommon) extends JobDAO with FileCa
   }
 
   private def deleteBinaryInfo(appName: String): Future[Int] = {
-    val deleteBinary = sqlCommon.binaries.filter(_.appName === appName)
-    val hashUsed = sqlCommon.binaries
-    .filter(_.binHash in deleteBinary.map(_.binHash)).filter(_.appName =!= appName)
-    val deleteBinariesContents = binariesContents.filter(_.binHash in deleteBinary.map(_.binHash))
+    val candidateDeleteBinaries = sqlCommon.binaries.filter(_.appName === appName)
+    val allBinariesUsingCandidateHash = sqlCommon.binaries.filter(
+      _.binHash in candidateDeleteBinaries.map(_.binHash))
+
     val dbAction = (for {
-      _ <- hashUsed.result.headOption.flatMap{
-        case None =>
-          deleteBinariesContents.delete
-        case Some(bc) =>
-          DBIO.successful(None) // no-op
-      }
-      b <- deleteBinary.delete
+      candidateBinaries <- candidateDeleteBinaries.result
+      allBinariesUsingHash <- allBinariesUsingCandidateHash.result
+      hashesToDelete = findAllHashesToDelete(appName, allBinariesUsingHash, candidateBinaries)
+      _ <- binariesContents.filter(_.binHash.inSet(hashesToDelete)).delete
+      b <- candidateDeleteBinaries.delete
     } yield b).transactionally
+
     sqlCommon.db.run(dbAction).recover(logDeleteErrors)
+  }
+
+  private def findAllHashesToDelete(appName: String,
+                                    allBinariesUsingHash: Seq[(Int, String, String, Timestamp, Array[Byte])],
+                                    candidateBinaries: Seq[(Int, String, String, Timestamp, Array[Byte])]):
+                                      Seq[Array[Byte]] = {
+    val hashOfOtherApps = allBinariesUsingHash
+                            .filter(_._2 != appName) // filter other apps
+                            .map(_._5) // hash
+                            .map(BinaryDAO.hashBytesToString(_))
+    val deleteCandidates = candidateBinaries.map( _._5).map(BinaryDAO.hashBytesToString(_))
+    deleteCandidates
+      .filterNot(hashOfOtherApps.contains(_))
+      .map(BinaryDAO.hashStringToBytes(_))
   }
 
   // Fetch the binary file from the database

--- a/job-server/src/test/scala/spark/jobserver/io/JobSqlDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/JobSqlDAOSpec.scala
@@ -3,7 +3,6 @@ package spark.jobserver.io
 import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
-
 import java.io.File
 
 import com.google.common.io.Files
@@ -126,6 +125,13 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
     }
   }
 
+  after {
+    val bins = Await.result(dao.getApps, timeout)
+    bins.foreach {
+      b => dao.deleteBinary(b._1)
+    }
+  }
+
   describe("save and get the jars") {
     it("should be able to save one jar and get it back") {
       jarFile.exists() should equal (false)
@@ -140,7 +146,8 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
     }
 
     it("should be able to save one jar and get it back without creating a cache") {
-      val configNoCache = config.withValue("spark.jobserver.cache-on-upload", ConfigValueFactory.fromAnyRef(false))
+      val configNoCache = config.withValue("spark.jobserver.cache-on-upload",
+        ConfigValueFactory.fromAnyRef(false))
       val daoNoCache = new JobSqlDAO(configNoCache)
 
       jarFile.exists() should equal (false)
@@ -154,6 +161,10 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
     }
 
     it("should be able to retrieve the jar file") {
+      val configNoCache = config.withValue("spark.jobserver.cache-on-upload",
+        ConfigValueFactory.fromAnyRef(false))
+      val daoNoCache = new JobSqlDAO(configNoCache)
+      daoNoCache.saveBinary(jarInfo.appName, BinaryType.Jar, jarInfo.uploadTime, jarBytes)
       jarFile.exists() should equal (false)
       val jarFilePath: String = dao.getBinaryFilePath(jarInfo.appName, BinaryType.Jar, jarInfo.uploadTime)
 
@@ -175,6 +186,10 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
     }
 
     it("should be able to retrieve the egg file") {
+      val configNoCache = config.withValue("spark.jobserver.cache-on-upload",
+        ConfigValueFactory.fromAnyRef(false))
+      val daoNoCache = new JobSqlDAO(configNoCache)
+      daoNoCache.saveBinary(eggInfo.appName, BinaryType.Egg, eggInfo.uploadTime, eggBytes)
       eggFile.exists() should equal (false)
       val eggFilePath: String = dao.getBinaryFilePath(eggInfo.appName, BinaryType.Egg, eggInfo.uploadTime)
 
@@ -185,20 +200,19 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
 
   describe("Basic saveJobInfo() and getJobInfos() tests") {
     it("Save another new jobInfo, bring down DB, bring up DB, should JobInfos from DB") {
+      dao.saveBinary(jarInfo.appName, BinaryType.Jar, jarInfo.uploadTime, jarBytes)
       dao.saveJobInfo(jobInfoNoEndNoErr)
       val jobInfo2 = genJobInfo(jarInfo, true, JobStatus.Running)
       val jobId2 = jobInfo2.jobId
       val expectedJobInfo2 = jobInfo2
 
       dao.saveJobInfo(jobInfo2)
-
       // Destroy and bring up the DB again
       dao = null
       dao = new JobSqlDAO(config)
 
       val jobs = Await.result(dao.getJobInfos(2), timeout)
       val jobIds = jobs map { _.jobId }
-
       jobIds should equal (Seq(jobId2, jobId))
       jobs should equal (Seq(expectedJobInfo2, expectedJobInfo))
     }
@@ -212,22 +226,24 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
       val info = genJarInfo(true, false)
       info.uploadTime should equal (jarInfo.uploadTime)
 
+      dao.saveBinary(jarInfo.appName, BinaryType.Jar, jarInfo.uploadTime, jarBytes)
+      dao.saveJobInfo(expectedJobInfo)
       val jobs: Seq[JobInfo] = Await.result(dao.getJobInfos(2), timeout)
 
-      jobs.size should equal (2)
+      jobs.size should equal (1)
       jobs.last should equal (expectedJobInfo)
 
       // Cannot compare JobInfos directly if error is a Some(Throwable) because
       // Throwable uses referential equality
       dao.saveJobInfo(expectedNoEndNoErr)
       val jobs2 = Await.result(dao.getJobInfos(2), timeout)
-      jobs2.size should equal (2)
+      jobs2.size should equal (1)
       jobs2.last.endTime should equal (None)
       jobs2.last.error shouldBe None
 
       dao.saveJobInfo(jobInfoSomeEndNoErr)
       val jobs3 = Await.result(dao.getJobInfos(2), timeout)
-      jobs3.size should equal (2)
+      jobs3.size should equal (1)
       jobs3.last.error.isDefined should equal (false)
       jobs3.last should equal (expectedSomeEndNoErr)
 
@@ -235,7 +251,7 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
       // Throwable uses referential equality
       dao.saveJobInfo(jobInfoSomeEndSomeErr)
       val jobs4 = Await.result(dao.getJobInfos(2), timeout)
-      jobs4.size should equal (2)
+      jobs4.size should equal (1)
       jobs4.last.endTime should equal (expectedSomeEndSomeErr.endTime)
       jobs4.last.error shouldBe defined
       jobs4.last.error.get.message should equal (throwable.getMessage)
@@ -247,6 +263,7 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
       val ctxToBeCleaned: JobInfo = JobInfo(
           "jobId", UUID.randomUUID().toString(), "context", jarInfo,
           "test-class", JobStatus.Running, DateTime.now(), None, None)
+      dao.saveBinary(jarInfo.appName, BinaryType.Jar, jarInfo.uploadTime, jarBytes)
       dao.saveJobInfo(ctxToBeCleaned)
 
       Await.ready(dao.cleanRunningJobInfosForContext(ctxToBeCleaned.contextId, DateTime.now()), timeout)
@@ -258,13 +275,95 @@ class JobSqlDAOSpec extends JobSqlDAOSpecBase with TestJarFinder with FunSpecLik
   }
 
   describe("delete binaries") {
-    it("should be able to delete jar file") {
-      val existing = Await.result(dao.getApps, timeout)
-      existing.keys should contain (jarInfo.appName)
-      dao.deleteBinary(jarInfo.appName)
+    class JobSqlDaoExtended(sqlCommon: SqlCommon) extends JobSqlDAO(config, sqlCommon) {
+      import profile.api._
 
-      val apps = Await.result(dao.getApps, timeout)
+      def getBinaryContentHashes(): Future[Seq[Array[Byte]]] = {
+        val query = binariesContents.map(_.binHash).result
+        sqlCommon.db.run(query)
+      }
+    }
+
+    it("should be able to delete jar file") {
+      val daoExt = new JobSqlDaoExtended(new SqlCommon(config))
+
+      var hashes = Await.result(daoExt.getBinaryContentHashes(), timeout)
+      hashes.size should equal (0)
+
+      daoExt.saveBinary(jarInfo.appName, BinaryType.Jar, jarInfo.uploadTime, jarBytes)
+
+      val existing = Await.result(daoExt.getApps, timeout)
+      existing.keys should contain (jarInfo.appName)
+      Await.result(daoExt.getBinaryContentHashes(), timeout).size should be(1)
+
+      daoExt.deleteBinary(jarInfo.appName)
+
+      val apps = Await.result(daoExt.getApps, timeout)
       apps.keys should not contain (jarInfo.appName)
+      hashes = Await.result(daoExt.getBinaryContentHashes(), timeout)
+      hashes.size should equal (0)
+    }
+
+    it("should delete unused binaries for the given name") {
+      val daoExt = new JobSqlDaoExtended(new SqlCommon(config))
+
+      daoExt.saveBinary(jarInfo.appName, BinaryType.Jar, jarInfo.uploadTime, jarBytes)
+      daoExt.saveBinary(jarInfo.appName, BinaryType.Jar, jarInfo.uploadTime, Array(10, 11, 12))
+      daoExt.saveBinary("otherName", BinaryType.Jar, jarInfo.uploadTime, jarBytes)
+      jarFile.exists() should equal (true)
+
+      var hashes = Await.result(daoExt.getBinaryContentHashes(), timeout)
+      hashes.size should equal (2)
+      val existing = Await.result(daoExt.getApps, timeout)
+      existing.keys should contain (jarInfo.appName)
+      existing.keys should contain ("otherName")
+
+      daoExt.deleteBinary(jarInfo.appName)
+
+      var binaries = Await.result(daoExt.getApps, timeout)
+      binaries.size should equal (1)
+      hashes = Await.result(daoExt.getBinaryContentHashes(), timeout)
+      hashes.size should equal (1)
+      hashes.head should be(BinaryDAO.calculateBinaryHash(jarBytes))
+      jarFile.exists() should equal (false)
+
+      daoExt.deleteBinary("otherName")
+
+      binaries = Await.result(daoExt.getApps, timeout)
+      hashes = Await.result(daoExt.getBinaryContentHashes(), timeout)
+      binaries.size should equal (0)
+      hashes.size should equal (0)
+    }
+
+    it("should not delete hash if it is being used by another app") {
+      val daoExt = new JobSqlDaoExtended(new SqlCommon(config))
+
+      daoExt.saveBinary(jarInfo.appName, BinaryType.Jar, jarInfo.uploadTime, jarBytes)
+      daoExt.saveBinary("appB", BinaryType.Jar, jarInfo.uploadTime, jarBytes)
+      daoExt.saveBinary("appC", BinaryType.Jar, jarInfo.uploadTime, Array(10, 11, 12))
+
+      daoExt.deleteBinary(jarInfo.appName)
+
+      val existing = Await.result(daoExt.getApps, timeout)
+      existing.keys should contain ("appB")
+      existing.keys should contain ("appC")
+
+      val hashes = Await.result(daoExt.getBinaryContentHashes(), timeout)
+      hashes.size should equal (2)
+      hashes(0) should be(BinaryDAO.calculateBinaryHash(jarBytes))
+      hashes(1) should be(BinaryDAO.calculateBinaryHash(Array(10, 11, 12)))
+    }
+
+    it("should delete all hashes against a single app") {
+      val daoExt = new JobSqlDaoExtended(new SqlCommon(config))
+
+      daoExt.saveBinary(jarInfo.appName, BinaryType.Jar, jarInfo.uploadTime, jarBytes)
+      daoExt.saveBinary(jarInfo.appName, BinaryType.Jar, jarInfo.uploadTime, Array(10, 11, 12))
+
+      daoExt.deleteBinary(jarInfo.appName)
+
+      Await.result(daoExt.getApps, timeout).size should be(0)
+      Await.result(daoExt.getBinaryContentHashes(), timeout).size should be(0)
     }
   }
 


### PR DESCRIPTION
In some special cases unused binaries were kept in the DB.
For example: Consider the following 3 binaries in the DB:
1) Name - "appA", Hash - 123
2) Name - "appA", Hash - 456
3) Name - "appB", Hash - 123
If someone would try to delete binary with the name "appA", the names
would be deleted, but not the binaries themselves. It means that binary
with hash "456" would still be available in the "binary_contents" table
and there would be no possibility to delete it.

Other scenarios:
1- If user deletes appA then app should be deleted but binary
 in binary contents table should remain.
 appA hash1
 appB hash1
 appC hash2

2- If user delets appA then both hashes/bin should be cleaned
from binary contents table
 appA hash1
 appA hash2

3- If user deletes appA then appB and hash/binary for appB should
stay.
 appA hash1
 appB hash2

Change-Id: I14a6f6070d78bf45debf2b3d7f4857ad647e01c6

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1198)
<!-- Reviewable:end -->
