### PR TITLE
ci(jobserver): Build failing due to missing public key

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -4,6 +4,7 @@ USER root
 # install and cache sbt, python
 
 RUN echo 'deb http://dl.bintray.com/sbt/debian /' > /etc/apt/sources.list.d/sbt.list && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 99E82A75642AC823 && \
     apt-get -qq update && \
     apt-get install -y --force-yes python3 python3-pip python-pip sbt=1.1.6
 

--- a/ci/install-python-dependencies.sh
+++ b/ci/install-python-dependencies.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
-pip install --upgrade pip==9.0.1
+pip install --upgrade pip
 pip install --user pyhocon
 pip3 install --user pyhocon
 pip install --user pep8


### PR DESCRIPTION
The travis build started to fail due to public key failure.

"W: GPG error: http://dl.bintray.com/sbt/debian
Release: The following signatures couldn't be verified
because the public key is not available:
NO_PUBKEY 99E82A75642AC823"

The fix was to import the key already from a source.

Once this was fixed, the build failed again due to
"pip._internal module not found" and the fix was
to upgrade the version.

The reason why these problems poped up now, is still
unknown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1281)
<!-- Reviewable:end -->
