### PR TITLE
Unify response format and codes

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/WebApi.scala
+++ b/job-server/src/main/scala/spark/jobserver/WebApi.scala
@@ -51,13 +51,9 @@ object WebApi {
     ctx.complete(StatusCodes.NotFound, errMap(msg))
   }
 
-  def logAndComplete(ctx: RequestContext, errMsg: String, stcode: Int) {
+  def logAndComplete(ctx: RequestContext, errMsg: String, stcode: StatusCode) {
     logger.info("StatusCode: " + stcode + ", ErrorMessage: " + errMsg)
-    ctx.complete(stcode, errMap(errMsg))
-  }
-
-  def logAndComplete(ctx: RequestContext, errMsg: String, statusCode: StatusCode) {
-    logAndComplete(ctx, errMsg, statusCode.intValue)
+    ctx.complete(stcode.intValue, errMap(errMsg))
   }
 
   def logAndComplete(ctx: RequestContext, errMsg: String, stcode: StatusCode, e: Throwable) {

--- a/job-server/src/test/scala/spark/jobserver/WebApiMainRoutesSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiMainRoutesSpec.scala
@@ -57,17 +57,17 @@ class WebApiMainRoutesSpec extends WebApiSpec {
       }
     }
 
-    it("should respond with OK if jar uploaded successfully") {
+    it("should respond with 201 if jar uploaded successfully") {
       Post("/binaries/foobar", Array[Byte](0, 1, 2)).
         withHeaders(BinaryType.Jar.contentType) ~> sealRoute(routes) ~> check {
-        status should be (OK)
+        status should be (Created)
       }
     }
 
-    it("should respond with OK if egg uploaded successfully") {
+    it("should respond with 201 if egg uploaded successfully") {
       Post("/binaries/pyfoo", Array[Byte](0, 1, 2)).
         withHeaders(BinaryType.Egg.contentType) ~> sealRoute(routes) ~> check {
-        status should be (OK)
+        status should be (Created)
       }
     }
 


### PR DESCRIPTION
This PR cleans up response codes and formats and also refactors WebApi code (renamed confusing `logAndComplete` functions, removed `errMap`, merged some functions together).

**Current behavior :**
Some of the endpoints response with "OK", some with json map.

**New behavior :**
Always respond with a JSON in unified "jobserver" format (with status "ERROR", "SUCCESS").

**Other information**:
Based on https://github.com/spark-jobserver/spark-jobserver/issues/25
I also tried first to remove any text response in case of "OK" and return just status code, but it turned out to be a bit confusing especially in case of binary upload.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1278)
<!-- Reviewable:end -->
