### PR TITLE
feat(api): Handle all throwables in loadAndValidateJob

### DIFF
--- a/job-server-api/src/main/scala/spark/jobserver/context/SparkContextFactory.scala
+++ b/job-server-api/src/main/scala/spark/jobserver/context/SparkContextFactory.scala
@@ -17,7 +17,7 @@ trait JobContainer {
 sealed trait LoadingError
 case object JobClassNotFound extends LoadingError
 case object JobWrongType extends LoadingError
-case class JobLoadError(ex: Exception) extends LoadingError
+case class JobLoadError(t: Throwable) extends LoadingError
 
 /**
   * Factory trait for creating a SparkContext or any derived Contexts,
@@ -90,7 +90,7 @@ trait ScalaContextFactory extends SparkContextFactory {
       if (isValidJob(job)) Good(ScalaJobContainer(job)) else Bad(JobWrongType)
     } catch {
       case _: ClassNotFoundException => Bad(JobClassNotFound)
-      case err: Exception => Bad(JobLoadError(err))
+      case t: Throwable => Bad(JobLoadError(t))
     }
   }
 
@@ -122,7 +122,7 @@ trait JavaContextFactory extends SparkContextFactory {
       if (isValidJob(job)) Good(ScalaJobContainer(JavaJob(job))) else Bad(JobWrongType)
     } catch {
       case _: ClassNotFoundException => Bad(JobClassNotFound)
-      case err: Exception => Bad(JobLoadError(err))
+      case t: Throwable => Bad(JobLoadError(t))
     }
   }
 

--- a/job-server-extras/src/main/scala/spark/jobserver/python/PythonContextFactory.scala
+++ b/job-server-extras/src/main/scala/spark/jobserver/python/PythonContextFactory.scala
@@ -64,8 +64,7 @@ trait PythonContextFactory extends SparkContextFactory {
                                   jobCache: JobCache): J Or LoadingError = {
     Try(jobCache.getPythonJob(appName, uploadTime, classPath)) match {
       case Success(jobInfo) => Good(PythonJobContainer(buildJob(jobInfo.eggPath, classPath)))
-      case Failure(ex: Exception) => Bad(JobLoadError(ex))
-      case Failure(ex) => Bad(JobLoadError(new Exception(ex)))
+      case Failure(t) => Bad(JobLoadError(t))
     }
   }
 


### PR DESCRIPTION
If an error (instead of an exception) happened during job
validation, akka.jvm-exit-on-fatal-error was shutting down the
JVM without responding back to Jobserver. The request then timed
out and did not give a useful error as for the Exception cases.

* Let loadAndValidateJob functions of ScalaContextFactory and
  JavaContextFactory catch Throwables (including Errors) instead
  of Exceptions only.
* Extend JobLoadError case class to contain Throwable instead of
  Exception
* For PythonContextFactory throwables were already caught and
  wrapped to an exception. Simplified this code to directly
  throw a Throwable instead of wrapping it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1252)
<!-- Reviewable:end -->
