### PR TITLE
Make zookeeper settings configurable

### DIFF
--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -68,6 +68,13 @@ spark {
     zookeeperdao {
       dir = "jobserver/db"
       connection-string = "localhost:2181"
+      curator {
+        retries = 3
+        # settings below are chosen for the cluster with 3 Zookeeper nodes
+        sleepMsBetweenRetries = 1000
+        connectionTimeoutMs = 2350
+        sessionTimeuoutMs = 10000
+      }
     }
 
     # To load up job jars on startup, place them here,

--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -73,7 +73,7 @@ spark {
         # settings below are chosen for the cluster with 3 Zookeeper nodes
         sleepMsBetweenRetries = 1000
         connectionTimeoutMs = 2350
-        sessionTimeuoutMs = 10000
+        sessionTimeoutMs = 10000
       }
     }
 

--- a/job-server/src/main/scala/spark/jobserver/io/zookeeper/MetaDataZookeeperDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/zookeeper/MetaDataZookeeperDAO.scala
@@ -5,7 +5,6 @@ import com.typesafe.config.ConfigRenderOptions
 import com.typesafe.config.ConfigFactory
 import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
-import spark.jobserver.JobServer.InvalidConfiguration
 import spark.jobserver.io._
 import spark.jobserver.util.JsonProtocols
 import spark.jobserver.util.Utils
