### PR TITLE
fix(jobserver): Don't allow STOPPING context to restart

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/util/CustomException.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/CustomException.scala
@@ -36,6 +36,9 @@ final case class ContextJVMInitializationTimeout() extends
 final case class ContextReconnectFailedException() extends
   Exception("Reconnect failed after Jobserver restart")
 
+final case class StoppedContextJoinedBackException() extends
+  Exception("Stopped context tried to join the cluster")
+
 final case class ContextForcefulKillTimeout() extends
   Exception("Forceful kill for a context failed within deletion time")
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format)
- [x] Tests for the changes have been added
- [x] Docs have been added / updated

If the context in stopping state will be restarted by Spark,
jobserver should kill the new instance of this context,
put context in FINISHED state and clean up all the jobs for
the context.

One of problematic scenarios:
Context is into the load and stops responding to Akka
heartbeats. At the same moment AkkaClusterSupervisor
receives stop request for this context, but can't
send it to the context. Context stays in STOPPING
state. Due to the load on the driver/restart of the
node or something else, context can be restarted by
Spark. Before the fix it was allowed to join the cluster
and was changing stopping context back to RUNNING state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1248)
<!-- Reviewable:end -->
