### PR TITLE
fix(jobserver): Properly set end_time on ForkedJVMInitTimeout 

### DIFF
--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -38,6 +38,12 @@ spark {
 
     dao-timeout = 6s
 
+    # At jobserver startup, a cleanup class can be provided which cleans the dao.
+    # Currently, only ZK implementation is provided.
+    # Empty string means disabled, full class path means enabled.
+    # Note: For H2, migrations should be used.
+    startup_dao_cleanup_class = ""
+
     # Automatically load a set of jars at startup time.  Key is the appName, value is the path/URL.
     # job-bin-paths {
     #   test = /path/to/my/test.jar

--- a/job-server/src/main/scala/spark/jobserver/JobServer.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobServer.scala
@@ -11,7 +11,7 @@ import java.io.File
 import java.util.concurrent.{TimeUnit, TimeoutException}
 
 import spark.jobserver.io._
-import spark.jobserver.util.ContextReconnectFailedException
+import spark.jobserver.util.{ContextReconnectFailedException, DAOCleanup}
 import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
 
@@ -22,6 +22,8 @@ import scala.util.{Failure, Success, Try}
 import scala.collection.mutable.ListBuffer
 import com.google.common.annotations.VisibleForTesting
 import spark.jobserver.io.zookeeper.AutoPurgeActor
+
+import scala.util.control.NonFatal
 
 /**
  * The Spark Job Server is a web service that allows users to submit and run Spark jobs, check status,
@@ -119,6 +121,8 @@ object JobServer {
     val dataFileDAO = new DataFileDAO(config)
     val dataManager = system.actorOf(Props(classOf[DataManagerActor], dataFileDAO), "data-manager")
     val binManager = system.actorOf(Props(classOf[BinaryManager], daoActor), "binary-manager")
+
+    startCleanupIfEnabled(config)
     startAutoPurge(system, daoActor, config)
 
     // Add initial job JARs, if specified in configuration.
@@ -317,6 +321,33 @@ object JobServer {
         case _ => logger.error("Initial auto purge unsuccessful.")
       }
     }
+  }
+
+  private def startCleanupIfEnabled(config: Config): Unit = {
+    isCleanupEnabled(config) match {
+      case true =>
+        logger.info("Cleanup of dao is enabled. Instantiating the class.")
+        Try(doStartupCleanup(config)) match {
+          case Success(true) => logger.info("Cleaned the dao successfully.")
+          case Success(false) => logger.error("Dao cleanup failed.")
+          case Failure(e) => logger.error("Failed to cleanup", e)
+        }
+      case false => logger.info("Startup dao cleanup is disabled.")
+    }
+  }
+
+  @VisibleForTesting
+  def isCleanupEnabled(config: Config): Boolean = {
+    val daoClassProperty = "spark.jobserver.startup_dao_cleanup_class"
+    (config.hasPath(daoClassProperty) && config.getString(daoClassProperty) != "")
+  }
+
+  @VisibleForTesting
+  def doStartupCleanup(config: Config): Boolean = {
+    val daoCleanupClass = Class.forName(config.getString("spark.jobserver.startup_dao_cleanup_class"))
+    val ctor = daoCleanupClass.getDeclaredConstructor(Class.forName("com.typesafe.config.Config"))
+    val daoCleanup = ctor.newInstance(config).asInstanceOf[DAOCleanup]
+    daoCleanup.cleanup()
   }
 
   def main(args: Array[String]) {

--- a/job-server/src/main/scala/spark/jobserver/util/CustomException.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/CustomException.scala
@@ -52,3 +52,6 @@ final case class NoIPAddressFoundException() extends
 
 final case class UnsupportedNetworkAddressStrategy(name: String) extends
   Exception(s"Unsupported network address strategy $name specified.")
+
+final case class NoCorrespondingContextAliveException(jobId: String) extends
+  Exception(s"No context is alive against running job ($jobId). Cleaning the job.")

--- a/job-server/src/main/scala/spark/jobserver/util/DAOCleanup.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/DAOCleanup.scala
@@ -1,0 +1,93 @@
+package spark.jobserver.util
+
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.Await
+import scala.concurrent.duration.FiniteDuration
+import scala.util.control.NonFatal
+
+import org.slf4j.LoggerFactory
+
+import com.typesafe.config.Config
+
+import JsonProtocols.ContextInfoJsonFormat
+import JsonProtocols.JobInfoJsonFormat
+import spark.jobserver.io.ContextInfo
+import spark.jobserver.io.JobInfo
+import spark.jobserver.io.JobStatus
+import spark.jobserver.io.zookeeper.MetaDataZookeeperDAO
+import spark.jobserver.io.zookeeper.ZookeeperUtils
+import spark.jobserver.io.ContextStatus
+
+trait DAOCleanup {
+  def cleanup(): Boolean
+}
+
+class ZKCleanup(config: Config) extends DAOCleanup {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+  private val hugeTimeout = FiniteDuration(1, TimeUnit.MINUTES)
+  implicit val ec = scala.concurrent.ExecutionContext.Implicits.global
+
+  override def cleanup(): Boolean = {
+    cleanUpContextsNoEndTime()
+    cleanUpJobsNoEndTime()
+  }
+
+  private val dao = new MetaDataZookeeperDAO(config)
+  private val zkUtils = new ZookeeperUtils(config)
+
+  def cleanUpContextsNoEndTime() : Boolean = {
+      logger.info("Repairing all contexts in final state with no endtime.")
+      try{
+        // Find all final contexts without endtime
+        val contexts = Await.result(dao.getContexts(None, Some(ContextStatus.getFinalStates())),
+          hugeTimeout)
+          .filter(c => c.endTime.isEmpty)
+        logger.warn(s"Found ${contexts.size} contexts in final state with no endtime.")
+        // Set a suitable endtime
+        Utils.usingResource(zkUtils.getClient) {
+          client =>
+            contexts.foreach( (contextInfo : ContextInfo) => {
+              val path = s"${MetaDataZookeeperDAO.contextsDir}/${contextInfo.id}"
+              logger.trace(s"Updating context $path")
+              zkUtils.write(client, contextInfo.copy(endTime = Some(contextInfo.startTime)), path)
+            })
+        }
+        logger.info(s"Updated endtime of ${contexts.size} contexts.")
+        true
+      } catch {
+        case NonFatal(e) =>
+          logger.error("Repair of contexts failed")
+          Utils.logStackTrace(logger, e)
+          false
+      }
+  }
+
+  def cleanUpJobsNoEndTime() : Boolean = {
+      logger.info("Repairing all jobs in final state with no endtime.")
+      try{
+        // Find all final jobs without endtime
+        val jobs = Await.result(dao.getJobs(10000, None), hugeTimeout)
+          .filter(j => JobStatus.getFinalStates().contains(j.state) && j.endTime.isEmpty)
+        logger.warn(s"Found ${jobs.size} jobs in final state with no endtime.")
+        // Set a suitable endtime
+        Utils.usingResource(zkUtils.getClient) {
+          client =>
+            jobs.foreach( (jobInfo : JobInfo) => {
+              val path = s"${MetaDataZookeeperDAO.jobsDir}/${jobInfo.jobId}"
+              logger.trace(s"Updating job $path")
+              zkUtils.write(client, jobInfo.copy(endTime = Some(jobInfo.startTime)), path)
+            })
+        }
+        logger.info(s"Updated endtime of ${jobs.size} jobs.")
+      } catch {
+        case NonFatal(e) =>
+          logger.error("Repair of jobs failed")
+          Utils.logStackTrace(logger, e)
+          return false
+      }
+      true
+  }
+
+}

--- a/job-server/src/test/scala/spark/jobserver/util/DAOCleanupSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/util/DAOCleanupSpec.scala
@@ -2,23 +2,14 @@ package spark.jobserver.io.zookeeper
 
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
-
 import org.joda.time.DateTime
 import org.scalatest.BeforeAndAfter
 import org.scalatest.FunSpecLike
 import org.scalatest.Matchers
-
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-
-import spark.jobserver.io.BinaryDAO
-import spark.jobserver.io.BinaryInfo
-import spark.jobserver.io.BinaryType
-import spark.jobserver.io.ContextInfo
-import spark.jobserver.io.JobInfo
-import spark.jobserver.util.CuratorTestCluster
-import spark.jobserver.util.Utils
-import spark.jobserver.util.ZKCleanup
+import spark.jobserver.io._
+import spark.jobserver.util.{CuratorTestCluster, NoCorrespondingContextAliveException, Utils, ZKCleanup}
 
 class DAOCleanupSpec extends FunSpecLike with Matchers with BeforeAndAfter {
 
@@ -32,6 +23,7 @@ class DAOCleanupSpec extends FunSpecLike with Matchers with BeforeAndAfter {
   def config: Config = ConfigFactory.parseString(
     s"""
          |spark.jobserver.zookeeperdao.connection-string = "${testServer.getConnectString}"
+         |spark.jobserver.dao-timeout = 3s
     """.stripMargin
   ).withFallback(
     ConfigFactory.load("local.test.combineddao.conf")
@@ -100,4 +92,124 @@ class DAOCleanupSpec extends FunSpecLike with Matchers with BeforeAndAfter {
     Await.result(dao.getJob("3"), timeout).get.endTime should equal(Some(date))
   }
 
+  describe("Non final jobs with final context tests") {
+    it("should not fail if nothing to repair") {
+      (new ZKCleanup(config)).cleanupNonFinalJobsWithFinalContext() should be(true)
+    }
+
+    it("should not repair jobs whose context are in non-final state") {
+      val runningContextInfo = runningContext
+      val runningJobInfo = runningJob.copy(
+        contextId = runningContext.id, contextName = runningContext.name)
+      val errorJobInfo = runningJobInfo.copy(jobId = "eId", state = JobStatus.Error)
+      Await.result(dao.saveContext(runningContextInfo), timeout) should equal(true)
+      Await.result(dao.saveJob(runningJobInfo), timeout) should equal(true)
+      Await.result(dao.saveJob(errorJobInfo), timeout) should equal(true)
+
+      (new ZKCleanup(config)).cleanupNonFinalJobsWithFinalContext() should be(true)
+
+      Await.result(dao.getJob(runningJobInfo.jobId), timeout).get should be(runningJobInfo)
+      Await.result(dao.getJob(errorJobInfo.jobId), timeout).get should be(errorJobInfo)
+    }
+
+    it("should repair job whose context is not running") {
+      val finishedContextInfo = contextWithEndtime
+      val runningJobInfo = runningJob.copy(
+        contextId = finishedContextInfo.id, contextName = finishedContextInfo.name)
+      Await.result(dao.saveContext(finishedContextInfo), timeout) should equal(true)
+      Await.result(dao.saveJob(runningJobInfo), timeout) should equal(true)
+
+      (new ZKCleanup(config)).cleanupNonFinalJobsWithFinalContext() should be(true)
+
+      checkIfJobIsCleaned(runningJobInfo.jobId)
+    }
+
+    it("should repair all jobs whose corresponding context is not running") {
+      val finishedContextInfo = contextWithEndtime
+      val runningJobInfo = runningJob.copy(
+        contextId = finishedContextInfo.id, contextName = finishedContextInfo.name)
+      val finishedJobInfo = runningJobInfo.copy(jobId = "fId", state = JobStatus.Finished)
+      val errorJobInfo = runningJobInfo.copy(jobId = "eId", state = JobStatus.Error)
+      val restartingJobInfo = runningJobInfo.copy(jobId = "rId", state = JobStatus.Restarting)
+
+      Await.result(dao.saveContext(finishedContextInfo), timeout) should equal(true)
+      Await.result(dao.saveJob(runningJobInfo), timeout) should equal(true)
+      Await.result(dao.saveJob(finishedJobInfo), timeout) should equal(true)
+      Await.result(dao.saveJob(errorJobInfo), timeout) should equal(true)
+      Await.result(dao.saveJob(restartingJobInfo), timeout) should equal(true)
+
+      (new ZKCleanup(config)).cleanupNonFinalJobsWithFinalContext() should be(true)
+
+      checkIfJobIsCleaned(runningJobInfo.jobId)
+      checkIfJobIsCleaned(restartingJobInfo.jobId)
+      Await.result(dao.getJob(finishedJobInfo.jobId), timeout).get should be(finishedJobInfo)
+      Await.result(dao.getJob(errorJobInfo.jobId), timeout).get should be(errorJobInfo)
+    }
+
+    it("should repair all jobs even if they belong to different contexts") {
+      val finishedContextInfo = contextWithEndtime
+      val erroredContextInfo = contextWithEndtime.copy(id = "eCtx", state = ContextStatus.Error)
+      val runningJobInfo = runningJob.copy(
+        contextId = finishedContextInfo.id, contextName = finishedContextInfo.name)
+      val runningJobInfo2 = runningJobInfo.copy(jobId = "jId2")
+      Await.result(dao.saveContext(finishedContextInfo), timeout) should equal(true)
+      Await.result(dao.saveContext(erroredContextInfo), timeout) should equal(true)
+      Await.result(dao.saveJob(runningJobInfo), timeout) should equal(true)
+      Await.result(dao.saveJob(runningJobInfo2), timeout) should equal(true)
+
+      (new ZKCleanup(config)).cleanupNonFinalJobsWithFinalContext() should be(true)
+
+      checkIfJobIsCleaned(runningJobInfo.jobId)
+      checkIfJobIsCleaned(runningJobInfo2.jobId)
+    }
+
+    it("should not throw exception if dao operations are failing") {
+      val wrongConfig = ConfigFactory.parseString(
+        s"""
+           |spark.jobserver.zookeeperdao.connection-string = "abc"
+           |spark.jobserver.dao-timeout = 3s
+    """.stripMargin).withFallback(
+        ConfigFactory.load("local.test.combineddao.conf")
+      )
+      new ZKCleanup(wrongConfig).cleanupNonFinalJobsWithFinalContext() should be(false)
+    }
+
+    it("should return true if context is not found") {
+      new ZKCleanup(config).isContextStateFinal("doesnt-exist") should be(true)
+    }
+
+    it("should return true if failed to fetch context") {
+      val wrongConfig = ConfigFactory.parseString(
+        s"""
+           |spark.jobserver.zookeeperdao.connection-string = "abc"
+           |spark.jobserver.dao-timeout = 3s
+    """.stripMargin).withFallback(
+        ConfigFactory.load("local.test.combineddao.conf")
+      )
+
+      Await.result(dao.saveContext(contextWithEndtime), timeout) should equal(true)
+
+      new ZKCleanup(wrongConfig).isContextStateFinal(contextWithEndtime.id) should be(true)
+    }
+
+    it("should return true if context is in final state") {
+      Await.result(dao.saveContext(contextWithEndtime), timeout) should equal(true)
+
+      new ZKCleanup(config).isContextStateFinal(contextWithEndtime.id) should be(true)
+    }
+
+    it("should return false if context is in final state") {
+      Await.result(dao.saveContext(runningContext), timeout) should equal(true)
+
+      new ZKCleanup(config).isContextStateFinal(runningContext.id) should be(false)
+    }
+  }
+
+  private def checkIfJobIsCleaned(jobId: String) = {
+    val updatedJob = Await.result(dao.getJob(jobId), timeout).get
+    updatedJob.state should equal(JobStatus.Error)
+    updatedJob.endTime should not be (None)
+    updatedJob.error.get.message should be(
+      NoCorrespondingContextAliveException(updatedJob.jobId).getMessage)
+  }
 }

--- a/job-server/src/test/scala/spark/jobserver/util/DAOCleanupSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/util/DAOCleanupSpec.scala
@@ -1,0 +1,103 @@
+package spark.jobserver.io.zookeeper
+
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+
+import org.joda.time.DateTime
+import org.scalatest.BeforeAndAfter
+import org.scalatest.FunSpecLike
+import org.scalatest.Matchers
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+
+import spark.jobserver.io.BinaryDAO
+import spark.jobserver.io.BinaryInfo
+import spark.jobserver.io.BinaryType
+import spark.jobserver.io.ContextInfo
+import spark.jobserver.io.JobInfo
+import spark.jobserver.util.CuratorTestCluster
+import spark.jobserver.util.Utils
+import spark.jobserver.util.ZKCleanup
+
+class DAOCleanupSpec extends FunSpecLike with Matchers with BeforeAndAfter {
+
+  /*
+   * Setup
+   */
+
+  private val timeout = 60 seconds
+  private val testServer = new CuratorTestCluster()
+
+  def config: Config = ConfigFactory.parseString(
+    s"""
+         |spark.jobserver.zookeeperdao.connection-string = "${testServer.getConnectString}"
+    """.stripMargin
+  ).withFallback(
+    ConfigFactory.load("local.test.combineddao.conf")
+  )
+
+  val dao = new MetaDataZookeeperDAO(config)
+  val zkUtils = new ZookeeperUtils(config)
+
+  before {
+    // Empty database
+    Utils.usingResource(zkUtils.getClient) {
+      client =>
+        zkUtils.delete(client, "")
+    }
+  }
+
+  /*
+   * Test data
+   */
+
+  val date = new DateTime(1548683342369L)
+  val otherDate = new DateTime(1548683342370L)
+  val bin = BinaryInfo("binaryWithJar", BinaryType.Jar, date, Some(BinaryDAO.calculateBinaryHashString("1".getBytes)))
+
+  val runningJob = JobInfo("1", "someContextId", "someContextName", bin, "someClassPath", "RUNNING", date, None, None)
+  val jobWithEndtime = JobInfo("2", "someContextId", "someContextName", bin, "someClassPath", "FINISHED", date, Some(otherDate), None)
+  val jobWithoutEndtime = JobInfo("3", "someContextId", "someContextName", bin, "someClassPath", "ERROR", date, None, None)
+
+  val runningContext = ContextInfo("1", "someName1", "someConfig", Some("ActorAddress"), date, None, "RUNNING", None)
+  val contextWithEndtime = ContextInfo("2", "someName2", "someConfig", Some("ActorAddress"), date, Some(otherDate), "FINISHED", None)
+  val contextWithoutEndtime = ContextInfo("3", "someName3", "someConfig", Some("ActorAddress"), date, None, "ERROR", None)
+
+  /*
+   * Tests
+   */
+
+  it("Should (only) repair contexts without endtime"){
+    Await.result(dao.saveBinary(bin.appName, bin.binaryType, bin.uploadTime, bin.binaryStorageId.get),
+      timeout) should equal(true)
+    Await.result(dao.saveContext(runningContext), timeout) should equal(true)
+    Await.result(dao.saveContext(contextWithEndtime), timeout) should equal(true)
+    Await.result(dao.saveContext(contextWithoutEndtime), timeout) should equal(true)
+    Await.result(dao.getContexts(None, None), timeout).size should equal(3)
+
+    val sut = new ZKCleanup(config)
+    sut.cleanUpContextsNoEndTime()
+
+    Await.result(dao.getContext("1"), timeout).get.endTime should equal(None)
+    Await.result(dao.getContext("2"), timeout).get.endTime should equal(Some(otherDate))
+    Await.result(dao.getContext("3"), timeout).get.endTime should equal(Some(date))
+  }
+
+  it("Should (only) repair jobs without endtime"){
+    Await.result(dao.saveBinary(bin.appName, bin.binaryType, bin.uploadTime, bin.binaryStorageId.get),
+      timeout) should equal(true)
+    Await.result(dao.saveJob(runningJob), timeout) should equal(true)
+    Await.result(dao.saveJob(jobWithEndtime), timeout) should equal(true)
+    Await.result(dao.saveJob(jobWithoutEndtime), timeout) should equal(true)
+    Await.result(dao.getJobs(100, None), timeout).size should equal(3)
+
+    val sut = new ZKCleanup(config)
+    sut.cleanUpJobsNoEndTime()
+
+    Await.result(dao.getJob("1"), timeout).get.endTime should equal(None)
+    Await.result(dao.getJob("2"), timeout).get.endTime should equal(Some(otherDate))
+    Await.result(dao.getJob("3"), timeout).get.endTime should equal(Some(date))
+  }
+
+}


### PR DESCRIPTION
**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?

**Current behavior :** 
When contexts are set to error because of a ForkedJVMInitTimeout, no end_time was set.

**New behavior :**
- end_time is now set correctly
- There is a configurable cleanup routine for zookeeper which does some maintenance tasks during startup if requested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1229)
<!-- Reviewable:end -->
