### PR TITLE
Bump sbt version to 1.2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -834,7 +834,7 @@ When POSTing new binaries, the content-type header must be set to one of the typ
     GET /contexts               - lists all current contexts
     GET /contexts/<name>        - gets info about a context, such as the spark UI url
     POST /contexts/<name>       - creates a new context
-    DELETE /contexts/<name>     - stops a context and all jobs running in it
+    DELETE /contexts/<name>     - stops a context and all jobs running in it. Additionally, you can pass ?force=true to stop a context forcefully. This is equivalent to killing the application from SparkUI (works for spark standalone only).
     PUT /contexts?reset=reboot  - shuts down all contexts and re-loads only the contexts from config. Use ?sync=false to execute asynchronously.
 
 Spark context configuration params can follow `POST /contexts/<name>` as query params. See section below for more details.

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val jobServer = Project(id = "job-server", base = file("job-server"))
       .dependsOn(clean in Compile in jobServerTestJar)
       .dependsOn(buildPython in jobServerPython)
       .dependsOn(clean in Compile in jobServerPython)
-      .inputTaskValue,
+      .evaluated,
     console in Compile := Defaults.consoleTask(fullClasspath in Compile, console in Compile).value,
     fullClasspath in Compile := (fullClasspath in Compile).map { classpath =>
       extraJarPaths ++ classpath
@@ -71,7 +71,7 @@ lazy val jobServerExtras = Project(id = "job-server-extras", base = file("job-se
       .dependsOn(buildPython in jobServerPython)
       .dependsOn(buildPyExamples in jobServerPython)
       .dependsOn(clean in Compile in jobServerPython)
-      .inputTaskValue
+      .evaluated
   )
   .dependsOn(jobServerApi, jobServer % "compile->compile; test->test")
   .disablePlugins(SbtScalariform)

--- a/job-server-extras/src/test/scala/spark/jobserver/SessionJobSpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/SessionJobSpec.scala
@@ -60,7 +60,7 @@ class SessionJobSpec extends ExtrasJobSpecBase(SessionJobSpec.getNewSystem) {
       expectMsgPF(120 seconds, "Did not get JobResult") {
         case JobResult(_, result: Long) => result should equal (3L)
       }
-      expectNoMsg()
+      expectNoMsg(1.seconds)
 
       manager ! JobManagerActor.StartJob("demo", hiveQueryClass, queryConfig, syncEvents ++ errorEvents)
       expectMsgPF(6 seconds, "Did not get JobResult") {
@@ -68,7 +68,7 @@ class SessionJobSpec extends ExtrasJobSpecBase(SessionJobSpec.getNewSystem) {
           result should have length 2
           result(0)(0) should equal ("Bob")
       }
-      expectNoMsg()
+      expectNoMsg(1.seconds)
     }
   }
 }

--- a/job-server/src/test/scala/spark/jobserver/JobSpecBase.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobSpecBase.scala
@@ -36,6 +36,7 @@ trait JobSpecConfig {
       "spark.jobserver.named-object-creation-timeout" -> "60 s",
       "akka.log-dead-letters" -> Integer.valueOf(0),
       "spark.master" -> "local[*]",
+      "spark.driver.host" -> "127.0.0.1",
       "context-factory" -> contextFactory,
       "spark.context-settings.test" -> "",
       "akka.test.single-expect-default" -> "6s",
@@ -57,7 +58,10 @@ trait JobSpecConfig {
       "streaming.stopGracefully" -> Boolean.box(false),
       "streaming.stopSparkContext" -> Boolean.box(true)
     )
-    ConfigFactory.parseMap(ConfigMap.asJava).withFallback(ConfigFactory.defaultOverrides())
+    ConfigFactory
+      .parseMap(ConfigMap.asJava)
+      .withFallback(config)
+      .withFallback(ConfigFactory.defaultOverrides())
   }
 
   lazy val contextConfigWithGracefulShutdown = {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.2.6


### PR DESCRIPTION
This PR contains the following changes:
- fix(test): Fix spark.driver.host to localhost
- feat(sbt): Move sbt to 1.2.6
- fix(readme): Add force=true flag for delete context
- fix(sbt): Use evaluated instead of inputTaskValue
- fix(tests): Speed up SessionJobSpec test

It essentially bumps sbt to version 1.2.6, adapts necessary configurations and also improves test runtime and documentation in one place.

**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?
- [X] Docs have been added / updated (for bug fixes / features) ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1254)
<!-- Reviewable:end -->
