### PR TITLE
feat(jobserver): Add HA setup for jobserver

### DIFF
--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -145,6 +145,20 @@ spark {
 
     # in yarn deployment, time out for job server to wait while creating contexts
     yarn-context-creation-timeout = 40 s
+
+    # - Empty list of master means HA mode is not enabled.
+    # - Specify the masters as a comma seperated list of format IP:PORT,IP2:PORT
+    #   - Try to keep the PORT for master equal to the config setting akka.remote.netty.tcp.port
+    # - On all masters, the order should be the same for the following property
+    # - Starting master nodes is out of scope of jobserver, external entity should start all nodes
+    # - HA setup is best suited with a HA dao layer. Currently, combined dao with HDFS + ZK is preferable.
+    # - HA setup can also be configured for client/cluster/supervise mode
+    #   - For supervise mode, akka.remote.netty.tcp.port setting should be hardcoded. See doc/supervise-mode.md
+    #   - For cluster mode, see doc/cluster.md and configure this property
+    #   - For client mode, use hardcoded akka.remote.netty.tcp.port instead of random
+    ha {
+      masters = []
+    }
   }
 
   # predefined Spark contexts

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -6,11 +6,10 @@ import java.util.concurrent.TimeUnit
 import akka.actor._
 import akka.pattern.ask
 import akka.cluster.Cluster
-import akka.cluster.ClusterEvent.{MemberEvent, MemberUp, CurrentClusterState}
+import akka.cluster.ClusterEvent.{CurrentClusterState, MemberEvent, MemberUp}
 import akka.util.Timeout
-
 import com.typesafe.config.{Config, ConfigFactory, ConfigRenderOptions}
-import spark.jobserver.util.{SparkJobUtils, ManagerLauncher}
+import spark.jobserver.util._
 
 import scala.collection.mutable
 import scala.reflect.ClassTag
@@ -19,13 +18,11 @@ import spark.jobserver.common.akka.InstrumentedActor
 
 import scala.concurrent.Await
 import org.joda.time.DateTime
-import spark.jobserver.JobManagerActor.{GetContexData, ContexData, SparkContextDead, RestartExistingJobs}
-import spark.jobserver.io.{JobDAOActor, ContextInfo, ContextStatus, JobStatus, ErrorData}
-import spark.jobserver.util.{InternalServerErrorException, NoCallbackFoundException,
-  ContextJVMInitializationTimeout, ContextForcefulKillTimeout, ResolutionFailedOnStopContextException}
+import spark.jobserver.JobManagerActor.{ContexData, GetContexData, RestartExistingJobs, SparkContextDead}
+import spark.jobserver.io._
 import com.google.common.annotations.VisibleForTesting
-import akka.cluster.singleton.{ClusterSingletonProxy, ClusterSingletonManager, ClusterSingletonProxySettings,
-  ClusterSingletonManagerSettings}
+import akka.cluster.singleton.{ClusterSingletonManager, ClusterSingletonManagerSettings,
+  ClusterSingletonProxy, ClusterSingletonProxySettings}
 
 object AkkaClusterSupervisorActor {
   val MANAGER_ACTOR_PREFIX = "jobManager-"
@@ -547,8 +544,18 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef,
     }.getOrElse(Files.createTempDirectory("jobserver"))
     logger.info("Created working directory {} for context {}", contextDir: Any, name)
 
+    val masterSeedNodes = Try {
+      Utils.getHASeedNodes(config) match {
+        case Nil => selfAddress.toString // for backward compatibility
+        case seedNodes => seedNodes.map(_.toString).mkString(",")
+      }
+    }.getOrElse {
+      logger.warn("Failed to get HA seed nodes, falling back to non-HA mode and using this node as master")
+      selfAddress.toString
+    }
+
     val launcher = new ManagerLauncher(config, contextConfig,
-        selfAddress.toString, encodedContextName, contextActorName, contextDir.toString)
+      masterSeedNodes, encodedContextName, contextActorName, contextDir.toString)
 
     launcher.start()
   }

--- a/job-server/src/main/scala/spark/jobserver/util/CustomException.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/CustomException.scala
@@ -62,3 +62,5 @@ final case class UnsupportedNetworkAddressStrategy(name: String) extends
 
 final case class NoCorrespondingContextAliveException(jobId: String) extends
   Exception(s"No context is alive against running job ($jobId). Cleaning the job.")
+
+final case class WrongFormatException(msg: String) extends Exception(msg)

--- a/job-server/src/test/scala/spark/jobserver/JobManagerSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobManagerSpec.scala
@@ -275,5 +275,17 @@ class JobManagerSpec extends FunSpecLike with Matchers with BeforeAndAfter
 
       super.shutdownHDFS()
     }
+
+    it("should exit jvm if master seed nodes cannot be parsed") {
+      def makeSystem(config: Config): ActorSystem = {
+        fail("Cannot reach this point as JVM should already be exited")
+        system
+      }
+
+      intercept[JVMExitException] {
+        JobManager.start(Seq("wrong_address", "test-manager", "").toArray,
+          makeSystem, waitForTerminationDummy)
+      }
+    }
   }
 }

