### PR TITLE
misc(akka): Upgrade Akka version to 2.4.20

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -3,7 +3,7 @@ import scala.util.Properties.isJavaAtLeast
 object Versions {
   lazy val spark = sys.env.getOrElse("SPARK_VERSION", "2.3.2")
 
-  lazy val akka = "2.4.9"
+  lazy val akka = "2.4.20"
   lazy val cassandra = "3.3.0"
   lazy val cassandraUnit = "2.2.2.1"
   lazy val commons = "1.4"


### PR DESCRIPTION
Jobserver should be updated to use 2.5.x as Akka version 2.4 is already officially out of support. Nevertheless it's not supported to make rolling update of Akka directly to 2.5-M1 without upgrading to at least 2.4.16.
See [official documentation](https://doc.akka.io/docs/akka/current/project/migration-guide-2.4.x-2.5.x.html#rolling-update)

Upgrading to 2.4.20 as it's currently the last version of 2.4 release.

**Pull Request checklist**
- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1255)
<!-- Reviewable:end -->
