### PR TITLE
Fixes and multi-jvm tests for split brain resolver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import com.typesafe.sbt.SbtMultiJvm.multiJvmSettings
+import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 
 import Dependencies._
 
@@ -15,6 +17,7 @@ lazy val akkaApp = Project(id = "akka-app", base = file("akka-app"))
 lazy val jobServer = Project(id = "job-server", base = file("job-server"))
   .settings(commonSettings)
   .settings(revolverSettings)
+  .settings(multiJvmSettings: _*)
   .settings(assembly := null.asInstanceOf[File])
   .settings(
     description := "Spark as a Service: a RESTful job server for Apache Spark",
@@ -39,6 +42,7 @@ lazy val jobServer = Project(id = "job-server", base = file("job-server"))
   .settings(publishSettings)
   .dependsOn(akkaApp, jobServerApi)
   .disablePlugins(SbtScalariform)
+  .configs(MultiJvm)
 
 lazy val jobServerTestJar = Project(id = "job-server-tests", base = file("job-server-tests"))
   .settings(commonSettings)

--- a/job-server/src/main/scala/akka/downing/KeepOldestAutoDown.scala
+++ b/job-server/src/main/scala/akka/downing/KeepOldestAutoDown.scala
@@ -104,6 +104,13 @@ class KeepOldestAutoDown(preferredOldestMemberRole: Option[String],
       logger.info("{} is reachable", m)
       refreshMember(m)
       removeFromUnreachable(m)
+      if (scheduledUnreachable.isEmpty && unstableUnreachable.nonEmpty) {
+        logger.info(s"Member $m is reachable again." +
+          s"Checking members for which UnreachableTimeout was already triggered: $unstableUnreachable. \n" +
+          s"This is the current cluster state (sorted by age): $membersByAge. \n" +
+          s"Current list of pending members (other node should have downed them): $pendingUnreachable")
+        downUnreachableNodes(unstableUnreachable)
+      }
     case MemberLeft(m) =>
       logger.info("{} is left the cluster", m)
       refreshMember(m)

--- a/job-server/src/main/scala/akka/downing/KeepOldestAutoDown.scala
+++ b/job-server/src/main/scala/akka/downing/KeepOldestAutoDown.scala
@@ -38,8 +38,8 @@ class KeepOldestAutoDown(preferredOldestMemberRole: Option[String],
         "so autoDownUnreachableAfter timeout must be greater than zero.")
   }
 
+  protected var membersByAge: SortedSet[Member] = SortedSet.empty(Member.ageOrdering)
   private val cluster = Cluster(context.system)
-  private var membersByAge: SortedSet[Member] = SortedSet.empty(Member.ageOrdering)
   private val skipMemberStatus = Set[MemberStatus](Down, Exiting)
   private var scheduledUnreachable: Map[Member, Cancellable] = Map.empty // waiting for timeout to fire
   private var pendingUnreachable: Set[Member] = Set.empty // waiting for the oldest node to down these nodes

--- a/job-server/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
+++ b/job-server/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
@@ -1,0 +1,90 @@
+package akka.cluster
+
+import akka.actor.Address
+import akka.downing.SBRMultiJvmSpecConfig.testTransport
+import akka.remote.testconductor.RoleName
+import akka.remote.testkit.{MultiNodeSpec, MultiNodeSpecCallbacks}
+import akka.testkit.EventFilter
+import akka.testkit.TestEvent.Mute
+import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.{BeforeAndAfterAll, FunSpecLike, Matchers}
+
+import scala.collection.immutable.TreeSet
+import scala.concurrent.duration._
+
+trait STMultiNodeSpec extends MultiNodeSpecCallbacks
+  with FunSpecLike with Matchers with BeforeAndAfterAll {
+
+  override def beforeAll(): Unit = multiNodeSpecBeforeAll()
+  override def afterAll(): Unit = multiNodeSpecAfterAll()
+}
+
+object MultiNodeClusterSpec {
+  val baseConfig: Config = ConfigFactory.parseString(s"""
+    akka {
+      # Disable all akka output to console
+      loglevel = "OFF" # Other options INFO, OFF, DEBUG, WARNING
+      stdout-loglevel = "OFF"
+      log-dead-letters = off
+      log-dead-letters-during-shutdown = off
+
+      actor {
+        provider = "akka.cluster.ClusterActorRefProvider"
+        warn-about-java-serializer-usage = off
+      }
+      remote.netty.tcp.hostname = "127.0.0.1"
+      cluster {
+        log-info                            = off
+        jmx.enabled                         = off
+        gossip-interval                     = 100 ms
+        leader-actions-interval             = 100 ms
+        unreachable-nodes-reaper-interval   = 300 ms
+        periodic-tasks-initial-delay        = 150 ms
+        publish-stats-interval              = 0 s # always, when it happens
+        failure-detector.heartbeat-interval = 100 ms
+        run-coordinated-shutdown-when-down = off
+        failure-detector.threshold = 2
+      }
+    }
+    spark.driver.supervise = false
+    """)
+
+  testTransport(on = true) // to use blackhole
+}
+
+trait MultiNodeClusterSpec extends STMultiNodeSpec {
+  self: MultiNodeSpec =>
+    val timeout: FiniteDuration = 5.seconds
+
+    def cluster: Cluster = Cluster(system)
+    def clusterView: ClusterReadView = cluster.readView
+
+    def muteAkkaLogMessages(): Unit = {
+      system.eventStream.publish(Mute(EventFilter.error(pattern = ".*Marking.* as UNREACHABLE.*")))
+      system.eventStream.publish(Mute(EventFilter.info(pattern = ".*Marking.* as REACHABLE.*")))
+      system.eventStream.publish(Mute(EventFilter.warning(pattern = ".*received dead letter from .*")))
+      system.eventStream.publish(Mute(EventFilter.warning(pattern = ".*unhandled message from.*")))
+    }
+
+  /**
+    * Expected to be run on the first (controller) node. Will first create a cluster
+    * from the first node and then let all the rest of the node join it.
+    * @param nodes list of RoleNames which should form a cluster
+    */
+    def formCluster(nodes: Seq[RoleName]): Unit = {
+      val nodesAddresses: TreeSet[Address] =
+        collection.immutable.TreeSet[Address]() ++ nodes.map(node(_).address)
+      runOn(nodes.head) {
+        cluster.join(node(myself).address)
+        awaitAssert(clusterView.members.map(_.address) should contain(node(myself).address))
+      }
+
+      runOn(nodes.tail: _*) {
+        cluster.join(node(nodes.head).address)
+      }
+
+      awaitAssert(clusterView.members.collect{
+        case m if m.status == MemberStatus.up => m.address
+      } should be (nodesAddresses), timeout)
+    }
+}

--- a/job-server/src/multi-jvm/scala/akka/downing/KeepOldestAutoDownMultiJVMSpec.scala
+++ b/job-server/src/multi-jvm/scala/akka/downing/KeepOldestAutoDownMultiJVMSpec.scala
@@ -140,7 +140,10 @@ abstract class SBRMultiJvmSpec extends MultiNodeSpec(SBRMultiJvmSpecConfig)
       runOn(bigCluster: _*) {
         val sbr = system.actorSelection(myAddress + downingProviderAddress)
         sbr ! InitializeTestActorRef
-        expectMsg(timeout, PingTestActor)
+        fishForMessage(timeout, "testProbe is waiting for confirmation from SBR"){
+          case PingTestActor => true
+          case _ => false // as the cluster is reused, some old messages after recovery may be received
+        }
       }
       enterBarrier("SBR knows testProbe address")
 
@@ -192,7 +195,10 @@ abstract class SBRMultiJvmSpec extends MultiNodeSpec(SBRMultiJvmSpecConfig)
       runOn(bigCluster: _*) {
         val sbr = system.actorSelection(myAddress + downingProviderAddress)
         sbr ! InitializeTestActorRef
-        expectMsg(timeout, PingTestActor)
+        fishForMessage(timeout, "testProbe is waiting for confirmation from SBR"){
+          case PingTestActor => true
+          case _ => false // as the cluster is reused, some old messages after recovery may be received
+        }
       }
       enterBarrier("SBR knows testProbe address")
 
@@ -249,7 +255,10 @@ abstract class SBRMultiJvmSpec extends MultiNodeSpec(SBRMultiJvmSpecConfig)
     runOn(bigCluster: _*) {
       val sbr = system.actorSelection(myAddress + downingProviderAddress)
       sbr ! InitializeTestActorRef
-      expectMsg(timeout, PingTestActor)
+      fishForMessage(timeout, "testProbe is waiting for confirmation from SBR"){
+        case PingTestActor => true
+        case _ => false // as the cluster is reused, some old messages after recovery may be received
+      }
     }
     enterBarrier("SBR knows testProbe address")
 

--- a/job-server/src/multi-jvm/scala/akka/downing/KeepOldestAutoDownMultiJVMSpec.scala
+++ b/job-server/src/multi-jvm/scala/akka/downing/KeepOldestAutoDownMultiJVMSpec.scala
@@ -1,0 +1,304 @@
+package akka.downing
+
+import akka.actor.Address
+import akka.cluster.MultiNodeClusterSpec
+import akka.downing.KeepOldestTestAutoDown._
+import akka.pattern.ask
+import akka.remote.testconductor.RoleName
+import akka.remote.testkit.{MultiNodeConfig, MultiNodeSpec, MultiNodeSpecCallbacks}
+import akka.remote.transport.ThrottlerTransportAdapter.Direction
+import akka.testkit.ImplicitSender
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{BeforeAndAfterAll, FunSpecLike, Matchers}
+
+import scala.concurrent.Await
+
+trait STMultiNodeSpec extends MultiNodeSpecCallbacks
+  with FunSpecLike with Matchers with BeforeAndAfterAll {
+
+  override def beforeAll(): Unit = multiNodeSpecBeforeAll()
+
+  override def afterAll(): Unit = multiNodeSpecAfterAll()
+}
+
+object SBRMultiJvmSpecConfig extends MultiNodeConfig {
+  val first: RoleName = role("first-node")
+  val second: RoleName = role("second-node")
+  val third: RoleName = role("third-node")
+  val fourth: RoleName = role("forth-node")
+  val fifth: RoleName = role("fifth-node")
+
+  commonConfig(MultiNodeClusterSpec.baseConfig.withFallback(
+    ConfigFactory.parseString("""
+      akka {
+        cluster.downing-provider-class = akka.downing.KeepOldestTestDowningProvider
+      }
+      custom-downing {
+        stable-after = 3s
+        down-removal-margin = 1s
+        oldest-auto-downing {
+          preferred-oldest-member-role = ""
+        }
+      }
+      """)
+  ))
+
+  testTransport(on = true) // to use blackhole (network split)
+}
+
+class SBRMultiJvmNode1 extends SBRMultiJvmSpec
+class SBRMultiJvmNode2 extends SBRMultiJvmSpec
+class SBRMultiJvmNode3 extends SBRMultiJvmSpec
+class SBRMultiJvmNode4 extends SBRMultiJvmSpec
+class SBRMultiJvmNode5 extends SBRMultiJvmSpec
+
+abstract class SBRMultiJvmSpec extends MultiNodeSpec(SBRMultiJvmSpecConfig)
+  with MultiNodeClusterSpec with FunSpecLike with Matchers with ImplicitSender {
+
+  import SBRMultiJvmSpecConfig._
+  def initialParticipants: Int = roles.size
+
+  private val downingProviderAddress: String = "/system/cluster/core/daemon/downingProvider"
+
+  private val addressesCache: Map[RoleName, Address] = roles.map(n => n -> node(n).address).toMap
+  private val twoNodesCluster: Vector[RoleName] = Vector(first, second)
+  private val bigCluster: Vector[RoleName] = Vector(first, second, third, fourth, fifth)
+
+  muteAkkaLogMessages()
+
+  /**
+    * Helper function to get the oldest member of the cluster and all the rest of the nodes
+    * according to the split brain resolver vision.
+    * @param currentCluster - RoleNames of the nodes, which are expected to be in the cluster
+    * @return tuple (oldestNode, allOtherNodesInTheCluster), allOtherNodesInTheCluster - still
+    *         sorted by age pf the nodes
+    */
+  private def getOldestAndOtherMembers(currentCluster: Vector[RoleName]): (RoleName, Vector[RoleName]) = {
+    val memberByAge = Await.result(
+      (system.actorSelection(myAddress + downingProviderAddress) ? GetMembersByAge)
+        (timeout), timeout).asInstanceOf[MembersByAge].members
+    val oldestMember = currentCluster.filter(n => node(n).address == memberByAge.head.address).head
+    val otherMembers = currentCluster.filter(_ != oldestMember)
+    (oldestMember, otherMembers)
+  }
+
+
+  describe("Tests for 2 nodes cluster"){
+
+    it ("In cluster of two nodes, the oldest node should shut down itself") {
+      runOn(twoNodesCluster: _*) {
+        formCluster(twoNodesCluster)
+      }
+      enterBarrier("Made a cluster of two nodes")
+
+      runOn(twoNodesCluster: _*) {
+        system.actorSelection(myAddress + downingProviderAddress) ! InitializeTestActorRef
+        expectMsg(timeout, PingTestActor)
+      }
+      enterBarrier("SBR initialized with testProbe address")
+
+      runOn(first) {
+        // split the cluster in two parts
+        testConductor.blackhole(twoNodesCluster(0), twoNodesCluster(1), Direction.Both).await
+      }
+      enterBarrier("Network split made")
+
+      runOn(twoNodesCluster: _*) {
+        awaitAssert(
+          clusterView.unreachableMembers.map(_.address) should be(
+            twoNodesCluster.filter(_ != myself).map(n => addressesCache(n)).toSet), timeout)
+      }
+      enterBarrier("Nodes see each other as unreachable")
+
+      runOn(twoNodesCluster: _*) {
+        val (oldestMember, _) = getOldestAndOtherMembers(twoNodesCluster)
+        if (oldestMember == myself) {
+          expectMsg(timeout, ShutDownSelfTriggered)
+        } else {
+          expectMsg(timeout, ShutDownAnotherNode(node(twoNodesCluster.head).address))
+        }
+      }
+      enterBarrier("Oldest node shuts itself down (and is downed by the second oldest)")
+
+      runOn(first) {
+        // cleanup: remove network split
+        testConductor.passThrough(twoNodesCluster(0), twoNodesCluster(1), Direction.Both).await
+      }
+      awaitAssert(clusterView.unreachableMembers should ===(Set.empty))
+      enterBarrier("Cleaned up. Test finished.")
+    }
+  }
+
+
+  describe("Tests for a bigger (>2 nodes) cluster"){
+    it ("oldest node should shutdown itself if it is isolated from the rest of the cluster") {
+      runOn(bigCluster: _*) {
+        formCluster(bigCluster)
+      }
+      enterBarrier("Made a bigger cluster")
+
+      runOn(bigCluster: _*) {
+        val sbr = system.actorSelection(myAddress + downingProviderAddress)
+        sbr ! InitializeTestActorRef
+        expectMsg(timeout, PingTestActor)
+      }
+      enterBarrier("SBR knows testProbe address")
+
+      runOn(first) {
+        val (oldestMember, otherMembers) = getOldestAndOtherMembers(bigCluster)
+        // split the cluster in two parts
+        for (secondSide <- otherMembers) {
+          testConductor.blackhole(oldestMember, secondSide, Direction.Both).await
+        }
+      }
+      enterBarrier("Network split created")
+
+      runOn(bigCluster: _*) {
+        val (oldestMember, otherMembers) = getOldestAndOtherMembers(bigCluster)
+
+        if (myself == oldestMember) {
+          // oldest node is alone and should shut down itself
+          awaitAssert(clusterView.unreachableMembers.map(_.address) should be(
+            otherMembers.map(n => node(n).address).toSet), timeout)
+          expectMsg(timeout, ShutDownSelfTriggered)
+        } else if (otherMembers.head == myself) {
+          // secondary oldest node should shutdown the oldest node
+          awaitAssert(clusterView.unreachableMembers.map(_.address) should be(
+            Set(node(bigCluster.head).address)), timeout)
+          expectMsg(timeout, ShutDownAnotherNode(addressesCache(oldestMember)))
+        } else {
+          // all other nodes should do nothing
+          expectNoMsg(timeout)
+        }
+      }
+      enterBarrier("Oldest node shut down itself and secondary oldest downed oldest on the other side.")
+
+      runOn(first) {
+        // cleanup: remove network split
+        for (secondSide <- bigCluster.tail) {
+          testConductor.passThrough(bigCluster.head, secondSide, Direction.Both).await
+        }
+      }
+      awaitAssert(clusterView.unreachableMembers should ===(Set.empty))
+      enterBarrier("Cleaned up. Test finished.")
+    }
+
+    it ("any node should shutdown itself if it is isolated from the rest of the cluster") {
+      runOn(bigCluster: _*) {
+        formCluster(bigCluster)
+      }
+      enterBarrier("Made a bigger cluster")
+
+      runOn(bigCluster: _*) {
+        val sbr = system.actorSelection(myAddress + downingProviderAddress)
+        sbr ! InitializeTestActorRef
+        expectMsg(timeout, PingTestActor)
+      }
+      enterBarrier("SBR knows testProbe address")
+
+      runOn(first) {
+        val (_, otherMembers) = getOldestAndOtherMembers(bigCluster)
+        val isolatedNode = otherMembers.last
+        // split the cluster in two parts
+        for (secondSide <- bigCluster.filter(_ != isolatedNode)) {
+          testConductor.blackhole(isolatedNode, secondSide, Direction.Both).await
+        }
+      }
+      enterBarrier("Network split created")
+
+      runOn(bigCluster: _*) {
+        val (oldestMember, otherMembers) = getOldestAndOtherMembers(bigCluster)
+        val isolatedNode = otherMembers.last
+
+        if (myself == isolatedNode) {
+          // isolated node should shutdown itself
+          awaitAssert(clusterView.unreachableMembers.map(_.address) should be(
+            bigCluster.filter(_ != isolatedNode).map(n => node(n).address).toSet), timeout)
+          expectMsg(timeout, ShutDownSelfTriggered)
+        } else if (myself == oldestMember) {
+          // the oldest node should shutdown isolated node
+          awaitAssert(clusterView.unreachableMembers.map(_.address) should be(
+            Set(addressesCache(isolatedNode))), timeout)
+          expectMsg(timeout, ShutDownAnotherNode(addressesCache(isolatedNode)))
+        } else {
+          // all other nodes should do nothing
+          expectNoMsg(timeout)
+        }
+      }
+      enterBarrier("Network split resolved.")
+
+      runOn(first) {
+        val (_, otherMembers) = getOldestAndOtherMembers(bigCluster)
+        val isolatedNode = otherMembers.last
+        // recover from the cluster split
+        for (secondSide <- bigCluster.filter(_ != isolatedNode)) {
+          testConductor.passThrough(isolatedNode, secondSide, Direction.Both).await
+        }
+      }
+      awaitAssert(clusterView.unreachableMembers should ===(Set.empty))
+      enterBarrier("Cleaned up. Test finished.")
+    }
+  }
+
+  it ("group of nodes should shutdown itself if multiple nodes including the oldest one are unreachable") {
+    runOn(bigCluster: _*) {
+      formCluster(bigCluster)
+    }
+    enterBarrier("Made a bigger cluster")
+
+    runOn(bigCluster: _*) {
+      val sbr = system.actorSelection(myAddress + downingProviderAddress)
+      sbr ! InitializeTestActorRef
+      expectMsg(timeout, PingTestActor)
+    }
+    enterBarrier("SBR knows testProbe address")
+
+    runOn(first) {
+      val (oldestMember, otherMembers) = getOldestAndOtherMembers(bigCluster)
+      val oldestAndSomeNode = Vector(oldestMember, otherMembers.last)
+      // split the cluster in two parts
+      for (firstSide <- oldestAndSomeNode; secondSide <- bigCluster.filter(!oldestAndSomeNode.contains(_))) {
+        testConductor.blackhole(firstSide, secondSide, Direction.Both).await
+      }
+    }
+    enterBarrier("Network split created")
+
+    runOn(bigCluster: _*) {
+      val (oldestMember, otherMembers) = getOldestAndOtherMembers(bigCluster)
+      val oldestAndSomeNode = Vector(oldestMember, otherMembers.last)
+
+      if (!oldestAndSomeNode.contains(myself)) {
+        // node from the split without oldest node should shutdown itself
+        awaitAssert(clusterView.unreachableMembers.map(_.address) should be(
+          oldestAndSomeNode.map(n => node(n).address).toSet), timeout)
+        expectMsg(timeout, ShutDownSelfTriggered)
+      } else if (myself == oldestMember) {
+        // oldest member should shutdown unreachable nodes
+        val isolatedNodesAddresses = bigCluster.filter(!oldestAndSomeNode.contains(_)).map(addressesCache(_))
+        awaitAssert(clusterView.unreachableMembers.map(_.address) should be(
+          isolatedNodesAddresses.sorted.toSet), timeout)
+        for (_ <- 1 to isolatedNodesAddresses.length) {
+          expectMsgPF(timeout, "Other nodes were not downed by the oldest node!") {
+            case ShutDownAnotherNode(nodeAddress) =>
+              isolatedNodesAddresses should contain(nodeAddress)
+          }
+        }
+      } else {
+        // all other nodes do nothing
+        expectNoMsg()
+      }
+    }
+    enterBarrier("Network split resolved.")
+
+    runOn(first) {
+      val (oldestMember, otherMembers) = getOldestAndOtherMembers(bigCluster)
+      val oldestAndSomeNode = Vector(oldestMember, otherMembers.last)
+      // recover from the cluster split
+      for (firstSide <- oldestAndSomeNode; secondSide <- bigCluster.filter(!oldestAndSomeNode.contains(_))) {
+        testConductor.passThrough(firstSide, secondSide, Direction.Both).await
+      }
+    }
+    awaitAssert(clusterView.unreachableMembers should ===(Set.empty))
+    enterBarrier("Cleaned up. Test finished.")
+  }
+}

--- a/job-server/src/multi-jvm/scala/akka/downing/KeepOldestTestDowningProvider.scala
+++ b/job-server/src/multi-jvm/scala/akka/downing/KeepOldestTestDowningProvider.scala
@@ -1,0 +1,56 @@
+package akka.downing
+
+import akka.actor.{ActorRef, ActorSystem, Address, Props}
+import akka.cluster.Member
+import akka.downing.KeepOldestTestAutoDown._
+
+import scala.collection.SortedSet
+import scala.concurrent.duration.FiniteDuration
+
+class KeepOldestTestDowningProvider(system: ActorSystem) extends  KeepOldestDowningProvider(system) {
+  override def downingActorProps: Option[Props] = {
+    val (stableAfter: FiniteDuration,
+    preferredOldestMemberRole: Option[_root_.java.lang.String],
+    shutdownActorSystem: Boolean) = getDowningProviderParams
+
+    Some(KeepOldestTestAutoDown.props(preferredOldestMemberRole, shutdownActorSystem, stableAfter))
+  }
+}
+
+object KeepOldestTestAutoDown {
+  object HealthCheck
+  object HealthCheckPassed
+  object InitializeTestActorRef
+  object PingTestActor
+  object ShutDownSelfTriggered
+  object GetMembersByAge
+  case class MembersByAge(members: SortedSet[Member])
+  case class ShutDownAnotherNode(node: Address)
+
+  def props(oldestMemberRole: Option[String], shutdownActorSystem: Boolean,
+            autoDownUnreachableAfter: FiniteDuration): Props =
+    Props(classOf[KeepOldestTestAutoDown], oldestMemberRole,
+      shutdownActorSystem, autoDownUnreachableAfter)
+}
+
+class KeepOldestTestAutoDown(preferredOldestMemberRole: Option[String],
+                             shutdownActorSystem: Boolean, autoDownUnreachableAfter: FiniteDuration)
+  extends KeepOldestAutoDown(preferredOldestMemberRole, shutdownActorSystem, autoDownUnreachableAfter) {
+
+  var testActorRef: ActorRef = _
+
+  override def receive: Receive = super.receive.orElse({
+    case InitializeTestActorRef =>
+      testActorRef = sender()
+      testActorRef ! PingTestActor
+    case GetMembersByAge => sender() ! MembersByAge(membersByAge)
+  })
+
+  override def shutdownSelf(): Unit = {
+    testActorRef ! ShutDownSelfTriggered
+  }
+
+  override  def down(node: Address): Unit = {
+    testActorRef! ShutDownAnotherNode(node)
+  }
+}

--- a/job-server/src/test/scala/akka/downing/KeepOldestAutoDownSpec.scala
+++ b/job-server/src/test/scala/akka/downing/KeepOldestAutoDownSpec.scala
@@ -255,6 +255,23 @@ class OldestAutoDowningSpec extends TestKit(ActorSystem("OldestAutoDowningSpec")
       }
     }
 
