### PR TITLE
Introduce Zookeeper Autopurge mechanism

### DIFF
--- a/doc/dao-setup.md
+++ b/doc/dao-setup.md
@@ -51,6 +51,8 @@ configuration file `local.conf`:
     zookeeperdao {
       dir = "jobserver/db"
       connection-string = "localhost:2181"
+      autopurge = true
+      autopurge_after_hours = 168
     }
 ```
 
@@ -63,8 +65,22 @@ Zookeeperdao settings:
 
 `dir` - directory to store data in. If left empty then the root directory (`/`) of
 Zookeeper will be used.
+
 `connection-string` -  comma separated `host:port` pairs, each corresponding to a Zookeeper server
 e.g. "127.0.0.1:2181,127.0.0.1:2182,127.0.0.1:2183,127.0.0.1:2184".
+
+`autopurge` -  A boolean specifying if the autopurge feature of Zookeeper DAO should be used or not.
+If no such property is specified, it defaults to `false`.
+
+`autopurge_after_hours` -  Integer value specifying the age of contexts and jobs in **hours**, after which they are considered old and purged in the next run.
+If no such property is specified, it defaults to `168` hours (7 days).
+
+##### Autopurge feature
+Due to the hierarchical nature of our Zookeeper schema, read queries require to iterate over all nodes and process each of them.
+Especially within a distributed setup large amounts of Zookeeper nodes can therefore reduce the Jobserver performance.
+The autopurge feature introduces an option to automatically remove old contexts and jobs to contain this effect.
+
+It works by starting an `AutoPurgeActor` on Jobserver startup, which every hour checks the zookeeper tree for jobs and contexts which have been finished for more than `autopurge_age` hours and deletes them.
 
 #### HDFS + SQL
 

--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -75,6 +75,8 @@ spark {
         connectionTimeoutMs = 2350
         sessionTimeoutMs = 10000
       }
+      autopurge = false
+      autopurge_after_hours = 168
     }
 
     # To load up job jars on startup, place them here,

--- a/job-server/src/main/scala/spark/jobserver/JobServer.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobServer.scala
@@ -21,6 +21,7 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 import scala.collection.mutable.ListBuffer
 import com.google.common.annotations.VisibleForTesting
+import spark.jobserver.io.zookeeper.AutoPurgeActor
 
 /**
  * The Spark Job Server is a web service that allows users to submit and run Spark jobs, check status,
@@ -118,6 +119,7 @@ object JobServer {
     val dataFileDAO = new DataFileDAO(config)
     val dataManager = system.actorOf(Props(classOf[DataManagerActor], dataFileDAO), "data-manager")
     val binManager = system.actorOf(Props(classOf[BinaryManager], daoActor), "binary-manager")
+    startAutoPurge(system, daoActor, config)
 
     // Add initial job JARs, if specified in configuration.
     storeInitialBinaries(config, binManager)
@@ -298,6 +300,20 @@ object JobServer {
       superviseModeEnabled: Boolean, akkaTcpPort: Int) {
     if (driverMode == "cluster" && superviseModeEnabled == true && akkaTcpPort == 0) {
       throw new InvalidConfiguration("Supervise mode requires akka.remote.netty.tcp.port to be hardcoded")
+    }
+  }
+
+  private def startAutoPurge(system: ActorSystem, daoActor: ActorRef, config : Config) : Unit = {
+    val enabled = AutoPurgeActor.isEnabled(config)
+
+    if (enabled){
+      val age = config.getInt("spark.jobserver.zookeeperdao.autopurge_after_hours")
+      val actor = system.actorOf(AutoPurgeActor.props(config, daoActor, age))
+      val initialPurge = (actor ? AutoPurgeActor.PurgeOldData)(AutoPurgeActor.maxPurgeDuration)
+      Await.result(initialPurge, AutoPurgeActor.maxPurgeDuration) match {
+        case AutoPurgeActor.PurgeComplete => logger.info("Initial auto purge completed successfully.")
+        case _ => logger.error("Initial auto purge unsuccessful.")
+      }
     }
   }
 

--- a/job-server/src/main/scala/spark/jobserver/io/CombinedDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/CombinedDAO.scala
@@ -9,12 +9,19 @@ import org.slf4j.LoggerFactory
 import slick.SlickException
 import spark.jobserver.JobServer.InvalidConfiguration
 import spark.jobserver.util._
+import spark.jobserver.io.CombinedDAO._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.util.Success
 import spark.jobserver.common.akka.metrics.YammerMetrics
+
+object CombinedDAO {
+  val binaryDaoPath = "spark.jobserver.combineddao.binarydao.class"
+  val metaDataDaoPath = "spark.jobserver.combineddao.metadatadao.class"
+  val rootDirPath = "spark.jobserver.combineddao.rootdir"
+}
 
 /**
   * @param config config of jobserver
@@ -35,9 +42,6 @@ class CombinedDAO(config: Config) extends JobDAO with FileCacher with YammerMetr
 
   var binaryDAO: BinaryDAO = _
   var metaDataDAO: MetaDataDAO = _
-  private val binaryDaoPath = "spark.jobserver.combineddao.binarydao.class"
-  private val metaDataDaoPath = "spark.jobserver.combineddao.metadatadao.class"
-  private val rootDirPath = "spark.jobserver.combineddao.rootdir"
   if (!(config.hasPath(binaryDaoPath) && config.hasPath(metaDataDaoPath) && config.hasPath(rootDirPath))) {
     throw new InvalidConfiguration(
       "To use CombinedDAO root directory and BinaryDAO, MetaDataDAO classes should be specified"

--- a/job-server/src/main/scala/spark/jobserver/io/zookeeper/AutoPurgeActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/zookeeper/AutoPurgeActor.scala
@@ -1,0 +1,117 @@
+package spark.jobserver.io.zookeeper
+
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.control.NonFatal
+
+import org.joda.time.DateTime
+import org.slf4j.LoggerFactory
+
+import com.typesafe.config.Config
+
+import akka.actor.ActorRef
+import akka.actor.Props
+import akka.util.Timeout
+import akka.pattern.ask
+import spark.jobserver.common.akka.InstrumentedActor
+import spark.jobserver.io.CombinedDAO
+import spark.jobserver.io.ContextStatus
+import spark.jobserver.io.JobDAOActor.ContextInfos
+import spark.jobserver.io.JobDAOActor.GetContextInfos
+import spark.jobserver.io.JobDAOActor.GetJobInfos
+import spark.jobserver.io.JobDAOActor.JobInfos
+import spark.jobserver.io.JobStatus
+import spark.jobserver.io.zookeeper.AutoPurgeActor._
+import spark.jobserver.util.Utils
+
+object AutoPurgeActor {
+  val logger = LoggerFactory.getLogger(getClass)
+
+  val maxPurgeDuration = 2 minutes
+  case object PurgeOldData
+  case object PurgeComplete
+
+  def props(config: Config, daoActor: ActorRef, age : Int): Props =
+    Props(classOf[AutoPurgeActor], config, daoActor, age)
+
+  def isEnabled(config : Config) : Boolean = {
+    if (config.getString("spark.jobserver.jobdao") == "spark.jobserver.io.CombinedDAO"){
+      if (config.getString(CombinedDAO.metaDataDaoPath) ==
+        "spark.jobserver.io.zookeeper.MetaDataZookeeperDAO"){
+        val enabled = config.getBoolean("spark.jobserver.zookeeperdao.autopurge")
+        logger.info(s"Zookeeper autopurge feature is set to $enabled.")
+        return enabled
+      }
+    }
+    logger.info(s"Zookeeper autopurge feature is not configured.")
+    false
+  }
+}
+
+/**
+ * Regularly purges old zookeeper data to maintain a steady performance
+ */
+class AutoPurgeActor(config: Config, daoActor: ActorRef, purgeOlderThanHours: Int)
+    extends InstrumentedActor {
+
+  private val zkUtils = new ZookeeperUtils(config)
+  private val awaitDuration = maxPurgeDuration / 2
+  private implicit val timeout = new Timeout(awaitDuration)
+
+  context.system.scheduler.schedule(1 hour, 1 hour, self, AutoPurgeActor.PurgeOldData)
+
+  override def wrappedReceive: Receive = {
+    case PurgeOldData =>
+      val recipient = sender
+      logger.info(s"Purging data older than $purgeOlderThanHours hours.")
+      val olderThanMillis = purgeOlderThanHours * 60 * 60 * 1000
+      val now = new DateTime().getMillis
+
+      // Purge contexts
+      try {
+        val contexts = Await.result((daoActor ? GetContextInfos(None, None))
+            .mapTo[ContextInfos], awaitDuration).contextInfos
+        val purgePaths = contexts.filter(c => ContextStatus.getFinalStates().contains(c.state))
+          .filter(c => c.endTime.isDefined && c.endTime.get.getMillis < (now - olderThanMillis))
+          .map(c => s"${MetaDataZookeeperDAO.contextsDir}/${c.id}")
+        logger.info(s"Purging ${purgePaths.size}/${contexts.size} contexts.")
+        deletePaths(purgePaths)
+        logger.info(s"${purgePaths.size} contexts have been purged.")
+      } catch {
+        case NonFatal(e) =>
+          logger.error("Querying contexts failed.")
+          Utils.logStackTrace(logger, e)
+      }
+
+      // Purge jobs
+      try{
+        val jobs = Await.result((daoActor ? GetJobInfos(10000)).mapTo[JobInfos], awaitDuration).jobInfos
+        val purgePaths = jobs.filter(j => JobStatus.getFinalStates().contains(j.state))
+          .filter(j => j.endTime.isDefined && j.endTime.get.getMillis < (now - olderThanMillis))
+          .map(j => s"${MetaDataZookeeperDAO.jobsDir}/${j.jobId}")
+        logger.info(s"Purging ${purgePaths.size}/${jobs.size} jobs.")
+        deletePaths(purgePaths)
+        logger.info(s"${purgePaths.size} jobs have been purged.")
+      } catch {
+        case NonFatal(e) =>
+          logger.error("Querying jobs failed.")
+          Utils.logStackTrace(logger, e)
+      }
+
+      logger.info("Purge complete.")
+      recipient ! PurgeComplete
+
+  }
+
+  private def deletePaths(paths : Seq[String]): Unit = {
+    Utils.usingResource(zkUtils.getClient) {
+      client =>
+        paths.foreach( (path : String) => {
+          logger.trace(s"Deleting $path")
+          zkUtils.delete(client, path)
+        })
+    }
+  }
+
+}

--- a/job-server/src/main/scala/spark/jobserver/io/zookeeper/MetaDataZookeeperDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/zookeeper/MetaDataZookeeperDAO.scala
@@ -14,9 +14,9 @@ import scala.concurrent.Future
 import org.apache.curator.framework.CuratorFramework
 
 object MetaDataZookeeperDAO {
-  private val binariesDir = "/binaries"
-  private val contextsDir = "/contexts"
-  private val jobsDir = "/jobs"
+  val binariesDir = "/binaries"
+  val contextsDir = "/contexts"
+  val jobsDir = "/jobs"
 }
 
 class MetaDataZookeeperDAO(config: Config) extends MetaDataDAO {

--- a/job-server/src/test/resources/local.test.combineddao.conf
+++ b/job-server/src/test/resources/local.test.combineddao.conf
@@ -3,6 +3,8 @@
 spark.jobserver {
   cache-on-upload = false
 
+  jobdao = spark.jobserver.io.CombinedDAO
+
   combineddao {
     rootdir = /tmp/spark-job-server-test
     binarydao {

--- a/job-server/src/test/scala/spark/jobserver/io/zookeeper/AutoPurgeActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/zookeeper/AutoPurgeActorSpec.scala
@@ -1,0 +1,161 @@
+package spark.jobserver.io.zookeeper
+
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+
+import org.joda.time.DateTime
+import org.scalatest.BeforeAndAfter
+import org.scalatest.FunSpecLike
+import org.scalatest.Matchers
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+
+import akka.actor.ActorRef
+import akka.actor.ActorSystem
+import akka.actor.Props
+import akka.testkit.ImplicitSender
+import akka.testkit.TestKit
+import spark.jobserver.common.akka.InstrumentedActor
+import spark.jobserver.io.BinaryDAO
+import spark.jobserver.io.BinaryInfo
+import spark.jobserver.io.BinaryType
+import spark.jobserver.io.ContextInfo
+import spark.jobserver.io.ErrorData
+import spark.jobserver.io.JobDAOActor.ContextInfos
+import spark.jobserver.io.JobDAOActor.GetContextInfos
+import spark.jobserver.io.JobDAOActor.GetJobInfos
+import spark.jobserver.io.JobDAOActor.JobInfos
+import spark.jobserver.io.JobInfo
+import spark.jobserver.util.CuratorTestCluster
+import spark.jobserver.util.Utils
+
+object AutoPurgeActorSpec {
+  val system = ActorSystem("test")
+}
+
+object DummyZookeeperDAOActor{
+  def props(dao : MetaDataZookeeperDAO): Props = Props(classOf[DummyZookeeperDAOActor], dao)
+}
+
+class DummyZookeeperDAOActor(dao : MetaDataZookeeperDAO) extends InstrumentedActor {
+  val timeout = 60 seconds
+  override def wrappedReceive: Receive = {
+    case GetContextInfos(_,_) => sender ! ContextInfos(Await.result(dao.getContexts(None, None), timeout))
+    case GetJobInfos(_) => sender ! JobInfos(Await.result(dao.getJobs(5000, None), timeout))
+  }
+}
+
+class AutoPurgeActorSpec extends TestKit(AutoPurgeActorSpec.system) with FunSpecLike with Matchers
+  with BeforeAndAfter with ImplicitSender{
+
+  /*
+   * Setup
+   */
+
+  private val timeout = 60 seconds
+  private val testServer = new CuratorTestCluster()
+
+  def config: Config = ConfigFactory.parseString(
+    s"""
+         |spark.jobserver.zookeeperdao.connection-string = "${testServer.getConnectString}"
+         |spark.jobserver.combineddao.binarydao.class = spark.jobserver.io.HdfsBinaryDAO
+         |spark.jobserver.combineddao.metadatadao.class = spark.jobserver.io.zookeeper.MetaDataZookeeperDAO
+         |spark.jobserver.zookeeperdao.autopurge = true
+         |spark.jobserver.zookeeperdao.autopurge_after_hours = 168
+    """.stripMargin
+  ).withFallback(
+    ConfigFactory.load("local.test.combineddao.conf")
+  )
+
+  var purgeActor : ActorRef = _
+  val dao = new MetaDataZookeeperDAO(config)
+  val zkUtils = new ZookeeperUtils(config)
+  val daoActor = system.actorOf(DummyZookeeperDAOActor.props(dao))
+
+  before {
+    // Empty database
+    Utils.usingResource(zkUtils.getClient) {
+      client =>
+        zkUtils.delete(client, "")
+    }
+    // Create actor
+    purgeActor = system.actorOf(AutoPurgeActor.props(config, daoActor, 8 * 24))
+  }
+
+  /*
+   * Test data
+   */
+
+  val age = 8 * 24 * 60 * 60 * 1000
+  val rightNow = new DateTime()
+  val backThen = new DateTime(rightNow.getMillis - age)
+  val bin = BinaryInfo("binaryWithJar", BinaryType.Jar, backThen,
+    Some(BinaryDAO.calculateBinaryHashString("1".getBytes)))
+  val oldContext = ContextInfo("1", "someName", "someConfig", Some("ActorAddress"), backThen,
+      Some(backThen), "FINISHED", None)
+  val recentContext = oldContext.copy(id = "2", endTime = Some(rightNow))
+  val runningContext = oldContext.copy(id = "3", state = "RUNNING")
+  val oldJob = JobInfo("1", "someContextId", "someContextName", bin, "someClassPath", "FINISHED",
+      backThen, Some(backThen), Some(ErrorData("someMessage", "someError", "someTrace")))
+  val recentJob = oldJob.copy(jobId = "2", endTime = Some(rightNow))
+  val runningJob = oldJob.copy(jobId = "3", state = "RUNNING")
+
+  /*
+   * Tests
+   */
+
+  it("Should accept a correct configuration"){
+    AutoPurgeActor.isEnabled(config) should equal(true)
+  }
+
+  it("Should purge old contexts and jobs"){
+    Await.result(dao.saveBinary(bin.appName, bin.binaryType, bin.uploadTime, bin.binaryStorageId.get),
+      timeout) should equal(true)
+    Await.result(dao.saveContext(oldContext), timeout) should equal(true)
+    Await.result(dao.saveJob(oldJob), timeout) should equal(true)
+    Await.result(dao.getContexts(None, None), timeout).size should equal(1)
+    Await.result(dao.getJobs(100, None), timeout).size should equal(1)
+
+    purgeActor ! AutoPurgeActor.PurgeOldData
+
+    expectMsg(AutoPurgeActor.PurgeComplete)
+    Await.result(dao.getJobs(100, None), timeout).size should equal(0)
+    Await.result(dao.getContexts(None, None), timeout).size should equal(0)
+  }
+
+  it("Should not purge recent contexts and jobs"){
+    Await.result(dao.saveBinary(bin.appName, bin.binaryType, bin.uploadTime, bin.binaryStorageId.get),
+      timeout) should equal(true)
+    Await.result(dao.saveContext(oldContext), timeout) should equal(true)
+    Await.result(dao.saveContext(recentContext), timeout) should equal(true)
+    Await.result(dao.saveJob(oldJob), timeout) should equal(true)
+    Await.result(dao.saveJob(recentJob), timeout) should equal(true)
+    Await.result(dao.getContexts(None, None), timeout).size should equal(2)
+    Await.result(dao.getJobs(100, None), timeout).size should equal(2)
+
+    purgeActor ! AutoPurgeActor.PurgeOldData
+
+    expectMsg(AutoPurgeActor.PurgeComplete)
+    Await.result(dao.getJobs(100, None), timeout) should equal(Seq(recentJob))
+    Await.result(dao.getContexts(None, None), timeout) should equal(Seq(recentContext))
+  }
+
+  it("Should only purge contexts and jobs in a final state"){
+    Await.result(dao.saveBinary(bin.appName, bin.binaryType, bin.uploadTime, bin.binaryStorageId.get),
+      timeout) should equal(true)
+    Await.result(dao.saveContext(oldContext), timeout) should equal(true)
+    Await.result(dao.saveContext(runningContext), timeout) should equal(true)
+    Await.result(dao.saveJob(oldJob), timeout) should equal(true)
+    Await.result(dao.saveJob(runningJob), timeout) should equal(true)
+    Await.result(dao.getContexts(None, None), timeout).size should equal(2)
+    Await.result(dao.getJobs(100, None), timeout).size should equal(2)
+
+    purgeActor ! AutoPurgeActor.PurgeOldData
+
+    expectMsg(AutoPurgeActor.PurgeComplete)
+    Await.result(dao.getJobs(100, None), timeout) should equal(Seq(runningJob))
+    Await.result(dao.getContexts(None, None), timeout) should equal(Seq(runningContext))
+  }
+
+}

--- a/job-server/src/test/scala/spark/jobserver/io/zookeeper/AutoPurgeActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/zookeeper/AutoPurgeActorSpec.scala
@@ -119,7 +119,7 @@ class AutoPurgeActorSpec extends TestKit(AutoPurgeActorSpec.system) with FunSpec
 
     purgeActor ! AutoPurgeActor.PurgeOldData
 
-    expectMsg(AutoPurgeActor.PurgeComplete)
+    expectMsg(timeout, AutoPurgeActor.PurgeComplete)
     Await.result(dao.getJobs(100, None), timeout).size should equal(0)
     Await.result(dao.getContexts(None, None), timeout).size should equal(0)
   }
@@ -136,7 +136,7 @@ class AutoPurgeActorSpec extends TestKit(AutoPurgeActorSpec.system) with FunSpec
 
     purgeActor ! AutoPurgeActor.PurgeOldData
 
-    expectMsg(AutoPurgeActor.PurgeComplete)
+    expectMsg(timeout, AutoPurgeActor.PurgeComplete)
     Await.result(dao.getJobs(100, None), timeout) should equal(Seq(recentJob))
     Await.result(dao.getContexts(None, None), timeout) should equal(Seq(recentContext))
   }
@@ -153,7 +153,7 @@ class AutoPurgeActorSpec extends TestKit(AutoPurgeActorSpec.system) with FunSpec
 
     purgeActor ! AutoPurgeActor.PurgeOldData
 
-    expectMsg(AutoPurgeActor.PurgeComplete)
+    expectMsg(timeout, AutoPurgeActor.PurgeComplete)
     Await.result(dao.getJobs(100, None), timeout) should equal(Seq(runningJob))
     Await.result(dao.getContexts(None, None), timeout) should equal(Seq(runningContext))
   }


### PR DESCRIPTION
**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?
- [X] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Due to the hierarchical nature of our zookeeper schema, read queries require to iterate over all nodes and process each of them. Especially within a distributed setup large amounts of Zookeeper
nodes can therefore reduce Jobserver performance.

**New behavior :**
This commit introduces an option to automatically remove old contexts and jobs to contain this effect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1220)
<!-- Reviewable:end -->
