### PR TITLE
fix(sbr): Should subscribe to events early and exit with -1 without hooks

### DIFF
--- a/job-server/src/main/scala/akka/downing/KeepOldestAutoDown.scala
+++ b/job-server/src/main/scala/akka/downing/KeepOldestAutoDown.scala
@@ -135,7 +135,7 @@ class KeepOldestAutoDown(preferredOldestMemberRole: Option[String],
       Await.result(context.system.terminate(), 10 seconds)
     } else {
       logger.info("ShutdownSelf: exiting the system with -1")
-      sys.exit(-1)
+      Runtime.getRuntime.halt(-1)
     }
   }
 

--- a/job-server/src/main/scala/akka/downing/KeepOldestDowningProvider.scala
+++ b/job-server/src/main/scala/akka/downing/KeepOldestDowningProvider.scala
@@ -76,7 +76,7 @@ class KeepOldestDowningProvider(system: ActorSystem) extends DowningProvider  {
         logger.info("DowningProvider: on split brain resolution will shutdown actor system.")
         true
       } else {
-        logger.info("DowningProvider: on split brain resolution will execute sys.exit(-1).")
+        logger.info("DowningProvider: on split brain resolution will exit JMV with exit code -1.")
         false
       }
     } else {

--- a/job-server/src/test/scala/akka/downing/KeepOldestAutoDownSpec.scala
+++ b/job-server/src/test/scala/akka/downing/KeepOldestAutoDownSpec.scala
@@ -46,6 +46,8 @@ class OldestAutoDownTestActor(address: Address,
     }
   }
 
+  override def preStart(): Unit = {}
+
   override def shutdownSelf(): Unit = {
     probe ! ShutDownCausedBySplitBrainResolver
   }


### PR DESCRIPTION
**Pull Request checklist**
- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format)

**Current behavior :** 
Previous implementation with `sys.exit(-1)` was calling Spark shutdown hooks
and sometimes putting context in KILLED stated (depending on success of the
DAO operation).

**New behavior :**
The `java.lang.Runtime.halt(int status)` method forcibly terminates the currently
running Java virtual machine. This method never returns normally. Unlike the
exit method, this method does not cause shutdown hooks to be started and does
not run uninvoked finalizers if finalization-on-exit has been enabled.

Split brain resolver class is initialised once the cluster is created.
When cluster is in inconsistent state, node may be in a JOINING
state and never reach UP state (e.g. node was joining the cluster and
right at the same moment all other nodes in the cluster went down).
To avoid this situation split brain resolver should start to react on
cluster events right after initialisation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1251)
<!-- Reviewable:end -->
