### PR TITLE
fix(singleton): Add watch to existing contexts automatically

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/JobServer.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobServer.scala
@@ -150,10 +150,6 @@ object JobServer {
           val proxy = system.actorOf(AkkaClusterSupervisorActor.proxyProps(system),
               "context-supervisor-proxy")
 
-          if (existingManagerActorRefs.length > 0) {
-            proxy ! ContextSupervisor.RegainWatchOnExistingContexts(existingManagerActorRefs)
-          }
-
           proxy ! ContextSupervisor.AddContextsFromConfig  // Create initial contexts
           startWebApi(system, proxy, jobDAO, webApiPF)
         }

--- a/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
@@ -33,7 +33,6 @@ object ContextSupervisor {
   case class GetSparkContexData(name: String)
   case class RestartOfTerminatedJobsFailed(contextId: String)
   case class ForkedJVMInitTimeout(contextActorName: String, contextInfo: ContextInfo)
-  case class RegainWatchOnExistingContexts(actorRefs: Seq[ActorRef])
   case object SparkContextStopped extends StopContextResponse with StopForcefullyContextResponse
 
   // Errors/Responses


### PR DESCRIPTION
Previously watches for existing contexts were added by sending a
RegainWatchOnExistingContexts message to the supervisor on
Jobserver startup.

For an HA/singleton setup, if a second singleton instance takes
over because of failure/restart of the first jobserver, there
are no watches created for the existing contexts.

Although the startup of the previously failed jobserver will
add those watches (via proxy) to the new singleton, and this
being a relatively rare scenario with a small time window, this
could result in missing terminated events and therefore contexts
remaining in state STOPPING.

To fix this, remove the RegainWatchOnExistingContexts message
completely and query/resolve the existing contexts on singleton
startup. Drawback is that query+resolution have to be done twice
now on regular startup (once for joining, once for watches) and
the synergy of doing it only once is not used anymore.

Change-Id: I02bfebcfdb0c6e4282aec9b00e82b795b11574c7

**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1246)
<!-- Reviewable:end -->
