### PR TITLE
Remove binaries if not used & adding logging to webapi

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/BinaryManager.scala
+++ b/job-server/src/main/scala/spark/jobserver/BinaryManager.scala
@@ -3,15 +3,15 @@ package spark.jobserver
 import akka.actor.ActorRef
 import akka.util.Timeout
 import spark.jobserver.io.JobDAOActor.{DeleteBinaryResult, SaveBinaryResult}
-import spark.jobserver.io.{BinaryType, JobDAOActor}
-import spark.jobserver.util.JarUtils
+import spark.jobserver.io.{BinaryType, JobDAOActor, JobInfo, JobStatus}
+import spark.jobserver.util.{JarUtils, NoSuchBinaryException}
 import org.joda.time.DateTime
 import java.nio.file.{Files, Paths}
 
 import scala.concurrent.Future
+import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 import spark.jobserver.common.akka.InstrumentedActor
-import spark.jobserver.util.NoSuchBinaryException
 
 // Messages to JarManager actor
 
@@ -34,8 +34,13 @@ case object InvalidBinary
 case object BinaryStored
 case object BinaryDeleted
 case object NoSuchBinary
+case class BinaryInUse(jobs: Seq[String])
 case class BinaryStorageFailure(ex: Throwable)
 case class BinaryDeletionFailure(ex: Throwable)
