### PR TITLE
fix(test): Deduplicate WebApi PUT contexts test

### DIFF
--- a/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
@@ -7,18 +7,14 @@ import akka.testkit.TestKit
 import com.typesafe.config.ConfigFactory
 import org.joda.time.DateTime
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 import spark.jobserver.JobManagerActor.JobKilledException
+import spark.jobserver.io.JobDAOActor._
 import spark.jobserver.io._
-import spray.client.pipelining._
-import JobServerSprayProtocol._
-import org.scalatest.time.{Seconds, Span}
-import spray.http._
 import spray.httpx.SprayJsonSupport
 import spray.routing.HttpService
 import spray.testkit.ScalatestRouteTest
-import scala.concurrent.Future
-import spark.jobserver.io.JobDAOActor._
 
 // Tests web response codes and formatting
 // Does NOT test underlying Supervisor / JarManager functionality
@@ -278,20 +274,4 @@ with ScalatestRouteTest with HttpService with ScalaFutures with SprayJsonSupport
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
   }
-
-  describe ("The WebApi") {
-
-    val jsonContentType = HttpHeaders.`Content-Type`(ContentType(MediaTypes.`application/json`))
-
-    it ("Should return valid JSON when resetting a context") {
-      val p = sendReceive ~> unmarshal[JobServerResponse]
-      val valid: Future[JobServerResponse] = p(Put("http://127.0.0.1:9999/contexts?reset=reboot"))
-      whenReady(valid) { r =>
-        r.isSuccess shouldBe true
-        r.status shouldBe "SUCCESS"
-        r.result shouldBe "Context reset"
-      }
-    }
-  }
-
 }


### PR DESCRIPTION
Recently master branch started to be red and one test is particularly flaky.
This test is added in WebApiSpec and is called multiple times. Although the main reason is still unclear, the first and easy fix is to move test to WebApiMainRoutesSpec and let it execute only once.

Observed exception:

```
    The future returned an exception of type: spray.can.Http$ConnectionAttemptFailedException,
    with message: Connection attempt to 127.0.0.1:9999 failed. (WebApiSpec.scala:290)
```

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Current behavior :** 

Travis build is failing often.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1300)
<!-- Reviewable:end -->
