### PR TITLE
fix(tests): Fix saveJobConfig tests

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/util/Utils.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/Utils.scala
@@ -1,6 +1,7 @@
 package spark.jobserver.util
 
 import java.io.{Closeable, File}
+import scala.util.{Failure, Success, Try}
 
 object Utils {
   def usingResource[A <: Closeable, B](resource: A)(f: A => B): B = {
@@ -21,6 +22,16 @@ object Utils {
       if (!folder.mkdirs()) {
         throw new RuntimeException(s"Could not create directory $folder")
       }
+    }
+  }
+
+  def retry[T](n: Int, retryDelayInMs: Int = 500)(fn: => T): T = {
+    Try { fn } match {
+      case Success(x) => x
+      case _ if n > 1 =>
+        Thread.sleep(retryDelayInMs)
+        retry(n - 1)(fn)
+      case Failure(e) => throw e
     }
   }
 }

--- a/job-server/src/test/scala/spark/jobserver/io/JobCassandraDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/JobCassandraDAOSpec.scala
@@ -13,6 +13,8 @@ import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
 import spark.jobserver.TestJarFinder
 import scala.concurrent.duration._
 import scala.concurrent.Await
+import org.scalatest._
+import spark.jobserver.util.Utils
 
 class JobCassandraDAOSpec extends TestJarFinder with FunSpecLike with Matchers with BeforeAndAfter
   with BeforeAndAfterAll {
@@ -153,7 +155,7 @@ class JobCassandraDAOSpec extends TestJarFinder with FunSpecLike with Matchers w
       // save job config
       dao.saveJobConfig(jobId, jobConfig)
 
-      val config = Await.result(dao.getJobConfig(jobId), timeout).get
+      val config = Utils.retry(3, retryDelayInMs = 1000)(Await.result(dao.getJobConfig(jobId), timeout).get)
 
       // test
       config should equal (expectedConfig)

--- a/job-server/src/test/scala/spark/jobserver/io/SqlCommonSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/SqlCommonSpec.scala
@@ -2,7 +2,6 @@ package spark.jobserver.io
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
-
 import com.google.common.io.Files
 import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
 import org.joda.time.DateTime
@@ -113,7 +112,7 @@ class SqlCommonSpec extends SqlCommonSpecBase with TestJarFinder with FunSpecLik
     }
 
     it("should save and get the same config") {
-      dao.saveJobConfig(jobId, jobConfig)
+      Await.result(dao.saveJobConfig(jobId, jobConfig), timeout) should be(true)
 
       val config = Await.result(dao.getJobConfig(jobId), timeout).get
       config should equal (expectedConfig)


### PR DESCRIPTION
saveJobConfig function in JobDAO has Unit return
value. This means that if we save a config
and read it again in next line then it boils down
to timing and the test becomes flaky.

This change adds a retry while reading the config
to fix the test.

Further, SqlCommonSpec uses the saveJobConfig from
SqlCommon which has a return value. So, in this
test, we just add Await.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1210)
<!-- Reviewable:end -->
