### PR TITLE
fix(jobserver): Graceful force kill if master is down

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/util/ForcefulKill.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/ForcefulKill.scala
@@ -2,16 +2,22 @@ package spark.jobserver.util
 
 import com.typesafe.config.Config
 import spray.client.pipelining._
-import spray.http.{HttpResponse, HttpRequest, FormData}
+import spray.http.{FormData, HttpRequest, HttpResponse}
 import spray.json._
+
 import scala.concurrent.{Await, Future}
 import akka.actor._
+import org.slf4j.LoggerFactory
+
+import scala.util.{Failure, Success, Try}
 
 trait ForcefulKill {
   def kill(): Unit
 }
 
 class StandaloneForcefulKill(config: Config, appId: String) extends ForcefulKill {
+  private val logger = LoggerFactory.getLogger(getClass)
+
   override def kill(): Unit = {
     implicit val system = ActorSystem()
     import system.dispatcher
@@ -20,36 +26,58 @@ class StandaloneForcefulKill(config: Config, appId: String) extends ForcefulKill
     val sparkMasterString = config.getString("spark.master")
     val mode = sparkMasterString.split("//")
     if (!mode.head.containsSlice("spark")) throw new NotStandaloneModeException()
-    val tempSplit = mode.drop(1).head.split(",")
-    var sparkMasterArray = scala.collection.mutable.ArrayBuffer.empty[String]
-    for (i <- tempSplit) {
-      val temp = i.split(":").filterNot(_.trim.equals(""))
-      sparkMasterArray += temp.head
-    }
-    var checkStatus = false
 
-    while(!checkStatus && !sparkMasterArray.isEmpty) {
-      val request = Get("http://" + sparkMasterArray.head + ":8080/json/")
-      val result: HttpResponse = getHTTPResponse(pipeline, request)
-      val ent = result.entity.data.asString
-      //  "status" is showing the state of this master
-      val status = ent.parseJson.asJsObject.getFields("status").mkString
-      checkStatus = status.contains("ALIVE")
-      if (!checkStatus) sparkMasterArray = sparkMasterArray.drop(1)
-      if (sparkMasterArray.isEmpty) throw new NoAliveMasterException()
-    }
+    val mastersIPsWithPort = mode.drop(1).head.split(",")
+    val masterIPs = mastersIPsWithPort.map(_.split(":").filterNot(_.trim().equals("")).head)
 
-    val url = "http://" + sparkMasterArray.head + ":8080/app/kill/"
-    val data = FormData(Seq("id" -> appId, "terminate" -> "true"))
-    val request = Post(url, data)
-    val result = getHTTPResponse(pipeline, request)
-    system.terminate()
+    masterIPs.foreach {
+      masterIP =>
+        val baseSparkURL = s"http://$masterIP:8080"
+        val getJsonRequest = Get(s"${baseSparkURL}/json/")
+
+        getHTTPResponse(pipeline, getJsonRequest).map {
+          getJsonResponse =>
+            val ent = getJsonResponse.entity.data.asString
+            val status = ent.parseJson.asJsObject.getFields("status").mkString
+            status.contains("ALIVE") match {
+              case true =>
+                logger.info(s"Master $masterIP is ALIVE, triggering a kill through UI")
+                val url = s"${baseSparkURL}/app/kill/"
+                val data = FormData(Seq("id" -> appId, "terminate" -> "true"))
+                val killAppRequest = Post(url, data)
+                getHTTPResponse(pipeline, killAppRequest).map {
+                  _ => logger.info(s"Successfully killed the app $appId through spark master $masterIP")
+                    system.terminate()
+                    return
+                }
+              case false =>
+                logger.warn(s"The status of spark master at $masterIP is $status. Skipping kill on it.")
+            }
+        }
+    }
+    logger.error("No master found in ACTIVE or alive state. Throwing exception.")
+    throw new NoAliveMasterException()
   }
 
-  protected def getHTTPResponse(pipeline: SendReceive, req: HttpRequest): HttpResponse = {
+  protected def getHTTPResponse(pipeline: SendReceive, req: HttpRequest): Option[HttpResponse] = {
+    val result = Try {
+      doRequest(pipeline, req)
+    }
+    result match {
+      case Success(response) if response.status.isSuccess => return Some(response)
+      case Success(response) if response.status.isFailure =>
+        logger.error(s"Failed to complete request (${req.uri})." +
+          s"Status code ${response.status.intValue}, complete response is $response")
+        return None
+      case Failure(e) =>
+        logger.error(s"Request ${req.uri} failed. Complete request ${req}", e)
+        return None
+    }
+  }
+
+  protected def doRequest(pipeline: SendReceive, req: HttpRequest): HttpResponse = {
     import scala.concurrent.duration._
-    val responce: Future[HttpResponse] = pipeline(req)
-    val result = Await.result(responce, 3 seconds)
-    result
+    val response: Future[HttpResponse] = pipeline(req)
+    Await.result(response, 3 seconds)
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?
- [X] Docs have been added / updated (for bug fixes / features) ?


Previously, if you have defined the spark
masters in config like
spark://master1:6066,master2:6066,
then in case of master1 being down, a forceful
kill will just return the following and never
try the kill though master2.

"Connection attempt to master1:8080 failed"

This change fixes this bug and improves
logging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1297)
<!-- Reviewable:end -->
