### PR TITLE
ZookeeperDAO fixes

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/BinaryManager.scala
+++ b/job-server/src/main/scala/spark/jobserver/BinaryManager.scala
@@ -39,7 +39,7 @@ case class BinaryStorageFailure(ex: Throwable)
 case class BinaryDeletionFailure(ex: Throwable)
 
 object BinaryManager {
-  val DELETE_TIMEOUT = 3.seconds
+  val DELETE_TIMEOUT = 5.seconds
 }
 
 /**
@@ -77,7 +77,6 @@ class BinaryManager(jobDao: ActorRef) extends InstrumentedActor {
       val requestor = sender
       val resp = (jobDao ? JobDAOActor.GetApps(filterOpt)).mapTo[JobDAOActor.Apps]
       resp.map { msg => msg.apps } pipeTo requestor
-
 
     case StoreLocalBinaries(localBinaries) =>
       val successF =

--- a/job-server/src/main/scala/spark/jobserver/io/zookeeper/MetaDataZookeeperDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/zookeeper/MetaDataZookeeperDAO.scala
@@ -31,7 +31,7 @@ class MetaDataZookeeperDAO(config: Config) extends MetaDataDAO {
    */
 
   override def saveContext(contextInfo: ContextInfo): Future[Boolean] = {
-    logger.debug("Saving new context")
+    logger.debug(s"Saving context ${contextInfo.id} (state: ${contextInfo.state})")
     Future {
       Utils.usingResource(zookeeperUtils.getClient) {
         client =>
@@ -101,7 +101,7 @@ class MetaDataZookeeperDAO(config: Config) extends MetaDataDAO {
    */
 
   override def saveJob(jobInfo: JobInfo): Future[Boolean] = {
-    logger.debug("Saving job")
+    logger.debug(s"Saving job ${jobInfo.jobId} (state: ${jobInfo.state})")
     Future {
       Utils.usingResource(zookeeperUtils.getClient) {
         client =>
@@ -206,7 +206,7 @@ class MetaDataZookeeperDAO(config: Config) extends MetaDataDAO {
    */
 
   override def saveJobConfig(jobId: String, config: Config): Future[Boolean] = {
-    logger.debug("Saving job config")
+    logger.debug(s"Saving job config for job $jobId")
     Future {
       Utils.usingResource(zookeeperUtils.getClient) {
         client =>
@@ -281,7 +281,7 @@ class MetaDataZookeeperDAO(config: Config) extends MetaDataDAO {
 
   override def saveBinary(name: String, binaryType: BinaryType,
                           uploadTime: DateTime, binaryStorageId: String): Future[Boolean] = {
-    logger.debug("Saving binary")
+    logger.debug(s"Saving binary $name")
     Future {
       Utils.usingResource(zookeeperUtils.getClient) {
         client =>

--- a/job-server/src/main/scala/spark/jobserver/io/zookeeper/ZookeeperUtils.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/zookeeper/ZookeeperUtils.scala
@@ -7,6 +7,7 @@ import org.apache.curator.retry.RetryNTimes
 import org.apache.curator.utils.ZKPaths
 import org.slf4j.LoggerFactory
 import spark.jobserver.JobServer.InvalidConfiguration
+import spark.jobserver.util.Utils
 import spray.json._
 
 import scala.util.control.NonFatal
@@ -24,7 +25,6 @@ object ZookeeperUtils {
     "sessionTimeout" -> "spark.jobserver.zookeeperdao.curator.sessionTimeoutMs"
   )
 }
-
 
 class ZookeeperUtils(config: Config) {
   import ZookeeperUtils._
@@ -89,7 +89,7 @@ class ZookeeperUtils(config: Config) {
       }
     } catch {
       case NonFatal(e) =>
-        logger.error(e.getMessage)
+        Utils.logStackTrace(logger, e)
         None
     }
   }
@@ -105,7 +105,7 @@ class ZookeeperUtils(config: Config) {
       true
     } catch {
       case NonFatal(e) =>
-        logger.error(e.getMessage)
+        Utils.logStackTrace(logger, e)
         false
     }
   }
@@ -124,7 +124,7 @@ class ZookeeperUtils(config: Config) {
       true
     } catch {
       case NonFatal(e) =>
-        logger.error(e.getMessage)
+        Utils.logStackTrace(logger, e)
         false
     }
   }

--- a/job-server/src/main/scala/spark/jobserver/util/JsonProtocols.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/JsonProtocols.scala
@@ -7,7 +7,8 @@ import spray.json.{DefaultJsonProtocol, JsNull, JsObject, JsString, JsValue, Roo
                    deserializationError, pimpAny}
 
 object JsonProtocols extends DefaultJsonProtocol {
-  val df: SimpleDateFormat = new SimpleDateFormat("yyyy-MM-dd HH-mm-ss SS Z")
+
+  val DATE_PATTERN = "yyyy-MM-dd HH-mm-ss SS Z"
 
   /*
    * BinaryInfo
@@ -111,6 +112,7 @@ object JsonProtocols extends DefaultJsonProtocol {
    * Helpers
    */
 
+  private def df : SimpleDateFormat = new SimpleDateFormat(DATE_PATTERN)
   private def fromJoda(dt: DateTime): String = df.format(dt.getMillis)
   private def toJoda(s: String): DateTime = new DateTime(df.parse(s).getTime)
   private def readOpt[A](j: JsValue, f: JsValue => A): Option[A] = {

--- a/job-server/src/main/scala/spark/jobserver/util/Utils.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/Utils.scala
@@ -1,7 +1,8 @@
 package spark.jobserver.util
 
-import java.io.{Closeable, File}
+import java.io.{Closeable, File, StringWriter, PrintWriter}
 import scala.util.{Failure, Success, Try}
+import org.slf4j.Logger
 
 object Utils {
   def usingResource[A <: Closeable, B](resource: A)(f: A => B): B = {
@@ -34,4 +35,11 @@ object Utils {
       case Failure(e) => throw e
     }
   }
+
+  def logStackTrace(logger: Logger, exception: Throwable): Unit = {
+    val sw = new StringWriter
+    exception.printStackTrace(new PrintWriter(sw))
+    logger.error(s"${exception.getMessage} : ${sw.toString}")
+  }
+
 }

--- a/job-server/src/test/scala/spark/jobserver/util/JsonProtocolsSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/util/JsonProtocolsSpec.scala
@@ -13,6 +13,7 @@ import spark.jobserver.util.JsonProtocols._
 import spray.json.pimpAny
 import spray.json.pimpString
 import spark.jobserver.io.ContextInfo
+import java.text.SimpleDateFormat
 
 class JsonProtocolsSpec extends FunSpec with Matchers with BeforeAndAfter {
 
@@ -21,10 +22,11 @@ class JsonProtocolsSpec extends FunSpec with Matchers with BeforeAndAfter {
    */
 
   // Date formatting
+  val df = new SimpleDateFormat("yyyy-MM-dd HH-mm-ss SS Z")
   val earlyDate = new DateTime().minusHours(1)
   val date = new DateTime()
-  val earlyDateStr = JsonProtocols.df.format(earlyDate.getMillis)
-  val dateStr = JsonProtocols.df.format(date.getMillis)
+  val earlyDateStr = df.format(earlyDate.getMillis)
+  val dateStr = df.format(date.getMillis)
 
   // BinaryInfo
   val testBinaryInfo = BinaryInfo("SomeName", BinaryType.Jar, earlyDate, Some("SomeStorId"))


### PR DESCRIPTION
**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?

**Content**
These are some production-tested fixes/improvements for the recently introduced MetadataZookeeperDAO, mainly:
- Increase verbosity of ZK dao logs to get a bit more insight
- Make date parsing of ZK dao thread safe, as this lead to exceptions in date parsing in the past
- Adapt one timeout so that potential zookeeper bottlenecks do not result in TimeoutExceptions

See commit messages for more details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1216)
<!-- Reviewable:end -->
