### PR TITLE
doc(readme): Remove SPARK_CLASSPATH as it's deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,6 @@ You have a couple options to package and upload dependency jars.
         ````
         The jars /myjars/deps01.jar & /myjars/deps02.jar (present only on the SJS node) will be loaded and made available for the Spark driver & executors.
     - Use the `--package` option with Maven coordinates with `server_start.sh`.
-    - Put the extra jars in the SPARK_CLASSPATH
 
 ### Named Objects
 #### Using Named RDDs


### PR DESCRIPTION
**Pull Request checklist**

- [x] Docs have been added / updated (for bug fixes / features)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1263)
<!-- Reviewable:end -->
