### PR TITLE
fix(jobserver): Fix custom exceptions constructor

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/util/CustomException.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/CustomException.scala
@@ -2,26 +2,21 @@ package spark.jobserver.util
 
 import spark.jobserver.io.ContextInfo
 
-case class DeleteBinaryInfoFailedException(private val appName: String) extends Exception {
-  private val message = s"can't delete meta data information for $appName";
-}
+final case class DeleteBinaryInfoFailedException(private val appName: String) extends
+    Exception(s"can't delete meta data information for $appName")
 
-case class NoStorageIdException(private val appName: String) extends Exception {
-  private val message = s"can't find hash for $appName in metadata database";
-}
+final case class NoStorageIdException(private val appName: String) extends
+  Exception(s"can't find hash for $appName in metadata database")
 
-case class SaveBinaryException(private val appName: String) extends Exception {
-  private val message = s"can't save binary: $appName in database";
-}
+final case class SaveBinaryException(private val appName: String) extends
+  Exception(s"can't save binary: $appName in database")
 
-case class NoSuchBinaryException(private val appName: String) extends Exception {
-  private val message = s"can't find binary: $appName in database";
-}
+final case class NoSuchBinaryException(private val appName: String)
+  extends Exception(s"can't find binary: $appName in database")
 
-case class ResolutionFailedOnStopContextException(private val context : ContextInfo) extends Exception {
-  private val message = s"""Could not resolve jobManagerActor (${context.actorAddress})
-    | for context ${context.name} during StopContext."""
-}
+final case class ResolutionFailedOnStopContextException(private val context : ContextInfo) extends Exception (
+  s"""Could not resolve jobManagerActor (${context.actorAddress})
+     | for context ${context.name} during StopContext.""".stripMargin)
 
 final case class InternalServerErrorException(id: String) extends
   Exception(s"Failed to create context ($id) due to internal error")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?


**New behavior :**

Custom exceptions should extend Exception class with `Exception(msg)` constructor, otherwise exception.getMessage function will return null.
This is especially important for ZookeeperDAO as the null value of the exception message breaks ContextInfo deserialization. Also a new test case for Zookeeper was added (checking that it is possible to save context with custom context exception).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1240)
<!-- Reviewable:end -->
