### PR TITLE
fix(jobserver): Remove refreshBinary for Zookeeper

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/io/zookeeper/MetaDataZookeeperDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/zookeeper/MetaDataZookeeperDAO.scala
@@ -151,7 +151,7 @@ class MetaDataZookeeperDAO(config: Config) extends MetaDataDAO with YammerMetric
         Utils.usingResource(zookeeperUtils.getClient) {
           client =>
             zookeeperUtils.sync(client, s"$jobsDir/$id")
-            readJobInfo(client, id).flatMap(j => refreshBinary(client, j))
+            readJobInfo(client, id)
         }
       }
     }
@@ -173,7 +173,6 @@ class MetaDataZookeeperDAO(config: Config) extends MetaDataDAO with YammerMetric
               }
             filteredJobs.sortBy(_.startTime.getMillis)(Ordering[Long].reverse)
               .take(limit)
-              .flatMap(j => refreshBinary(client, j))
         }
       }
     }
@@ -195,7 +194,6 @@ class MetaDataZookeeperDAO(config: Config) extends MetaDataDAO with YammerMetric
                 case Some(allowed) => allJobs.filter(j => allowed.contains(j.state))
               }
             filteredJobs.sortBy(_.startTime.getMillis)(Ordering[Long].reverse)
-              .flatMap(j => refreshBinary(client, j))
         }
       }
     }
@@ -215,29 +213,6 @@ class MetaDataZookeeperDAO(config: Config) extends MetaDataDAO with YammerMetric
       }
     }
 
-  }
-
-  /**
-   * Within JobInfo only an initial copy of the binary info is stored
-   * to identify the original BinaryInfo stored in another ZK dir
-   *
-   * The jobInfo shall only be returned if the BinaryInfo elsewhere still exists
-   */
-  private def refreshBinary(client: CuratorFramework, j: JobInfo): Option[JobInfo] = {
-    zookeeperUtils.read[Seq[BinaryInfo]](client, s"$binariesDir/" + j.binaryInfo.appName) match {
-      case Some(infoForBinary) =>
-        // identified by name AND uploadTime
-        infoForBinary.find(_.uploadTime.getMillis == j.binaryInfo.uploadTime.getMillis) match {
-          case Some(_) => Some(j)
-          case None =>
-            logger.info(s"Didn't find a binary for name and uploadtime: ("
-              + j.binaryInfo.appName + "," + j.binaryInfo.uploadTime + ")")
-            None
-        }
-      case None =>
-        logger.debug(s"Didn't find a binary for name " + j.binaryInfo.appName)
-        None
-    }
   }
 
   /*

--- a/job-server/src/test/scala/spark/jobserver/io/zookeeper/MetaDataZookeeperDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/zookeeper/MetaDataZookeeperDAOSpec.scala
@@ -358,11 +358,11 @@ class MetaDataZookeeperDAOSpec extends FunSpec with TestJarFinder with FunSpecLi
       jobs should equal(Seq(minimalJob))
     }
 
-    it("should not retrieve jobs with missing binaries") {
+    it("should retrieve jobs with missing binaries") {
       val success = Await.result(dao.saveJob(normalJob), timeout)
       success should equal(true)
-      Await.result(dao.getJob("someJobId"), timeout) should equal(None)
-      Await.result(dao.getJobs(100, None), timeout).size should equal(0)
+      Await.result(dao.getJob("someJobId"), timeout) should equal(Some(normalJob))
+      Await.result(dao.getJobs(100, None), timeout).size should equal(1)
     }
 
     it("should be able to access data after DAO recreation") {


### PR DESCRIPTION
This feature was introduced to
a) Keep a consistent version of BinaryInfo at the JobInfo object
   (already addressed by commit:
   "fix(jobserver): Create Job with full BinaryInfo information").
b) Mimic behavior of the JobSqlDAO that removes with missing
   binaries during join, which seems like this is actually unintended 
   in SQL as well.

Removing this query does also improve performance.

**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1223)
<!-- Reviewable:end -->
