### PR TITLE
fix(dependent-jars): Dependent-jar-uris for context config

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
@@ -344,7 +344,8 @@ class JobManagerActor(daoActor: ActorRef, supervisorActorAddress: String, contex
 
       try {
         // Load context side jars first in case the ContextFactory comes from it
-        val cpFromConfig = Utils.getSeqFromConfig(contextConfig, "cp")
+        val cpFromConfig = Utils.getSeqFromConfig(contextConfig, "cp") ++
+          Utils.getSeqFromConfig(contextConfig, "dependent-jar-uris")
         val cp = if (cpFromConfig.nonEmpty) {
           // TODO: can be done without blocking await?
           val daoResponse = Await.result(


### PR DESCRIPTION
Add mapping to the old dependent-jar-parameter for the
context config. Currently posting dependent jars for the context with `dependent-jar-uris` parameter doesn't work.

More information can be found in this issue: https://github.com/spark-jobserver/spark-jobserver/issues/1151

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1279)
<!-- Reviewable:end -->
