### PR TITLE
fix(jobserver): Persist error state sequentially during startup

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/JobServer.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobServer.scala
@@ -203,18 +203,21 @@ object JobServer {
     val updatedContextInfo = contextInfo.copy(endTime = Option(DateTime.now()),
         state = ContextStatus.Error, error = Some(ContextReconnectFailedException()))
     jobDaoActor ! JobDAOActor.SaveContextInfo(updatedContextInfo)
-    (jobDaoActor ? JobDAOActor.GetJobInfosByContextId(
-        contextInfo.id, Some(JobStatus.getNonFinalStates())))(timeout).onComplete {
-      case Success(JobDAOActor.JobInfos(jobInfos)) =>
-        jobInfos.foreach(jobInfo => {
-        jobDaoActor ! JobDAOActor.SaveJobInfo(jobInfo.copy(state = JobStatus.Error,
-            endTime = Some(DateTime.now()), error = Some(ErrorData(ContextReconnectFailedException()))))
-        })
-      case Failure(e: Exception) =>
-        logger.error(s"Exception occurred while fetching jobs for context (${contextInfo.id})", e)
-      case unexpectedMsg @ _ =>
-        logger.error(
-            s"$unexpectedMsg message received while fetching jobs for context (${contextInfo.id})")
+    try{
+      Await.ready((jobDaoActor ? JobDAOActor.GetJobInfosByContextId(
+          contextInfo.id, Some(JobStatus.getNonFinalStates())))(timeout), timeout.duration).value.get match {
+        case Success(JobDAOActor.JobInfos(jobInfos)) =>
+          jobInfos.foreach(jobInfo => {
+          jobDaoActor ! JobDAOActor.SaveJobInfo(jobInfo.copy(state = JobStatus.Error,
+              endTime = Some(DateTime.now()), error = Some(ErrorData(ContextReconnectFailedException()))))
+          })
+        case Failure(e: Exception) =>
+          logger.error(s"Exception occurred while fetching jobs for context (${contextInfo.id})", e)
+      }
+    } catch {
+      case _ : TimeoutException =>
+        logger.error(s"Fetching job infos for context ${contextInfo.id} timed out. "
+            + "Not updating jobs to error state.")
     }
   }
 


### PR DESCRIPTION
In case the resolution of a JobManagerActor in cluster mode fails
based on ContextInfo in the database, the context and associated
jobs are set to state 'error'.

With Zookeeper, if a lot of such updates are performed (which can
happen during update of big clusters), the linear nature of a
(by sync) consistent Zookeeper may lead to queued requests,
which makes the latest requests take longer.

Instead of performing these updates parallel in futures, this is
now done sequentially, so that timeouts are not compromised by
earlier operations.

* Replace ask oncomplete with Await.ready in one instance
* Adapt test to run blocking call in a parallel thread

Change-Id: I80ac6ebde3bcd168c8164900a98067e9f76ca491

**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1224)
<!-- Reviewable:end -->
