### PR TITLE
feat(sbt): Use cached resolution

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 
 import Dependencies._
 
+updateOptions := updateOptions.value.withCachedResolution(true)
 transitiveClassifiers in Global := Seq(Artifact.SourceClassifier)
 lazy val dirSettings = Seq()
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) 
- [x] Tests for the changes have been added (for bug fixes / features) 
- [x] Docs have been added / updated (for bug fixes / features) 


**New behavior:**
The Cached Resolution feature is akin to the incremental compilation,
which only recompiles the sources that have been changed since
the last compile. Unlike the Scala compiler, Ivy does not have
the concept of separate compilation, so that needed to be implemented.

Instead of resolving the full dependency graph, the Cached Resolution
feature creates minigraphs — one for each direct dependency
appearing in all related subprojects. These minigraphs are
resolved using Ivy’s resolution engine, and the result is stored
locally under ~/.sbt/$SBT_VERSION/dependency/
After all minigraphs are resolved, they are stitched together
by applying the conflict resolution algorithm (typically picking
the latest version).

When you add a new library to your project, Cached Resolution
feature will check for the minigraph files under
~/.sbt/$SBT_VERSION/dependency/ and load the previously
resolved nodes, which incurs negligible I/O overhead,
and only resolve the newly added library. The intended
performance improvement is that the second and third subprojects
can take advantage of the resolved minigraphs from the first one
and avoid duplicated work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1235)
<!-- Reviewable:end -->
