### PR TITLE
feat(jobserver): Make AkkaClusterSupervisorActor a singleton

### DIFF
--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -255,6 +255,19 @@ akka {
     failure-detector.acceptable-heartbeat-pause = 3s
     failure-detector.threshold = 12.0
   }
+
+  cluster.singleton {
+    singleton-name = "context-supervisor"
+    role = "supervisor"
+  }
+
+  cluster.singleton-proxy {
+    singleton-name = ${akka.cluster.singleton.singleton-name}
+    role = ${akka.cluster.singleton.role}
+    singleton-identification-interval = 1s
+    buffer-size = 1000
+  }
+
 }
 
 

--- a/job-server/src/main/scala/spark/jobserver/JobManager.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManager.scala
@@ -74,7 +74,13 @@ object JobManager {
       config.getConfig("spark").root.render())
 
     val masterAddress = systemConfig.getBoolean("spark.jobserver.kill-context-on-supervisor-down") match {
-      case true => clusterAddress.toString + "/user/context-supervisor"
+      /*
+       * TODO
+       * Note: This zombie killing logic has to be replaced by a proper split brain
+       * resolver, since the fix of resolving the AkkaClusterSupervisor no longer works
+       * when there is more than one Jobserver in the cluster (as it might be there or not).
+       */
+      case true => clusterAddress.toString + "/user/singleton/context-supervisor"
       case false => ""
     }
 
@@ -161,4 +167,3 @@ object JobManager {
         TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS)
   }
 }
-

--- a/job-server/src/test/scala/spark/jobserver/JobServerSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobServerSpec.scala
@@ -72,7 +72,13 @@ class JobServerSpec extends TestKit(JobServerSpec.system) with FunSpecLike with 
     return None
   }
 
-  def makeSupervisorSystem(config: Config): ActorSystem = actorSystem
+  def makeSupervisorSystem(config: Config): ActorSystem = {
+    val configWithRole = config.withValue("akka.cluster.roles",
+      ConfigValueFactory.fromIterable(List("supervisor").asJava))
+    actorSystem = ActorSystem("JobServerSpec", configWithRole)
+    actorSystem
+  }
+
   implicit val timeout: Timeout = 3 seconds
 
   describe("Fails on invalid configuration") {
@@ -193,7 +199,9 @@ class JobServerSpec extends TestKit(JobServerSpec.system) with FunSpecLike with 
       resolveActorRef("/user/dao-manager") shouldNot be(None)
       resolveActorRef("/user/data-manager") shouldNot be(None)
       resolveActorRef("/user/binary-manager") shouldNot be(None)
-      resolveActorRef("/user/context-supervisor") shouldNot be (None)
+      resolveActorRef("/user/singleton") shouldNot be (None)
+      resolveActorRef("/user/singleton/context-supervisor") shouldNot be (None)
+      resolveActorRef("/user/context-supervisor-proxy") shouldNot be (None)
       resolveActorRef("/user/job-info") shouldNot be(None)
     }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,6 +20,7 @@ object Dependencies {
     // to use this one
     "com.typesafe.akka" %% "akka-slf4j" % akka,
     "com.typesafe.akka" %% "akka-cluster" % akka exclude("com.typesafe.akka", "akka-remote"),
+    "com.typesafe.akka" %% "akka-cluster-tools" % akka,
     "io.spray" %% "spray-json" % sprayJson,
     "io.spray" %% "spray-can" % spray,
     "io.spray" %% "spray-caching" % spray,


### PR DESCRIPTION
Following the [HA proposal mentioned in issue #1236](https://github.com/spark-jobserver/spark-jobserver/issues/1236), this singleton change represents step 3/5 to achieve jobserver HA:

**Details**

* Create AkkaClusterSupervisorActor as an akka cluster singleton
  on jobserver startup
* Adapt application.conf for a cluster singleton
* Adapt JobserverSpec to also check for singleton infrastructure
  in case of context-per-jvm=true
* Temporarily adapt changes to jobManager zombie kill features as
  long as we have no split brain resolver.

In jobserver HA mode the logic following a MemberUp event
(initializing a context) or Terminated event (updating context
and associated job states in the database) can conflict when
handled by two or more active jobservers. Moving this logic to a
cluster singleton ensures that this logic is executed exclusively
by one actor.
See: https://doc.akka.io/docs/akka/current/cluster-singleton.html

Making the AkkaClusterSupervisorActor a singleton is a relatively
simple, straight-forward solution, which requires few changes and
is therefore a good initial solution for HA. The downside is
that a singleton now handles more than just the necessary
AkkaClusterEvents (i.e. context management parts, which could be
handled locally by each jobserver), which represents a potential
bottleneck in the future.

A recommended optimization for the future would be to refactor
the AkkaClusterSupervisorActor into two actors (cluster and
context managing parts), where only the cluster parts will be
handled by a singleton. To not overburden the initial HA of
jobserver, this refactoring is left out for now.

**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?
- [X] Docs have been added / updated (for bug fixes / features) ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1239)
<!-- Reviewable:end -->
