### PR TITLE
Downgrade zookeeper version and remove not needed ZK test helper

### DIFF
--- a/job-server/src/test/scala/spark/jobserver/io/zookeeper/MetaDataZookeeperDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/zookeeper/MetaDataZookeeperDAOSpec.scala
@@ -33,7 +33,7 @@ class MetaDataZookeeperDAOSpec extends FunSpec with TestJarFinder with FunSpecLi
   before {
     Utils.usingResource(zkUtils.getClient) {
       client =>
-        zkUtils.delete(client, "/")
+        zkUtils.delete(client, "")
     }
   }
 

--- a/job-server/src/test/scala/spark/jobserver/io/zookeeper/MetaDataZookeeperDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/zookeeper/MetaDataZookeeperDAOSpec.scala
@@ -31,7 +31,6 @@ class MetaDataZookeeperDAOSpec extends FunSpec with TestJarFinder with FunSpecLi
   private val zkUtils = new ZookeeperUtils(testServer.getConnectString, testDir, 1)
 
   before {
-    testServer.createBaseDir(testDir)
     Utils.usingResource(zkUtils.getClient) {
       client =>
         zkUtils.delete(client, "/")

--- a/job-server/src/test/scala/spark/jobserver/io/zookeeper/ZookeeperUtilsSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/zookeeper/ZookeeperUtilsSpec.scala
@@ -16,7 +16,6 @@ class ZookeeperUtilsSpec extends FunSpec with Matchers with BeforeAndAfter {
   import JsonProtocols._
 
   before {
-    testServer.createBaseDir(testPath)
     client = zookeeperUtils.getClient
     zookeeperUtils.delete(client, "/")
   }

--- a/job-server/src/test/scala/spark/jobserver/io/zookeeper/ZookeeperUtilsSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/zookeeper/ZookeeperUtilsSpec.scala
@@ -17,7 +17,7 @@ class ZookeeperUtilsSpec extends FunSpec with Matchers with BeforeAndAfter {
 
   before {
     client = zookeeperUtils.getClient
-    zookeeperUtils.delete(client, "/")
+    zookeeperUtils.delete(client, "")
   }
 
   after {
@@ -27,9 +27,9 @@ class ZookeeperUtilsSpec extends FunSpec with Matchers with BeforeAndAfter {
   describe("write, read and delete data") {
     it("should write, list and delete object") {
       zookeeperUtils.write[BinaryInfo](client, testInfo, "/testfile") should equal(true)
-      zookeeperUtils.list(client, "/") should equal(Seq("testfile"))
+      zookeeperUtils.list(client, "") should equal(Seq("testfile"))
       zookeeperUtils.delete(client, "/testfile") should equal(true)
-      zookeeperUtils.list(client, "/") should equal(Seq.empty[String])
+      zookeeperUtils.list(client, "") should equal(Seq.empty[String])
     }
 
     it("should read object") {
@@ -53,11 +53,11 @@ class ZookeeperUtilsSpec extends FunSpec with Matchers with BeforeAndAfter {
       zookeeperUtils.write[BinaryInfo](client, testInfo, "/testfile1")
       zookeeperUtils.write[BinaryInfo](client, testInfo, "/testfile2")
       zookeeperUtils.write[BinaryInfo](client, testInfo, "/testfile3")
-      zookeeperUtils.list(client, "/").sorted should equal(Seq("testfile1", "testfile2", "testfile3"))
+      zookeeperUtils.list(client, "").sorted should equal(Seq("testfile1", "testfile2", "testfile3"))
     }
 
     it("should return empty list if there are no children") {
-      zookeeperUtils.list(client, "/").sorted should equal(Seq())
+      zookeeperUtils.list(client, "").sorted should equal(Seq())
     }
   }
 
@@ -68,9 +68,9 @@ class ZookeeperUtilsSpec extends FunSpec with Matchers with BeforeAndAfter {
     }
 
     it("should not see other namespaces") {
-      zookeeperUtils.list(client, "/").sorted should equal(Seq())
+      zookeeperUtils.list(client, "").sorted should equal(Seq())
       val zkUtils2 = new ZookeeperUtils(testServer.getConnectString, "", 1)
-      zkUtils2.list(zkUtils2.getClient, "/") should equal(Seq("zookeeper"))
+      zkUtils2.list(zkUtils2.getClient, "") should equal(Seq("zookeeper"))
     }
   }
 }

--- a/job-server/src/test/scala/spark/jobserver/util/CuratorTestCluster.scala
+++ b/job-server/src/test/scala/spark/jobserver/util/CuratorTestCluster.scala
@@ -16,22 +16,4 @@ class CuratorTestCluster {
   }
 
   def getConnectString: String = server.getConnectString
-
-  def createBaseDir(basePath: String): Boolean = {
-    Utils.usingResource(new ZookeeperUtils(getConnectString, basePath, 1).getClient) {
-      client =>
-        try {
-          if (client.checkExists().forPath(basePath) == null) {
-            ZKPaths.mkdirs(
-              client.getZookeeperClient.getZooKeeper, basePath
-            )
-          }
-          true
-        } catch {
-          case NonFatal(e) =>
-            logger.error(s"Didn't manage to create dir $basePath: ${e.getMessage}")
-            false
-        }
-    }
-  }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -58,8 +58,7 @@ object Dependencies {
   )
 
   lazy val zookeeperDeps = Seq(
-    "org.apache.curator" % "curator-framework" % curator excludeAll(excludeZookeeper, excludeGuava),
-    "org.apache.zookeeper" % "zookeeper" % zookeeper
+    "org.apache.curator" % "apache-curator" % curator % Provided
   )
 
   lazy val cassandraDeps = Seq(
@@ -80,9 +79,9 @@ object Dependencies {
   )
 
   lazy val miscTestDeps = Seq(
-    "org.apache.hadoop" % "hadoop-hdfs" % hadoop % Test classifier "tests",
-    "org.apache.hadoop" % "hadoop-common" % hadoop % Test classifier "tests",
-    "org.apache.hadoop" % "hadoop-minicluster" % hadoop % Test,
+    "org.apache.hadoop" % "hadoop-hdfs" % hadoop % Test classifier "tests" excludeAll(excludeCurator),
+    "org.apache.hadoop" % "hadoop-common" % hadoop % Test classifier "tests" excludeAll(excludeCurator),
+    "org.apache.hadoop" % "hadoop-minicluster" % hadoop % Test excludeAll(excludeCurator),
     "org.apache.curator" % "curator-test" % curatorTest % Test excludeAll(excludeGuava)
   )
 

--- a/project/ExclusionRules.scala
+++ b/project/ExclusionRules.scala
@@ -10,4 +10,5 @@ object ExclusionRules {
   val excludeJpountz = ExclusionRule(organization = "net.jpountz.lz4", name = "lz4")
   val excludeZookeeper = ExclusionRule(organization = "org.apache.zookeeper", name = "zookeeper")
   val excludeGuava = ExclusionRule(organization = "com.google.guava")
+  val excludeCurator = ExclusionRule(organization = "org.apache.curator")
 }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -29,7 +29,6 @@ object Versions {
   lazy val sprayJson = "1.3.2"
   lazy val typeSafeConfig = if (isJavaAtLeast("1.8")) "1.3.0" else "1.2.1"
   lazy val cassandraConnector = "2.3.2"
-  lazy val curator = "4.0.1"
+  lazy val curator = "2.6.0"
   lazy val curatorTest = "2.12.0"
-  lazy val zookeeper = "3.4.13"
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) 
- [x] Tests for the changes have been added (for bug fixes / features) 
- [x] Docs have been added / updated (for bug fixes / features) 

**Current behavior :** 

Jobserver jar is started with spark-submit command and because
of this jobserver is using Curator library version imported
by Spark.


**New behavior :**

As we don't use any specific Curator features introduced after
2.6.0, the easiest option will be to downgrade to match
Curator dependency of Spark 2.3.2. The dependency will be
now marked as provided, because we will use the library
from Spark. Downgrade is also important so that our tests
are made for the right version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1206)
<!-- Reviewable:end -->
