### PR TITLE
refactor(jobserver): Address SBT warnings

### DIFF
--- a/akka-app/src/main/scala/spark/jobserver/common/akka/AkkaTestUtils.scala
+++ b/akka-app/src/main/scala/spark/jobserver/common/akka/AkkaTestUtils.scala
@@ -7,10 +7,7 @@ import scala.concurrent.Await
 object AkkaTestUtils {
   import scala.concurrent.duration._
 
-  // This is a var for now because we need to let people change it, and we can't pass this in as a param
-  // because then we would change the API.  If we have it as a default param, we can't have multiple methods
-  // with the same name.
-  var timeout = 15 seconds
+  private val timeout = 15 seconds
 
   def shutdownAndWait(actor: ActorRef) {
     if (actor != null) {
@@ -21,8 +18,7 @@ object AkkaTestUtils {
 
   def shutdownAndWait(system: ActorSystem) {
     if (system != null) {
-      system.shutdown()
-      system.awaitTermination(timeout)
+      Await.result(system.terminate(), timeout)
     }
   }
 }

--- a/job-server-extras/src/main/scala/spark/jobserver/SparkSessionJob.scala
+++ b/job-server-extras/src/main/scala/spark/jobserver/SparkSessionJob.scala
@@ -3,7 +3,7 @@ package spark.jobserver
 import com.typesafe.config.Config
 import org.apache.spark.sql.SparkSession
 import org.scalactic._
-import spark.jobserver.api.{SparkJobBase, JobEnvironment, ValidationProblem}
+import spark.jobserver.api.{JobEnvironment, ValidationProblem}
 import spark.jobserver.context.SparkSessionContextLikeWrapper
 
 trait SparkSessionJob extends spark.jobserver.api.SparkJobBase {

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -341,6 +341,10 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef,
                   case Success(ContextStopError(e)) =>
                     logger.error(s"Context stopped (force=${force}) failed with message ${e.getMessage}")
                     originalSender ! ContextStopError(e)
+                  case Success(unknownMessage) =>
+                    logger.error(s"Received  unknown response type: $unknownMessage")
+                    originalSender ! ContextStopError(
+                      new Throwable(s"Received unknown response trying to stop the context."))
                   case Failure(t) =>
                     logger.error(s"Context stopped failed with message ${t.getMessage}")
                     originalSender ! ContextStopError(t)

--- a/job-server/src/main/scala/spark/jobserver/JobManager.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManager.scala
@@ -15,7 +15,8 @@ import spark.jobserver.util.JobServerRoles
 import spark.jobserver.io.{JobDAO, JobDAOActor}
 import spark.jobserver.util.{HadoopFSFacade, NetworkAddressFactory, Utils}
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.Await
+import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -160,7 +161,7 @@ object JobManager {
         // the driver process, that why we have to wait here.
         // Calling System.exit results in a failed YARN application result:
         // org.apache.spark.deploy.yarn.ApplicationMaster#runImpl() in Spark
-        system.awaitTermination
+        Await.result(system.terminate(), Duration.Inf)
       } else {
         // Spark Standalone Cluster Mode:
         // We have to call System.exit(0) otherwise the driver process keeps running

--- a/job-server/src/main/scala/spark/jobserver/JobServer.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobServer.scala
@@ -242,6 +242,8 @@ object JobServer {
           jobDaoActor ! JobDAOActor.SaveJobInfo(jobInfo.copy(state = JobStatus.Error,
               endTime = Some(DateTime.now()), error = Some(ErrorData(ContextReconnectFailedException()))))
           })
+        case Success(unknownResponse) =>
+          logger.error(s"Received unexpected response: $unknownResponse")
         case Failure(e: Exception) =>
           logger.error(s"Exception occurred while fetching jobs for context (${contextInfo.id})", e)
       }


### PR DESCRIPTION
Refactor the code a bit
and address some of SBT warnings:

* Cases in a match should cover all possible replies
* Timeout in AkkaTestUtils can be private val as the variable is not
changed anywhere
* Replace deprecated functions
* Remove shadowed import

Leaves warnings about SQLContext and HiveContext untouched (as there
seem to be no easy way to fix it and we need to refactor SparkContext
into SparkSession)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1250)
<!-- Reviewable:end -->
