### PR TITLE
refactor(jobserver): Replace hard-coded dao timers with config values

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
@@ -61,8 +61,6 @@ object JobManagerActor {
   case object SparkContextAlive
   case object SparkContextDead
 
-
-
   // Akka 2.2.x style actor props for actor creation
   def props(daoActor: ActorRef, supervisorActorAddress: String = "", contextId: String = "",
       initializationTimeout: FiniteDuration = 40.seconds): Props =
@@ -506,8 +504,6 @@ class JobManagerActor(daoActor: ActorRef, supervisorActorAddress: String, contex
       postEachJob()
       Future.successful()
     }
-
-    val daoAskTimeout = Timeout(3 seconds)
 
     (daoActor ? JobDAOActor.GetLastBinaryInfo(appName))(daoAskTimeout).
       mapTo[JobDAOActor.LastBinaryInfo].flatMap{

--- a/job-server/src/main/scala/spark/jobserver/JobServer.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobServer.scala
@@ -195,8 +195,7 @@ object JobServer {
 
   @VisibleForTesting
   def setReconnectionFailedForContextAndJobs(contextInfo: ContextInfo,
-      jobDaoActor: ActorRef) {
-    val finiteDuration = FiniteDuration(3, SECONDS)
+      jobDaoActor: ActorRef, timeout: Timeout) {
     val ctxName = contextInfo.name
     val logMsg = s"Reconnecting to context $ctxName failed ->" +
       s"updating status of context $ctxName and related jobs to error"
@@ -205,7 +204,7 @@ object JobServer {
         state = ContextStatus.Error, error = Some(ContextReconnectFailedException()))
     jobDaoActor ! JobDAOActor.SaveContextInfo(updatedContextInfo)
     (jobDaoActor ? JobDAOActor.GetJobInfosByContextId(
-        contextInfo.id, Some(JobStatus.getNonFinalStates())))(finiteDuration).onComplete {
+        contextInfo.id, Some(JobStatus.getNonFinalStates())))(timeout).onComplete {
       case Success(JobDAOActor.JobInfos(jobInfos)) =>
         jobInfos.foreach(jobInfo => {
         jobDaoActor ! JobDAOActor.SaveJobInfo(jobInfo.copy(state = JobStatus.Error,
@@ -231,7 +230,7 @@ object JobServer {
 
     resp.contextInfos.map{ contextInfo =>
       getManagerActorRef(contextInfo, system) match {
-        case None => setReconnectionFailedForContextAndJobs(contextInfo, jobDaoActor)
+        case None => setReconnectionFailedForContextAndJobs(contextInfo, jobDaoActor, daoAskTimeout)
         case Some(actorRef) => validManagerRefs += actorRef
       }
     }

--- a/job-server/src/test/scala/spark/jobserver/JobServerSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobServerSpec.scala
@@ -301,7 +301,7 @@ class JobServerSpec extends TestKit(JobServerSpec.system) with FunSpecLike with 
       val daoActorProbe = TestProbe()
 
       val (ctxRunning, _) = createContext("ctxRunning", ContextStatus.Running, true)
-      JobServer.setReconnectionFailedForContextAndJobs(ctxRunning, daoActorProbe.ref)
+      JobServer.setReconnectionFailedForContextAndJobs(ctxRunning, daoActorProbe.ref, timeout)
 
       // Check if context is updated correctly
       val saveContextMsg = daoActorProbe.expectMsgType[JobDAOActor.SaveContextInfo]


### PR DESCRIPTION
* Use configurable dao-timeout for dao operations in the method
  setReconnectionFailedForContextAndJobs instead of hard-coded
  3s timeout.
* Remove line in JobManagerActor hiding the dao with a hard-coded
  timeout of 3s.

Both timeouts are used for DAO operations and should therefore
use the existing timeout to prevent harder debugging and a
lack of configurability.

Change-Id: I09ed882aeaee64ddc24e4522c2836b8a51dc6c57

**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