+
+object BinaryManager {
+  val DELETE_TIMEOUT = 3.seconds
+}
 
 /**
  * An Actor that manages the jars stored by the job server.   It's important that threads do not try to
@@ -56,8 +61,15 @@ class BinaryManager(jobDao: ActorRef) extends InstrumentedActor {
   }
 
   private def deleteBinary(appName: String): Future[Try[Unit]] = {
-    (jobDao ? JobDAOActor.DeleteBinary(appName)).
+    (jobDao ? JobDAOActor.DeleteBinary(appName))(BinaryManager.DELETE_TIMEOUT).
       mapTo[DeleteBinaryResult].map(_.outcome)
+  }
+
+  private def getActiveJobsUsingBinary(binName: String): Future[Seq[JobInfo]] = {
+    (jobDao ? JobDAOActor.GetJobsByBinaryName(
+          binName, Some(JobStatus.getNonFinalStates())))(BinaryManager.DELETE_TIMEOUT)
+        .mapTo[JobDAOActor.JobInfos]
+        .map(_.jobInfos)
   }
 
   override def wrappedReceive: Receive = {
@@ -108,13 +120,22 @@ class BinaryManager(jobDao: ActorRef) extends InstrumentedActor {
       }
 
     case DeleteBinary(appName) =>
+      val recipient = sender()
       logger.info(s"Deleting binary $appName")
-      deleteBinary(appName).map {
-        case Success(_) => BinaryDeleted
-        case Failure(ex) => ex match {
-          case e: NoSuchBinaryException => NoSuchBinary
-          case _ => BinaryDeletionFailure(ex)
-        }
-      }.pipeTo(sender)
+      getActiveJobsUsingBinary(appName).onComplete {
+        case Success(Seq()) =>
+          logger.info(s"No active job found for binary $appName. Deleting binary.")
+          deleteBinary(appName).map {
+            case Success(_) => {
+              BinaryDeleted
+            }
+            case Failure(ex) => ex match {
+              case _: NoSuchBinaryException => NoSuchBinary
+              case _ => BinaryDeletionFailure(ex)
+            }
+          }.pipeTo(recipient)
+        case Success(jobs) => recipient ! BinaryInUse(jobs.map(_.jobId))
+        case Failure(ex) => recipient ! BinaryDeletionFailure(ex)
+      }
   }
 }

--- a/job-server/src/main/scala/spark/jobserver/io/CombinedDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/CombinedDAO.scala
@@ -236,4 +236,9 @@ class CombinedDAO(config: Config) extends JobDAO with FileCacher with YammerMetr
         ""
     }
   }
+
+  override def getJobsByBinaryName(binName: String, statuses: Option[Seq[String]] = None):
+      Future[Seq[JobInfo]] = {
+    metaDataDAO.getJobsByBinaryName(binName, statuses)
+  }
 }

--- a/job-server/src/main/scala/spark/jobserver/io/JobCassandraDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobCassandraDAO.scala
@@ -11,16 +11,14 @@ import scala.collection.convert.Wrappers.JListWrapper
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.DurationInt
 import scala.util.Try
-
 import com.datastax.driver.core._
-import com.datastax.driver.core.querybuilder.{Insert, QueryBuilder => QB }
+import com.datastax.driver.core.querybuilder.{Insert, QueryBuilder => QB}
 import com.datastax.driver.core.querybuilder.QueryBuilder._
 import com.datastax.driver.core.schemabuilder.{Create, SchemaBuilder}
 import com.datastax.driver.core.schemabuilder.SchemaBuilder.Direction
 import com.typesafe.config.{Config, ConfigFactory, ConfigRenderOptions}
 import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
-
 import spark.jobserver.cassandra.Cassandra.Resultset.toFuture
 
 object Metadata {
@@ -178,6 +176,11 @@ class JobCassandraDAO(config: Config) extends JobDAO with FileCacher {
     session.execute(fillInsert(insertInto(ContextsTable)))
     session.execute(fillInsert(insertInto(OrderedContextsByNameTable)))
     session.execute(fillInsert(insertInto(OrderedContextsByStateTable)))
+  }
+
+  override def getJobsByBinaryName(binName: String, statuses: Option[Seq[String]] = None):
+      Future[Seq[JobInfo]] = {
+    throw new NotImplementedError()
   }
 
   override def getContextInfo(id: String): Future[Option[ContextInfo]] = {

--- a/job-server/src/main/scala/spark/jobserver/io/JobDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobDAO.scala
@@ -63,6 +63,14 @@ trait JobDAO {
   def getBinaryFilePath(appName: String, binaryType: BinaryType, uploadTime: DateTime): String
 
   /**
+    * Return all jobs using a certain binary
+    * @param binName Name of binary
+    * @param statuses List of job statuses
+    * @return Sequence of all job infos matching query
+    */
+  def getJobsByBinaryName(binName: String, statuses: Option[Seq[String]] = None): Future[Seq[JobInfo]]
+
+  /**
    * Persist a context info.
    *
    * @param contextInfo

--- a/job-server/src/main/scala/spark/jobserver/io/JobDAOActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobDAOActor.scala
@@ -44,6 +44,7 @@ object JobDAOActor {
   case class GetContextInfoByName(name: String) extends JobDAORequest
   case class GetContextInfos(limit: Option[Int] = None,
       statuses: Option[Seq[String]] = None) extends JobDAORequest
+  case class GetJobsByBinaryName(appName: String, statuses: Option[Seq[String]] = None) extends JobDAORequest
 
   //Responses
   sealed trait JobDAOResponse
@@ -88,6 +89,9 @@ class JobDAOActor(dao: JobDAO) extends InstrumentedActor {
 
     case GetBinaryPath(appName, binType, uploadTime) =>
       sender() ! BinaryPath(dao.getBinaryFilePath(appName, binType, uploadTime))
+
+    case GetJobsByBinaryName(binName, statuses) =>
+      dao.getJobsByBinaryName(binName, statuses).map(JobInfos).pipeTo(sender)
 
     case SaveContextInfo(contextInfo) =>
       saveContextAndRespond(sender, contextInfo)

--- a/job-server/src/main/scala/spark/jobserver/io/JobFileDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobFileDAO.scala
@@ -153,6 +153,11 @@ class JobFileDAO(config: Config) extends JobDAO {
   override def getBinaryFilePath(appName: String, binaryType: BinaryType, uploadTime: DateTime): String =
     new File(rootDir, createJarName(appName, uploadTime) + s".${binaryType.extension}").getAbsolutePath
 
+  override def getJobsByBinaryName(binName: String, statuses: Option[Seq[String]] = None):
+      Future[Seq[JobInfo]] = {
+    throw new NotImplementedError()
+  }
+
   private def createJarName(appName: String, uploadTime: DateTime): String =
     appName + "-" + uploadTime.toString().replace(':', '_')
 

--- a/job-server/src/main/scala/spark/jobserver/io/JobSqlDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobSqlDAO.scala
@@ -189,6 +189,11 @@ class JobSqlDAO(config: Config, sqlCommon: SqlCommon) extends JobDAO with FileCa
     }
   }
 
+  override def getJobsByBinaryName(binName: String, statuses: Option[Seq[String]] = None):
+      Future[Seq[JobInfo]] = {
+    sqlCommon.getJobsByBinaryName(binName, statuses)
+  }
+
   override def saveContextInfo(contextInfo: ContextInfo): Unit = {
     if (!Await.result(sqlCommon.saveContext(contextInfo), futureTimeout)) {
       throw new SlickException(s"Could not update ${contextInfo.id} in the database")

--- a/job-server/src/main/scala/spark/jobserver/io/MetaDataDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/MetaDataDAO.scala
@@ -71,6 +71,14 @@ trait MetaDataDAO {
   def getJobsByContextId(contextId: String, statuses: Option[Seq[String]] = None): Future[Seq[JobInfo]]
 
   /**
+    * Return all jobs using a certain binary
+    * @param binName Name of binary
+    * @param statuses List of job statuses
+    * @return Sequence of all job infos matching query
+    */
+  def getJobsByBinaryName(binName: String, statuses: Option[Seq[String]] = None): Future[Seq[JobInfo]]
+
+  /**
     * Persist a job configuration along with provided job id.
     *
     * @param id

--- a/job-server/src/main/scala/spark/jobserver/io/MetaDataSqlDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/MetaDataSqlDAO.scala
@@ -10,7 +10,6 @@ import com.typesafe.config.Config
 import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
 import slick.driver.JdbcProfile
-import spark.jobserver.util.Utils
 
 class MetaDataSqlDAO(config: Config) extends MetaDataDAO {
   private val logger = LoggerFactory.getLogger(getClass)
@@ -209,6 +208,10 @@ class MetaDataSqlDAO(config: Config) extends MetaDataDAO {
   def deleteBinary(name: String): Future[Boolean] = {
     val deleteBinary = sqlCommon.binaries.filter(_.appName === name).delete
     sqlCommon.db.run(deleteBinary).map(_ > 0).recover(logDeleteErrors)
+  }
+
+  def getJobsByBinaryName(binName: String, statuses: Option[Seq[String]] = None): Future[Seq[JobInfo]] = {
+    sqlCommon.getJobsByBinaryName(binName, statuses)
   }
 
   private def binaryInfoFromRow(row: (Int, String, String, Timestamp, Array[Byte])): BinaryInfo = row match {

--- a/job-server/src/test/scala/spark/jobserver/BinaryManagerSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/BinaryManagerSpec.scala
@@ -8,7 +8,7 @@ import akka.testkit.{ImplicitSender, TestKit}
 import org.joda.time.DateTime
 import org.scalatest.{BeforeAndAfterAll, FunSpecLike, Matchers}
 import spark.jobserver.common.akka.{AkkaTestUtils, InstrumentedActor}
-import spark.jobserver.io.BinaryType
+import spark.jobserver.io.{BinaryInfo, BinaryType, JobInfo, JobStatus}
 
 object BinaryManagerSpec {
   val system = ActorSystem("binary-manager-test")
@@ -19,6 +19,9 @@ object BinaryManagerSpec {
 
     import spark.jobserver.io.JobDAOActor._
 
+    val jobInfo = JobInfo("bar", "cid", "context", BinaryInfo("demo", BinaryType.Egg, DateTime.now),
+        "com.abc.meme", JobStatus.Running, DateTime.now, None, None)
+
     override def wrappedReceive: Receive = {
       case GetApps(_) =>
         sender ! Apps(Map("app1" -> (BinaryType.Jar, dt)))
@@ -28,6 +31,12 @@ object BinaryManagerSpec {
         sender ! SaveBinaryResult(Success({}))
       case DeleteBinary(_) =>
         sender ! DeleteBinaryResult(Success({}))
+      case GetJobsByBinaryName(appName, statuses) =>
+        appName match {
+          case "empty" => sender ! JobInfos(Seq())
+          case "running" => sender ! JobInfos(Seq(jobInfo))
+          case "fail" =>
+        }
     }
   }
 }
@@ -66,9 +75,19 @@ class BinaryManagerSpec extends TestKit(BinaryManagerSpec.system) with ImplicitS
       expectMsgPF(3 seconds){case BinaryStorageFailure(ex) if ex.getMessage == "deliberate failure" => }
     }
 
-    it("should respond when deleted successfully") {
-      binaryManager ! DeleteBinary("valid")
-      expectMsg(BinaryDeleted)
+    it("should respond when deleted successfully if no active job is using the binary") {
+      binaryManager ! DeleteBinary("empty")
+      expectMsg(3.seconds, BinaryDeleted)
+    }
+
+    it("should not delete if binary is still in use") {
+      binaryManager ! DeleteBinary("running")
+      expectMsg(3.seconds, BinaryInUse(Seq("bar")))
+    }
+
+    it("should handle failures during deletion of binary and within timeout") {
+      binaryManager ! DeleteBinary("fail")
+      expectMsgType[BinaryDeletionFailure](BinaryManager.DELETE_TIMEOUT + 1.seconds)
     }
   }
 }

--- a/job-server/src/test/scala/spark/jobserver/InMemoryDAO.scala
+++ b/job-server/src/test/scala/spark/jobserver/InMemoryDAO.scala
@@ -126,7 +126,12 @@ class InMemoryDAO extends JobDAO {
     Await.result(getApps, 60 seconds).get(appName).map(t => BinaryInfo(appName, t._1, t._2))
   }
 
-override def deleteBinary(appName: String): Unit = {
+  override def deleteBinary(appName: String): Unit = {
     binaries = binaries.filter { case ((name, _, _), _) => appName != name }
+  }
+
+  override def getJobsByBinaryName(binName: String, statuses: Option[Seq[String]] = None):
+      Future[Seq[JobInfo]] = {
+    throw new NotImplementedError()
   }
 }

--- a/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
@@ -152,6 +152,8 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
       case StoreBinary(_, _, _)         => sender ! BinaryStored
 
       case DeleteBinary("badbinary") => sender ! NoSuchBinary
+      case DeleteBinary("active") => sender ! BinaryInUse(Seq("job-active"))
+      case DeleteBinary("failure") => sender ! BinaryDeletionFailure(new Exception("deliberate"))
       case DeleteBinary(_) => sender ! BinaryDeleted
 
       case DataManagerActor.StoreData("errorfileToRemove", _) => sender ! DataManagerActor.Error

--- a/job-server/src/test/scala/spark/jobserver/io/CombinedDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/CombinedDAOSpec.scala
@@ -503,6 +503,9 @@ class DummyMetaDataDAO(config: Config) extends MetaDataDAO {
 
   override def getJobs(limit: Int, status: Option[String]): Future[Seq[JobInfo]] = ???
 
+  override def getJobsByBinaryName(binName: String, statuses: Option[Seq[String]] = None):
+    Future[Seq[JobInfo]] = ???
+
   override def getJob(id: String): Future[Option[JobInfo]] = {
     Future.successful(jobInfos.get(id))
   }

--- a/job-server/src/test/scala/spark/jobserver/io/JobDAOActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/JobDAOActorSpec.scala
@@ -99,6 +99,21 @@ object JobDAOActorSpec {
       }
     }
 
+    override def getJobsByBinaryName(binName: String, statuses: Option[Seq[String]] = None):
+        Future[Seq[JobInfo]] = {
+      binName match {
+        case "empty" => Future.successful(Seq.empty)
+        case "multiple" =>
+          val dt = DateTime.parse("2013-05-29T00Z")
+          val jobInfo =
+            JobInfo("bar", "cid", "context", BinaryInfo("demo", BinaryType.Egg, dt),
+              "com.abc.meme", JobStatus.Running, dt, None, None)
+
+          Future.successful(Seq(jobInfo, jobInfo.copy(jobId = "kaboom")))
+        case _ => Future.failed(new Exception("Unknown message"))
+      }
+    }
+
     override def cleanRunningJobInfosForContext(contextName: String, endTime: DateTime): Future[Unit] = {
       cleanupProbe.ref ! contextName
       Future.successful(())
@@ -253,6 +268,19 @@ class JobDAOActorSpec extends TestKit(JobDAOActorSpec.system) with ImplicitSende
       daoActor ! UpdateContextById(contextId3, ContextInfoModifiable(
         ContextStatus.Started))
       expectMsgType[SaveFailed].error.getMessage() should be("deliberate failure")
+    }
+
+    it("should get empty list of jobs if binary name is invalid") {
+      daoActor ! GetJobsByBinaryName("empty")
+      expectMsg(JobInfos(Seq()))
+    }
+
+    it("should get jobs by binary name") {
+      daoActor ! GetJobsByBinaryName("multiple")
+
+      expectMsgPF(5.seconds, "Get the jobs") {
+        case JobInfos(jobs) => jobs.map(_.jobId) should contain allOf("bar", "kaboom")
+      }
     }
   }
 }

--- a/job-server/src/test/scala/spark/jobserver/io/zookeeper/MetaDataZookeeperDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/zookeeper/MetaDataZookeeperDAOSpec.scala
@@ -3,7 +3,7 @@ package spark.jobserver.io.zookeeper
 import com.typesafe.config.{Config, ConfigFactory}
 import org.joda.time.DateTime
 import org.scalatest.{BeforeAndAfter, FunSpec, FunSpecLike, Matchers}
-import spark.jobserver.io.{BinaryDAO, BinaryInfo, BinaryType, ContextInfo, ErrorData, JobInfo}
+import spark.jobserver.io._
 import spark.jobserver.util.CuratorTestCluster
 import spark.jobserver.TestJarFinder
 
@@ -183,6 +183,30 @@ class MetaDataZookeeperDAOSpec extends FunSpec with TestJarFinder with FunSpecLi
       resultList.head.appName should equal(binJar.appName)
     }
 
+    it("should get jobs by binary name") {
+      Await.result(dao.saveBinary(binJar.appName, binJar.binaryType,
+        binJar.uploadTime, binJar.binaryStorageId.get), timeout)
+
+      Await.result(dao.saveJob(normalJob), timeout)
+
+      Await.result(dao.getJobsByBinaryName(binJar.appName), timeout) should be(Seq(normalJob))
+    }
+
+    it("should get jobs by binary name and status") {
+      Await.result(dao.saveBinary(binJar.appName, binJar.binaryType,
+        binJar.uploadTime, binJar.binaryStorageId.get), timeout)
+
+      val runningJob = normalJob.copy(state = JobStatus.Running)
+      val restartingJob = normalJob.copy(jobId = "restarting", state = JobStatus.Restarting)
+      val errorJob = normalJob.copy(jobId = "error", state = JobStatus.Error)
+
+      Await.result(dao.saveJob(runningJob), timeout)
+      Await.result(dao.saveJob(restartingJob), timeout)
+      Await.result(dao.saveJob(errorJob), timeout)
+
+      Await.result(dao.getJobsByBinaryName(binJar.appName,
+        Some(Seq(JobStatus.Running, JobStatus.Error))), timeout) should contain allOf(runningJob, errorJob)
+    }
   }
 
   /*

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -80,7 +80,7 @@
  </check>
  <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
   <parameters>
-   <parameter name="maxTypes"><![CDATA[34]]></parameter>
+   <parameter name="maxTypes"><![CDATA[35]]></parameter>
   </parameters>
  </check>
  <check level="error" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="false">


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
Currently, user is allowed to delete a binary even
    if the binary is being used by a job. Deletion
    leads to 2 cases
    - Once the jobs finishes, a message is sent to
    JobStatusActor which tries to persist the state to
    dao but fails because saveJobInfo tries to query
    binaries table for binId but since the binary is
    deleted, query fails and status is not saved.
    - During restart scenario, driver tries to restart
    the job and needs binary. Since, binary is deleted
    the job cannot be restarted.

**New behavior :**
The fix for this is to not allow deletion of binary if an active job is using it.


**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

The new dao function not implemented by FileDAO and C*

**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1209)
<!-- Reviewable:end -->