--- a/job-server/src/test/scala/spark/jobserver/JobServerSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobServerSpec.scala
@@ -388,8 +388,8 @@ class JobServerSpec extends TestKit(JobServerSpec.system) with FunSpecLike with 
 
       within(5.seconds) {
         awaitAssert {
-          cluster.state.members.size should ===(1)
-          cluster.state.members.head.status should ===(MemberStatus.Up)
+          cluster.state.members.size should === (1)
+          cluster.state.members.head.status should === (MemberStatus.Up)
           cluster.state.members.head.address === cluster.selfAddress
         }
       }

--- a/job-server/src/test/scala/spark/jobserver/util/UtilsSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/util/UtilsSpec.scala
@@ -36,5 +36,12 @@ class UtilsSpec extends FunSpecLike with Matchers
       Utils.getHASeedNodes(config) should be(
         List(Address("akka.tcp", JobServer.ACTOR_SYSTEM_NAME, "IP", 20)))
     }
+
+    it("should return multiple seed nodes") {
+      val config = ConfigFactory.parseString("spark.jobserver.ha.masters=[\"IP:20\", \"IP2:20\"]")
+      Utils.getHASeedNodes(config) should be(
+        List(Address("akka.tcp", JobServer.ACTOR_SYSTEM_NAME, "IP", 20),
+             Address("akka.tcp", JobServer.ACTOR_SYSTEM_NAME, "IP2", 20)))
+    }
   }
 }

--- a/job-server/src/test/scala/spark/jobserver/util/UtilsSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/util/UtilsSpec.scala
@@ -1,0 +1,40 @@
+package spark.jobserver.util
+
+import akka.actor.Address
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
+import spark.jobserver.JobServer
+
+class UtilsSpec extends FunSpecLike with Matchers
+  with BeforeAndAfter {
+
+  describe("getHASeedNodes tests") {
+    it("should return empty list if ha configs are not specified") {
+      Utils.getHASeedNodes(ConfigFactory.empty()) should be(List.empty)
+    }
+
+    it("should return empty list if ha configs is empty") {
+      val config = ConfigFactory.parseString("spark.jobserver.ha.masters=[]")
+      Utils.getHASeedNodes(config) should be(List.empty)
+    }
+
+    it("should throw exception is wrong format is specified in configuration") {
+      val config = ConfigFactory.parseString("spark.jobserver.ha.masters=[\"IP_WITHOUT_PORT\"]")
+      val config1 = ConfigFactory.parseString("spark.jobserver.ha.masters=[\"IP:20\";\"IP2:20\"]")
+
+      intercept[WrongFormatException] {
+        Utils.getHASeedNodes(config)
+      }
+
+      intercept[WrongFormatException] {
+        Utils.getHASeedNodes(config1)
+      }
+    }
+
+    it("should return seed nodes") {
+      val config = ConfigFactory.parseString("spark.jobserver.ha.masters=[\"IP:20\"]")
+      Utils.getHASeedNodes(config) should be(
+        List(Address("akka.tcp", JobServer.ACTOR_SYSTEM_NAME, "IP", 20)))
+    }
+  }
+}


### PR DESCRIPTION
With recent changes, spinning up multiple
jobserver instances is possible. This change
adds required changes to setup an HA jobserver
cluster.

The address(es) can be specified in comma
separated format in spark.jobserver.ha.masters
section.

At startup, jobserver automatically forms
a new cluster with all the masters or joins
the old cluster of slaves. While forming the
cluster for the first time, the first node
shouldn't fail to come. If it does then the
secondary node will be hanging forever.

kill-context-on-supervisor-down is used in
client mode for killing the slaves if supervisor
is down. This was implemented because at the
time, we didn't had any good split brain resolver.
We were relying on auto-down to mark the node
as DOWN and kill-context-on-supervisor-down to
actually kill the node. Split brain will take
care of both now. Currently, this HA solution
partially breaks the kill-context-on-supervisor
feature because slaves react only on the state of
1 master. In client mode, if HA setup is required
then a proper split brain resolver should be used
with kill-context-on-supervisor-down disabled.

On the slave side, I had 2 options
Option#1: Use the new ha.masters section and use it to
directly to join the masters. If this section is not
defined then use the arguments pass in JVM
Option#2: From the master pass all masters in JVM
arguments

I opted for Option#2 because it is simple and as a
developer, I don't have another branch in my mind
on how master addresses reach the slaves.

Testing:
- Tested with 1 and 2 master setup with cluster +
  supervise mode
- Tested with client mode

Notes:
- If master goes down in cluster mode,
  and comes up with a new dynamic port, then H2
  database on slave will fail to connect. Not
  a problem in ZK dao implementation.
- If port is dynamic in HA mode, then on slave
  restart, it won't know the seed nodes to connect to.
  So, port hardcoding is required.

Change-Id: I0553d0e400d471a6de70f86b9e94096231f43939

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1241)
<!-- Reviewable:end -->