@@ -15,8 +14,6 @@ import scala.concurrent.Future
 import org.apache.curator.framework.CuratorFramework
 
 object MetaDataZookeeperDAO {
-  private val baseDirPath = "spark.jobserver.zookeeperdao.dir"
-  private val connectionStringPath = "spark.jobserver.zookeeperdao.connection-string"
   private val binariesDir = "/binaries"
   private val contextsDir = "/contexts"
   private val jobsDir = "/jobs"
@@ -27,25 +24,7 @@ class MetaDataZookeeperDAO(config: Config) extends MetaDataDAO {
   import JsonProtocols._
 
   private val logger = LoggerFactory.getLogger(getClass)
-
-  /*
-   * Configuration
-   */
-
-  if (!config.hasPath(baseDirPath)) {
-    throw new InvalidConfiguration(
-      s"To use ZooKeeperDAO please specify ZK root dir for DAO in configuration file: $baseDirPath"
-    )
-  }
-
-  if (!config.hasPath(connectionStringPath)) {
-    throw new InvalidConfiguration(
-      s"To use ZooKeeperDAO please specify ZooKeeper connection string: $connectionStringPath"
-    )
-  }
-
-  private val connectionString = config.getString(connectionStringPath)
-  private val zookeeperUtils = new ZookeeperUtils(connectionString, config.getString(baseDirPath))
+  private val zookeeperUtils = new ZookeeperUtils(config)
 
   /*
    * Contexts

--- a/job-server/src/main/scala/spark/jobserver/io/zookeeper/ZookeeperUtils.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/zookeeper/ZookeeperUtils.scala
@@ -1,10 +1,12 @@
 package spark.jobserver.io.zookeeper
 
+import com.typesafe.config.Config
 import org.apache.curator.framework.{CuratorFramework, CuratorFrameworkFactory}
 import org.apache.curator.framework.api.{BackgroundCallback, CuratorEvent}
 import org.apache.curator.retry.RetryNTimes
 import org.apache.curator.utils.ZKPaths
 import org.slf4j.LoggerFactory
+import spark.jobserver.JobServer.InvalidConfiguration
 import spray.json._
 
 import scala.util.control.NonFatal
@@ -12,16 +14,45 @@ import scala.util.control.NonFatal
 // Fix type mismatch: java.util.List[String] in curator results
 import scala.collection.JavaConversions._ // scalastyle:ignore
 
-class ZookeeperUtils(connectString: String, baseFolder: String, retries: Int = 3) {
+object ZookeeperUtils {
+  private val settings = Map(
+    "baseFolder" -> "spark.jobserver.zookeeperdao.dir",
+    "connectionString" -> "spark.jobserver.zookeeperdao.connection-string",
+    "retries" -> "spark.jobserver.zookeeperdao.curator.retries",
+    "sleepBetweenRetries" -> "spark.jobserver.zookeeperdao.curator.sleepMsBetweenRetries",
+    "connectionTimeout" -> "spark.jobserver.zookeeperdao.curator.connectionTimeoutMs",
+    "sessionTimeout" -> "spark.jobserver.zookeeperdao.curator.sessionTimeuoutMs"
+  )
+}
+
+
+class ZookeeperUtils(config: Config) {
+  import ZookeeperUtils._
+
   private val logger = LoggerFactory.getLogger(getClass)
+
+  for (path <- settings.values) {
+    if (!config.hasPath(path)) {
+      throw new InvalidConfiguration(
+        s"To use ZookeeperDAO please specify $path in configuration file."
+      )
+    }
+  }
+
+  private val connectionString = config.getString(settings("connectionString"))
+  private val baseFolder = config.getString(settings("baseFolder"))
+  private val retries = config.getInt(settings("retries"))
+  private val connectionTimeout = config.getInt(settings("connectionTimeout"))
+  private val sleepBetweenRetries = config.getInt(settings("sleepBetweenRetries"))
+  private val sessionTimeout = config.getInt(settings("sessionTimeout"))
 
   def getClient: CuratorFramework = {
     val client = CuratorFrameworkFactory.builder.
-      connectString(connectString).
-      retryPolicy(new RetryNTimes(retries, 1000)).
+      connectString(connectionString).
+      retryPolicy(new RetryNTimes(retries, sleepBetweenRetries)).
       namespace(baseFolder).
-      connectionTimeoutMs(2350).
-      sessionTimeoutMs(10000).
+      connectionTimeoutMs(connectionTimeout).
+      sessionTimeoutMs(sessionTimeout).
       build
     client.start()
     client

--- a/job-server/src/main/scala/spark/jobserver/io/zookeeper/ZookeeperUtils.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/zookeeper/ZookeeperUtils.scala
@@ -21,7 +21,7 @@ object ZookeeperUtils {
     "retries" -> "spark.jobserver.zookeeperdao.curator.retries",
     "sleepBetweenRetries" -> "spark.jobserver.zookeeperdao.curator.sleepMsBetweenRetries",
     "connectionTimeout" -> "spark.jobserver.zookeeperdao.curator.connectionTimeoutMs",
-    "sessionTimeout" -> "spark.jobserver.zookeeperdao.curator.sessionTimeuoutMs"
+    "sessionTimeout" -> "spark.jobserver.zookeeperdao.curator.sessionTimeoutMs"
   )
 }
 

--- a/job-server/src/test/resources/local.test.combineddao.conf
+++ b/job-server/src/test/resources/local.test.combineddao.conf
@@ -19,7 +19,7 @@ spark.jobserver {
       retries = 1
       sleepMsBetweenRetries = 100
       connectionTimeoutMs = 235
-      sessionTimeuoutMs = 1000
+      sessionTimeoutMs = 1000
     }
   }
 }

--- a/job-server/src/test/resources/local.test.combineddao.conf
+++ b/job-server/src/test/resources/local.test.combineddao.conf
@@ -1,0 +1,25 @@
+# This file contains common test settings for CombinedDAO and ZookeeperDAO
+
+spark.jobserver {
+  cache-on-upload = false
+
+  combineddao {
+    rootdir = /tmp/spark-job-server-test
+    binarydao {
+      class = spark.jobserver.io.DummyBinaryDAO
+    }
+    metadatadao {
+      class = spark.jobserver.io.DummyMetaDataDAO
+    }
+  }
+
+  zookeeperdao {
+    dir = "test"
+    curator {
+      retries = 1
+      sleepMsBetweenRetries = 100
+      connectionTimeoutMs = 235
+      sessionTimeuoutMs = 1000
+    }
+  }
+}

--- a/job-server/src/test/scala/spark/jobserver/io/CombinedDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/CombinedDAOSpec.scala
@@ -44,19 +44,12 @@ object CombinedDAOTestHelper {
 class CombinedDAOSpec extends CombinedDAOSpecBase with FunSpecLike with BeforeAndAfterAll
   with Matchers{
 
-    val rootDirKey = "spark.jobserver.combineddao.rootdir"
-    val baseRootDir = "/tmp/spark-job-server-test"
-    val rootDir = s"$baseRootDir/combineddao"
-    def config: Config = ConfigFactory.parseString(
-      s"""
-        |$rootDirKey = $rootDir,
-        |spark.jobserver.combineddao.binarydao.class = spark.jobserver.io.DummyBinaryDAO,
-        |spark.jobserver.combineddao.metadatadao.class = spark.jobserver.io.DummyMetaDataDAO
-        |spark.jobserver.cache-on-upload = false
-      """.stripMargin
-    )
-    val daoTimeout: FiniteDuration = 3 seconds
-    var dao: CombinedDAO = new CombinedDAO(config)
+    def config: Config = ConfigFactory.load("local.test.combineddao.conf")
+    private val rootDirKey = "spark.jobserver.combineddao.rootdir"
+    private val baseRootDir = config.getString(rootDirKey)
+    private val rootDir = s"$baseRootDir/combineddao"
+    private val daoTimeout: FiniteDuration = 3 seconds
+    private var dao: CombinedDAO = new CombinedDAO(config)
 
     override def beforeAll() {
       Files.createDirectories(Paths.get(rootDir))

--- a/job-server/src/test/scala/spark/jobserver/io/zookeeper/MetaDataZookeeperDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/zookeeper/MetaDataZookeeperDAOSpec.scala
@@ -19,16 +19,18 @@ class MetaDataZookeeperDAOSpec extends FunSpec with TestJarFinder with FunSpecLi
    */
 
   private val timeout = 60 seconds
-
   private val testServer = new CuratorTestCluster()
-  private val testDir = "jobserver-test"
+
   def config: Config = ConfigFactory.parseString(
     s"""
-         |spark.jobserver.zookeeperdao.connection-string = "${testServer.getConnectString}",
-         |spark.jobserver.zookeeperdao.dir = $testDir""".stripMargin)
+         |spark.jobserver.zookeeperdao.connection-string = "${testServer.getConnectString}"
+    """.stripMargin
+  ).withFallback(
+    ConfigFactory.load("local.test.combineddao.conf")
+  )
 
   private var dao = new MetaDataZookeeperDAO(config)
-  private val zkUtils = new ZookeeperUtils(testServer.getConnectString, testDir, 1)
+  private val zkUtils = new ZookeeperUtils(config)
 
   before {
     Utils.usingResource(zkUtils.getClient) {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**New behavior :**

Zookeeper timeout setting may vary depending on cluster (number of nodes particularly), so it makes sense to have them in config file for DAO.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1211)
<!-- Reviewable:end -->
