### PR TITLE
Introduce stop-context-on-job-error flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -953,6 +953,8 @@ To add to the underlying Hadoop configuration in a Spark context, add the hadoop
         }
     }
 
+`stop-context-on-job-error=true` can be passed to context if you want the context to stop immediately after first error is reported by a job. The default value is false.
+
 For the exact context configuration parameters, see JobManagerActor docs as well as application.conf.
 
 ### Other configuration settings

--- a/job-server-api/src/main/scala/spark/jobserver/context/SparkContextFactory.scala
+++ b/job-server-api/src/main/scala/spark/jobserver/context/SparkContextFactory.scala
@@ -63,6 +63,8 @@ trait SparkContextFactory {
     val sparkConf = configToSparkConf(config, contextConfig, contextName)
     makeContext(sparkConf, contextConfig, contextName)
   }
+
+  def updateConfig(config: Config): Config = config
 }
 
 case class ScalaJobContainer(job: api.SparkJobBase) extends JobContainer {

--- a/job-server-extras/src/main/scala/spark/jobserver/StreamingTaskFailedTestJob.scala
+++ b/job-server-extras/src/main/scala/spark/jobserver/StreamingTaskFailedTestJob.scala
@@ -1,0 +1,27 @@
+package spark.jobserver
+
+import com.typesafe.config.Config
+import org.apache.spark.rdd.RDD
+import org.apache.spark.streaming.StreamingContext
+
+import scala.collection.mutable
+
+object StreamingTaskFailedTestJob extends SparkStreamingJob {
+  def validate(ssc: StreamingContext, config: Config): SparkJobValidation = SparkJobValid
+
+  def runJob(ssc: StreamingContext, config: Config): Any = {
+    val queue = mutable.Queue[RDD[String]]()
+    val lines = ssc.queueStream(queue)
+    val words = lines.flatMap{ l =>
+      1/0
+      l.split(" ")
+    }
+
+    queue += ssc.sparkContext.makeRDD(Seq("123", "test", "test2"))
+
+    val wordCounts = words.countByValue()
+    wordCounts.foreachRDD(rdd => rdd.count())
+    ssc.start()
+    ssc.awaitTermination()
+  }
+}

--- a/job-server-extras/src/test/scala/spark/jobserver/StreamingJobSpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/StreamingJobSpec.scala
@@ -145,6 +145,16 @@ class StreamingJobSpec extends JobSpecBase(StreamingJobSpec.getNewSystem) {
 
       deathWatch.expectNoMsg(1.seconds)
     }
+
+    it("should automatically stop a streaming context if" +
+      s" job throws an exception (since ${JobserverConfig.STOP_CONTEXT_ON_JOB_ERROR} is by default true)") {
+      val deathWatch = TestProbe()
+      deathWatch.watch(manager)
+
+      triggerFailingStreamingJob(cfg)
+
+      deathWatch.expectTerminated(manager, 3.seconds)
+    }
   }
 
   private def triggerFailingStreamingJob(ctxConfig: Config): Unit = {

--- a/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
@@ -344,6 +344,8 @@ class JobManagerActor(daoActor: ActorRef, supervisorActorAddress: String, contex
           jarLoader.addURL(new URL(convertJarUriSparkToJava(jarUri)))
         }
         factory = getContextFactory()
+        // Add defaults or update the config according to a specific context
+        contextConfig = factory.updateConfig(contextConfig)
         jobContext = factory.makeContext(config, contextConfig, contextName)
         jobContext.sparkContext.addSparkListener(sparkListener)
         sparkEnv = SparkEnv.get

--- a/job-server/src/main/scala/spark/jobserver/util/JobserverConfig.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/JobserverConfig.scala
@@ -1,0 +1,11 @@
+package spark.jobserver.util
+
+object JobserverConfig {
+
+  /**
+    * A configuration property for contexts and can be passed during the POST /context.
+    * If set, on any error the context would be stopped.
+    */
+  val STOP_CONTEXT_ON_JOB_ERROR = "stop-context-on-job-error"
+
+}


### PR DESCRIPTION
**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?
- [X] Docs have been added / updated (for bug fixes / features) ?

Introduce a new property stop-context-on-job-error, which can be set to true if context termination is required after job failure. By default the value is `false`.

Additionally set the default to `true` for streaming jobs only, since Spark kills the driver if a streaming job has an error and we want the same behavior in jobserver.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1256)
<!-- Reviewable:end -->
