### PR TITLE
refactor(jobserver): Remove outdated TODO

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -269,9 +269,6 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef,
     case AddContext(name, contextConfig) =>
       val originator = sender()
       val mergedConfig = contextConfig.withFallback(defaultContextConfig)
-      // TODO(velvia): This check is not atomic because contexts is only populated
-      // after SparkContext successfully created!  See
-      // https://github.com/spark-jobserver/spark-jobserver/issues/349
       val resp = getActiveContextByName(name)
       (resp._1, resp._2) match {
         case (true, Some(c)) => originator ! ContextAlreadyExists


### PR DESCRIPTION
As stated in the issue (which is already closed) this check is atomic by now. Remove the comment to avoid confusion.

https://github.com/spark-jobserver/spark-jobserver/issues/349

**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1257)
<!-- Reviewable:end -->
