### PR TITLE
refactor(webapi): Deprecate WebAPI /jars path

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Also see [Chinese docs / 中文](doc/chinese/job-server.md).
 - [Architecture](#architecture)
 - [API](#api)
   - [Binaries](#binaries)
-  - [Jars (deprecated)](#jars-deprecated)
   - [Contexts](#contexts)
   - [Jobs](#jobs)
   - [Data](#data)
@@ -823,13 +822,6 @@ Flow diagrams are checked in in the doc/ subdirectory.  .diagram files are for w
     DELETE /binaries/<appName>  - delete defined binary
 
 When POSTing new binaries, the content-type header must be set to one of the types supported by the subclasses of the `BinaryType` trait. e.g. "application/java-archive" or application/python-archive". If you are using curl command, then you must pass "-H 'Content-Type: application/python-archive'" or "-H 'Content-Type: application/java-archive'".
-
-### Jars (deprecated)
-
-    GET /jars                   - lists all the jars and the last upload timestamp
-    POST /jars/<appName>        - uploads a new jar under <appName>
-
-These routes are kept for legacy purposes but are deprecated in favour of the /binaries routes
 
 ### Contexts
 

--- a/bin/ec2_example.sh.template
+++ b/bin/ec2_example.sh.template
@@ -10,7 +10,7 @@ if [ -n "$SSH_KEY" ]  ; then
 fi
 
 VERSION=$(sed -E 's/version in ThisBuild := "(.*)"/\1/' version.sbt)
-wget -O- --post-file "$bin"/../job-server-extras/target/scala-2.10/job-server-extras_2.10-$VERSION.jar "$DEPLOY_HOSTS/jars/km"
+curl -X POST "$DEPLOY_HOSTS/binaries/km" -H "Content-Type: application/java-archive" --data-binary @"$bin"/../job-server-extras/target/scala-2.10/job-server-extras_2.10-$VERSION.jar
 scp -rp -o StrictHostKeyChecking=no $ssh_key_to_use "$bin"/../job-server-extras/src/main/KMeansExample/* ${APP_USER}@"${DEPLOY_HOSTS%:*}:/var/www/html/"
 
 echo "The example is running at ${DEPLOY_HOSTS%:*}:5080"

--- a/doc/job-server-flow.md
+++ b/doc/job-server-flow.md
@@ -16,26 +16,6 @@
 LocalClusterSupervisor (context-per-jvm=false)
 ==========
 
-Jar routes
-----------
-- get a list of mapping from appName to uploadTime for all the known job jars:
-
-        user->WebApi: GET /jars
-        WebApi->JarManager: ListJars
-        JarManager->WebApi: Map(appName -> uploadTime)
-        WebApi->user: 200 + JSON
-
-- upload a job jar file with an appName
-
-        user->WebApi: POST /jars/<appName> jarFile
-        WebApi->JarManager: StoreJar(appName, jarBytes)
-        opt if Jar validation fails
-          JarManager->WebApi: InvalidJar
-          WebApi->user: 400
-        end
-        JarManager->WebApi: JarStored
-        WebApi->user: 200
-
 Context routes
 ----------
 - get a list of all known contextNames

--- a/job-server/src/main/scala/spark/jobserver/WebApi.scala
+++ b/job-server/src/main/scala/spark/jobserver/WebApi.scala
@@ -216,7 +216,7 @@ class WebApi(system: ActorSystem,
   val myRoutes = logRequestResponse(accessLogger) {
     cors {
       overrideMethodWithParameter("_method") {
-        binaryRoutes ~ jarRoutes ~ contextRoutes ~ jobRoutes ~
+        binaryRoutes ~ contextRoutes ~ jobRoutes ~
           dataRoutes ~ healthzRoutes ~ otherRoutes
       }
     }
@@ -373,49 +373,6 @@ class WebApi(system: ActorSystem,
           }
         }
       }
-    }
-  }
-
-  /**
-   * Routes for listing and uploading jars
-   *    GET /jars              - lists all current jars
-   *    POST /jars/<appName>   - upload a new jar file
-   *
-   * NB these routes are kept for legacy purposes but are deprecated in favour
-   *  of the /binaries routes.
-   */
-  def jarRoutes: Route = pathPrefix("jars") {
-    // user authentication
-    authenticate(authenticator) { authInfo =>
-      // GET /jars route returns a JSON map of the app name and the last time a jar was uploaded.
-      get { ctx =>
-        val future = (binaryManager ? ListBinaries(Some(BinaryType.Jar))).
-          mapTo[collection.Map[String, (BinaryType, DateTime)]].map(_.mapValues(_._2))
-        future.map { jarTimeMap =>
-          val stringTimeMap = jarTimeMap.map { case (app, dt) => (app, dt.toString()) }.toMap
-          ctx.complete(stringTimeMap)
-        }.recover {
-          case e: Exception => ctx.complete(500, errMap(e, "ERROR"))
-        }
-      } ~
-        // POST /jars/<appName>
-        // The <appName> needs to be unique; uploading a jar with the same appName will replace it.
-        post {
-          path(Segment) { appName =>
-            entity(as[Array[Byte]]) { jarBytes =>
-              val future = binaryManager ? StoreBinary(appName, BinaryType.Jar, jarBytes)
-              respondWithMediaType(MediaTypes.`application/json`) { ctx =>
-                future.map {
-                  case BinaryStored => ctx.complete(StatusCodes.OK, successMap("Jar uploaded"))
-                  case InvalidBinary => badRequest(ctx, "Jar is not of the right format")
-                  case BinaryStorageFailure(ex) => ctx.complete(500, errMap(ex, "Storage Failure"))
-                }.recover {
-                  case e: Exception => ctx.complete(500, errMap(e, "ERROR"))
-                }
-              }
-            }
-          }
-        }
     }
   }
 

--- a/job-server/src/test/scala/spark/jobserver/WebApiMainRoutesSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiMainRoutesSpec.scala
@@ -26,30 +26,6 @@ class WebApiMainRoutesSpec extends WebApiSpec {
       StatusKey -> JobStatus.Finished)
   }
 
-  describe("jars routes") {
-    it("should list all jars") {
-      Get("/jars") ~> sealRoute(routes) ~> check {
-        status should be (OK)
-        responseAs[Map[String, String]] should be (Map("demo1" -> "2013-05-29T00:00:00.000Z",
-                                                     "demo2" -> "2013-05-29T01:00:00.000Z"))
-      }
-    }
-
-    it("should respond with OK and meaningful message if jar uploaded successfully") {
-      Post("/jars/foobar", Array[Byte](0, 1, 2)) ~> sealRoute(routes) ~> check {
-        status should be (OK)
-        val result = responseAs[Map[String, String]]
-        result(ResultKey) should equal("Jar uploaded")
-      }
-    }
-
-    it("should respond with bad request if jar formatted incorrectly") {
-      Post("/jars/badjar", Array[Byte](0, 1, 2)) ~> sealRoute(routes) ~> check {
-        status should be (BadRequest)
-      }
-    }
-  }
-
   describe("binaries routes") {
     it("should list all binaries") {
       Get("/binaries") ~> sealRoute(routes) ~> check {

--- a/job-server/src/test/scala/spark/jobserver/auth/WebApiWithAuthenticationSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/auth/WebApiWithAuthenticationSpec.scala
@@ -158,27 +158,6 @@ class WebApiWithAuthenticationSpec extends FunSpec with Matchers with BeforeAndA
     }
   }
 
-  describe("jars routes") {
-    it("should allow user with valid authorization") {
-      Get("/jars").withHeaders(authorization) ~> sealRoute(routesWithProxyUser) ~> check {
-        status should be(OK)
-      }
-    }
-
-    it("should not allow user with invalid password") {
-      Post("/jars/foobar", Array[Byte](0, 1, 2)).
-        withHeaders(authorizationInvalidPassword) ~> sealRoute(routesWithProxyUser) ~> check {
-        status should be(Unauthorized)
-      }
-    }
-
-    it("should not allow unknown user") {
-      Get("/jars").withHeaders(authorizationUnknownUser) ~> sealRoute(routesWithProxyUser) ~> check {
-        status should be(Unauthorized)
-      }
-    }
-  }
-
   describe("binaries routes") {
 
     it("should allow user with valid authorization") {
@@ -474,13 +453,6 @@ class WebApiWithAuthenticationSpec extends FunSpec with Matchers with BeforeAndA
     it("jobs should not allow user with valid authorization when timeout") {
       Get("/jobs/foobar").withHeaders(authorization) ~>
         sealRoute(routesWithTimeout(true, 0)) ~> check {
-          status should be(InternalServerError)
-        }
-    }
-
-    it("jars should not allow user with valid authorization when timeout") {
-      Get("/jars").withHeaders(authorization) ~>
-        sealRoute(routesWithTimeout(false, 0)) ~> check {
           status should be(InternalServerError)
         }
     }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**New behavior:**

The path is long time deprecated and not supported.
As already a new version of Jobserver with the deprecated path
was released, the path can be finally removed from the
WebApi to clean up the code a bit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1234)
<!-- Reviewable:end -->
