### PR TITLE
fix(travis): Update base container tag 

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM instructure/java:8
+FROM openjdk:8-jdk
 
 USER root
 # install and cache sbt, python

--- a/ci/install-python-dependencies.sh
+++ b/ci/install-python-dependencies.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
-pip install --upgrade pip
+pip install --upgrade pip==9.0.1
 pip install --user pyhocon
 pip3 install --user pyhocon
 pip install --user pep8


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**  Travis build failing


**New behavior :**
It seems that the tag 8 of java is not available
anymore on dockerhub because the team maintaining
it has deprecated the java:8.
instructure/dockerfiles@aad60a3

Here are all the available tags
https://hub.docker.com/r/instructure/java/tags

Since "instructure" does not has many downloads,
there are good chances that they deprecate again.
So, using a famous java8 container from openjdk.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1204)
<!-- Reviewable:end -->
