### PR TITLE
Improve SBR shutdown logic

### DIFF
--- a/akka-app/src/main/scala/spark/jobserver/common/akka/AkkaTestUtils.scala
+++ b/akka-app/src/main/scala/spark/jobserver/common/akka/AkkaTestUtils.scala
@@ -18,7 +18,8 @@ object AkkaTestUtils {
 
   def shutdownAndWait(system: ActorSystem) {
     if (system != null) {
-      Await.result(system.terminate(), timeout)
+      system.terminate()
+      Await.result(system.whenTerminated, timeout)
     }
   }
 }

--- a/job-server/src/main/scala/spark/jobserver/util/JobserverConfig.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/JobserverConfig.scala
@@ -27,4 +27,9 @@ object JobserverConfig {
    */
   val BINARY_SQL_DAO_CLASS = "spark.jobserver.io.BinarySqlDAO"
   val METADATA_SQL_DAO_CLASS = "spark.jobserver.io.MetaDataSqlDAO"
+
+  /**
+   * Prefix used for naming JobManagerActor. Name is constructed as prefix + context id.
+   */
+  val MANAGER_ACTOR_PREFIX = "jobManager-"
 }

--- a/job-server/src/test/scala/spark/jobserver/JobManagerSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobManagerSpec.scala
@@ -67,7 +67,8 @@ class JobManagerSpec extends FunSpecLike with Matchers with BeforeAndAfter
   }
 
   def makeSupervisorSystem(config: Config): ActorSystem = system
-  def waitForTerminationDummy(system: ActorSystem, master: String, deployMode: String) { }
+  def waitForTerminationDummy(system: ActorSystem, master: String, deployMode: String,
+                              daoActor: ActorRef, contextId: String) { }
   implicit val timeout: Timeout = 3 seconds
 
   describe("starting job manager") {
@@ -222,7 +223,8 @@ class JobManagerSpec extends FunSpecLike with Matchers with BeforeAndAfter
 
     it ("calls wait for termination") {
       var called = false
-      def waitForTermination(system: ActorSystem, master: String, deployMode: String) {
+      def waitForTermination(system: ActorSystem, master: String, deployMode: String,
+                             daoActor: ActorRef, contextId: String) {
         called = true
       }
       val configFileName = writeConfigFile(Map(

--- a/job-server/src/test/scala/spark/jobserver/JobServerSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobServerSpec.scala
@@ -50,8 +50,11 @@ class JobServerSpec extends TestKit(JobServerSpec.system) with FunSpecLike with 
     Files.deleteIfExists(configFile)
   }
 
+  override def beforeAll(): Unit = System.setSecurityManager(new NoExitSecurityManager)
+
   override def afterAll() {
     akka.AkkaTestUtils.shutdownAndWait(JobServerSpec.system)
+    System.setSecurityManager(null)
   }
 
   def writeConfigFile(configMap: Map[String, Any]): String = {
@@ -209,7 +212,7 @@ class JobServerSpec extends TestKit(JobServerSpec.system) with FunSpecLike with 
 
       genActor match {
         case true =>
-          val actor = actorSystem.actorOf(Props.empty, name = AkkaClusterSupervisorActor.MANAGER_ACTOR_PREFIX + uuid)
+          val actor = actorSystem.actorOf(Props.empty, name = JobserverConfig.MANAGER_ACTOR_PREFIX + uuid)
           (ContextInfoPF(Some(actor.path.address.toString)), Some(actor))
         case false =>
           (ContextInfoPF(Some("invalidAddress")), None)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Current behavior :** 

It can happen that node was removed from the cluster or actor system was terminated, but jobserver or driver node still continues to run. In this case, we see incorrect behaviour, failing requests to start/stop resources or a zombie context.
We need to exit jobserver master or spark driver JVMs in 2 cases:
    * Actor system was terminated
    * Actor system was removed from the cluster

**Other information**:

Exiting jobserver master is a low risk operation and can be easily done in both cases.
For the driver we need to take into account the following points:
1. MemberRemoved event will be triggered also if actor system leaves cluster on it's own wish. We should try not to interfere with planned exit, therefore registerOnMemberRemoved hook waits 3 minutes before exiting system with -1 (meaning driver will be restarted by Spark master). In case it was planned shutdown, jobserver should not allow driver to come up again.
2. It's important to use Runtime.getRuntime.halt(-1) and not system.exit(-1) as otherwise shutdown hooks will be called and it may lead to incorrect driver state in joberver DB.

https://doc.akka.io/docs/akka/2.4/scala/cluster-usage.html#How_To_Cleanup_when_Member_is_Removed

With an update to Akka 2.5 maybe better approach with a help of "Coordinated Shutdown" extension.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1299)
<!-- Reviewable:end -->
