### PR TITLE
refactor(readme): Set stop-context-on-job-error=true

### DIFF
--- a/README.md
+++ b/README.md
@@ -989,7 +989,8 @@ To add to the underlying Hadoop configuration in a Spark context, add the hadoop
         }
     }
 
-`stop-context-on-job-error=true` can be passed to context if you want the context to stop immediately after first error is reported by a job. The default value is false.
+`stop-context-on-job-error=true` can be passed to context if you want the context to stop immediately after first error is reported by a job. The default value is false but for StreamingContextFactory the default is true.
+You can also change the default value globally in application.conf `context-settings` section.
 
 For the exact context configuration parameters, see JobManagerActor docs as well as application.conf.
 


### PR DESCRIPTION
The default in code was always true which was
contradicting with readme file. Now adjusting
readme file according to the code.

Change-Id: Ia63e82d694f4de688a8ef83eafe72fa93e79e3cb

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1284)
<!-- Reviewable:end -->