+
+    it("should down node even if next planned UnreachableTimeout got cancelled") {
+      // TODO: this test can be potentially flaky. Rewrite the tests without sleep.
+      val oldestDowningProviderWithTimeout = system.actorOf(Props(
+        new OldestAutoDownTestActor(
+          initialMembersByAge.head.address, 2.seconds, None, testActor
+        )))
+      oldestDowningProviderWithTimeout ! CurrentClusterState(members = initialMembersByAge)
+      oldestDowningProviderWithTimeout ! UnreachableMember(someMember)
+      Thread.sleep(1200) // make some pause between 2 unreachable nodes
+      oldestDowningProviderWithTimeout ! UnreachableMember(secondOldestMember)
+      Thread.sleep(1000) // wait a bit so that timeout for the first node was already triggered
+      oldestDowningProviderWithTimeout ! ReachableMember(secondOldestMember)
+      expectMsg(DownCalled(someMember.address))
+    }
+
+
     it("should down multiple unreachable nodes one after another (with timeout setting)") {
       val oldestDowningProviderWithTimeout = system.actorOf(Props(
         new OldestAutoDownTestActor(

--- a/job-server/src/test/scala/akka/downing/KeepOldestAutoDownSpec.scala
+++ b/job-server/src/test/scala/akka/downing/KeepOldestAutoDownSpec.scala
@@ -314,11 +314,32 @@ class OldestAutoDowningSpec extends TestKit(ActorSystem("OldestAutoDowningSpec")
     it("should not down the node if not the oldest and oldest is alone unreachable") {
       val othersNodeDowningProvider = system.actorOf(Props(
         new OldestAutoDownTestActor(
-          initialMembersByAge.drop(3).head.address, 1.seconds, None, testActor
+          someMember.address, 1.seconds, None, testActor
         )))
       othersNodeDowningProvider ! CurrentClusterState(members = initialMembersByAge)
       othersNodeDowningProvider ! UnreachableMember(initialMembersByAge.head)
       expectNoMsg(3.seconds)
+    }
+
+    it("should not down the node if not the oldest and oldest is alone unreachable even though there are" +
+      " some nodes in Joining state") {
+      val othersNodeDowningProvider = system.actorOf(Props(
+        new OldestAutoDownTestActor(
+          someMember.address, 1.seconds, None, testActor
+        )))
+      val joiningMember = TestMember(Address("akka.tcp", "sys", "joining", 2552), Joining, Set("slave"))
+      othersNodeDowningProvider ! CurrentClusterState(members = initialMembersByAge)
+      othersNodeDowningProvider ! ReachableMember(joiningMember)
+      othersNodeDowningProvider ! UnreachableMember(initialMembersByAge.head)
+      expectNoMsg(3.seconds)
+    }
+
+    it("should down joining node if it becomes unreachable after a while") {
+      val joiningMember = TestMember(Address("akka.tcp", "sys", "joining", 2552), Joining, Set("slave"))
+      oldestDowningProvider ! CurrentClusterState(members = initialMembersByAge)
+      oldestDowningProvider ! ReachableMember(joiningMember)
+      oldestDowningProvider ! UnreachableMember(joiningMember)
+      expectMsg(DownCalled(joiningMember.address))
     }
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -75,6 +75,7 @@ object Dependencies {
   lazy val coreTestDeps = Seq(
     scalaTestDep,
     "com.typesafe.akka" %% "akka-testkit" % akka % Test,
+    "com.typesafe.akka" %% "akka-multi-node-testkit" % akka % Test,
     "io.spray" %% "spray-testkit" % spray % Test,
     "org.cassandraunit" % "cassandra-unit" % cassandraUnit % Test excludeAll(excludeJpountz)
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,3 +17,5 @@ addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")
 
 addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.5.0")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.4.0")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**New behavior :**

In current SBR implementation if several nodes become unreachable, for each of them there will be an UnreachableTimeout scheduled, but all nodes will be downed together when the last scheduled UnreachableTimeout is received.
This PR fixes the problem that when the last UnreachableTimeout was canceled and the corresponding node became reachable again, the remaining unstableUnreachable nodes were not downed at all.


Introduce first multi-jvm tests for split-brain resolver class. For the easiness of testing KeepOldestTestDowningProvider is made, which instead of downing nodes sends messages to testProbe.

Regarding usage of multi-jvm package, please be aware that:
* First node in test plays the role of controller. If
first node is killed during the test, the test will crash.
All cluster operations as making network split are
made on the first node.
* It's very important to use barriers and make sure that all nodes joined the cluster (not just started, but joined the cluster and seen as UP).
* Testing network split awaitAssert should be used to be sure that all nodes are seen as unreachable/reachable. Failure detector needs couple of heartbeats to mark the node unreachable.
* Barriers can be made only on all nodes (no subset), therefore should be always called from the main test thread.
* MultiNodeClusterSpec is in separate package (akka.cluster) as only from this package it can
see additional methods of cluster class and use ClusterReadView to check current cluster state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1264)
<!-- Reviewable:end -->
