### PR TITLE
fix(file-cache): Create missing directories

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/io/CombinedDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/CombinedDAO.scala
@@ -20,7 +20,7 @@ import spark.jobserver.common.akka.metrics.YammerMetrics
 object CombinedDAO {
   val binaryDaoPath = "spark.jobserver.combineddao.binarydao.class"
   val metaDataDaoPath = "spark.jobserver.combineddao.metadatadao.class"
-  val rootDirPath = "spark.jobserver.combineddao.rootdir"
+  val rootDirConfPath = "spark.jobserver.combineddao.rootdir"
 }
 
 /**
@@ -60,7 +60,8 @@ class CombinedDAO(config: Config) extends JobDAO with FileCacher with YammerMetr
    *  Configuration, Validation & Initialization
    */
 
-  if (!(config.hasPath(binaryDaoPath) && config.hasPath(metaDataDaoPath) && config.hasPath(rootDirPath))) {
+  if (!(config.hasPath(binaryDaoPath) && config.hasPath(metaDataDaoPath) &&
+    config.hasPath(rootDirConfPath))) {
     throw new InvalidConfiguration(
       "To use CombinedDAO root directory and BinaryDAO, MetaDataDAO classes should be specified"
     )
@@ -82,8 +83,8 @@ class CombinedDAO(config: Config) extends JobDAO with FileCacher with YammerMetr
       )
   }
 
-  val rootDir: String = config.getString(rootDirPath)
-  val rootDirFile: File = new File(rootDir)
+  val rootDirPath: String = config.getString(rootDirConfPath)
+  val rootDirFile: File = new File(rootDirPath)
 
   private val defaultAwaitTime = 60 seconds
 
@@ -284,7 +285,7 @@ class CombinedDAO(config: Config) extends JobDAO with FileCacher with YammerMetr
     Utils.usingTimer(binRead){ () =>
       Await.result(metaDataDAO.getBinary(name), defaultAwaitTime) match {
         case Some(binaryInfo) =>
-          val binFile = new File(rootDir, createBinaryName(name, binaryType, uploadTime))
+          val binFile = new File(rootDirPath, createBinaryName(name, binaryType, uploadTime))
           binaryInfo.binaryStorageId match {
             case Some(_) =>
               if (!binFile.exists()) {

--- a/job-server/src/test/scala/spark/jobserver/io/FileCacherRandomDirSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/FileCacherRandomDirSpec.scala
@@ -5,23 +5,11 @@ import java.io.File
 import org.joda.time.DateTime
 import org.scalatest.{FunSpecLike, Matchers}
 
-class FileCacherSpec extends FileCacher with FunSpecLike with Matchers {
-
-  override val rootDirPath: String = "."
+class FileCacherRandomDirSpec extends FileCacher with FunSpecLike with Matchers {
+  override val rootDirPath: String = s"/tmp/spark-jobserver/${util.Random.alphanumeric.take(30).mkString}"
   override val rootDirFile: File = new File(rootDirPath)
 
-  it("produces binary name") {
-    val appName = createBinaryName("job", BinaryType.Jar, DateTime.parse("2016-10-10T13:00:00Z"))
-    appName should be("job-20161010_130000_000.jar")
-  }
-
-  it("clean cache binaries") {
-    val f = File.createTempFile("jobTest-20161010_010000_000.jar", ".jar", new File(rootDirPath))
-    cleanCacheBinaries("jobTest")
-    f.exists() should be(false)
-  }
-
-  it("should cache binary in current directory (default '.')") {
+  it("should create cache directory if it doesn't exist") {
     val bytes = "some test content".toCharArray.map(_.toByte)
     val appName = "test-file-cached"
     val currentTime = DateTime.now


### PR DESCRIPTION
If directory specified for the file caching doesn't exist, Jobserver should create it instead of failing the operation.
As cacheBinary is a protected method, new spec class for the test of modified FileCacher version is introduced. 

Seen exception:
```
   java.io.IOException: No such file or directory
````

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**BREAKING CHANGES**

No

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1298)
<!-- Reviewable:end -->
