### PR TITLE
feat(jobserver): Add /binaries/<appName> endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -854,6 +854,7 @@ Flow diagrams are checked in in the doc/ subdirectory.  .diagram files are for w
 ### Binaries
 
     GET /binaries               - lists all current binaries
+    GET /binaries /<appName>    - gets info about the last binary uploaded under this name (app-name, binary-type, upload-time)
     POST /binaries/<appName>    - upload a new binary file
     DELETE /binaries/<appName>  - delete defined binary
 

--- a/job-server/src/test/scala/spark/jobserver/WebApiMainRoutesSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiMainRoutesSpec.scala
@@ -37,6 +37,26 @@ class WebApiMainRoutesSpec extends WebApiSpec {
       }
     }
 
+    it("should retrieve a specific binary") {
+      Get("/binaries/demo") ~> sealRoute(routes) ~> check {
+        status should be (OK)
+        responseAs[Map[String, String]] should be(Map(
+          "app-name" -> "demo",
+          "binary-type" -> "Jar",
+          "upload-time" -> "2013-05-29T00:00:00.000Z"
+        ))
+      }
+    }
+
+    it("should return with 404 if binary cannot be found") {
+      Get("/binaries/nonexisting") ~> sealRoute(routes) ~> check {
+        status should be (NotFound)
+        responseAs[Map[String, String]] should be(Map(
+            "status" -> "ERROR",
+            "result" -> "Can't find binary with name nonexisting"))
+      }
+    }
+
     it("should respond with OK if jar uploaded successfully") {
       Post("/binaries/foobar", Array[Byte](0, 1, 2)).
         withHeaders(BinaryType.Jar.contentType) ~> sealRoute(routes) ~> check {
@@ -737,4 +757,3 @@ class WebApiMainRoutesSpec extends WebApiSpec {
     }
   }
 }
-

--- a/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
@@ -26,6 +26,7 @@ import org.apache.xerces.util.URI.MalformedURIException
 
 import scala.concurrent.duration.Duration
 import spark.jobserver.util.{NoSuchBinaryException, Utils}
+import spark.jobserver.io.JobDAOActor.LastBinaryInfo
 
 // Tests web response codes and formatting
 // Does NOT test underlying Supervisor / JarManager functionality
@@ -151,6 +152,8 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
           "demo2" -> (BinaryType.Jar, dt.plusHours(1)),
           "demo3" -> (BinaryType.Egg, dt.plusHours(2))
         )
+      case GetBinary("demo") => sender ! LastBinaryInfo(Some(binaryInfo))
+      case GetBinary(_) => sender ! LastBinaryInfo(None)
       // Ok these really belong to a JarManager but what the heck, type unsafety!!
       case StoreBinary("badjar", _, _)  => sender ! InvalidBinary
       case StoreBinary("daofail", _, _) => sender ! BinaryStorageFailure(new Exception("DAO failed to store"))


### PR DESCRIPTION
The current endpoint /binaries only returns all binaries from the
DAO. It should be possible to retrieve information about a specific
binary (given an appName) as well. Especially if the amount of
binaries in the database grows the current API design is not well
suited for this use case.

* Add new message GetBinary(appName) to BinaryManager returning
  BinaryInfo retrieved from the DAO.
* Add new endpoint /binaries/<appName> to the WebAPI
* Extend WebApi and BinaryManager tests accordingly
* Update documentation for API

Change-Id: Ie240a90568a4dabfae67960c873579cc57aa24de

**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?
- [X] Docs have been added / updated (for bug fixes / features) ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1273)
<!-- Reviewable:end -->
