### PR TITLE
fix: sort jobs by start time in descending order

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/io/SqlCommon.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/SqlCommon.scala
@@ -270,7 +270,7 @@ class SqlCommon(config: Config) {
     } else {
       jobs
     }
-    val limitQuery = baseQuery.sortBy(_.startTime).take(limit)
+    val limitQuery = baseQuery.sortBy(_.startTime.desc).take(limit)
     // Transform the each row of the table into a map of JobInfo values
     for (r <- db.run(limitQuery.result)) yield {
       r.map(jobInfoFromRow)

--- a/job-server/src/test/scala/spark/jobserver/io/SqlCommonSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/SqlCommonSpec.scala
@@ -180,6 +180,23 @@ class SqlCommonSpec extends SqlCommonSpecBase with TestJarFinder with FunSpecLik
       retrievedError.error.isDefined should equal (true)
     }
 
+    it("should load latest jobs") {
+      val dt1 = DateTime.now()
+      val dt2 = dt1.minus(1000)
+
+      val finishedJob: JobInfo =
+        JobInfo("test-finished", "cid", "test", "test-class",
+          JobStatus.Finished, dt1, Some(dt1), None, Seq(jarInfo))
+      val finishedJob2: JobInfo =
+        JobInfo("old-finished", "old-cid", "old", "old-class",
+          JobStatus.Finished, dt2, Some(dt2), None, Seq(jarInfo))
+      helperJobSqlDao.saveJobInfo(finishedJob)
+      helperJobSqlDao.saveJobInfo(finishedJob2)
+
+      val retrievedFinished = Await.result(dao.getJobs(1, Some(JobStatus.Finished)), timeout).head
+      retrievedFinished.jobId should equal ("test-finished")
+    }
+
     it("should retrieve jobs by context id") {
       val contextId = UUID.randomUUID().toString()
       val runningJob = genJobInfo(jarInfo, true, JobStatus.Running, Some(contextId))


### PR DESCRIPTION
Previously only the _limit_ oldest jobs were loaded. If more than
_limit_ jobs were executed, the latest jobs would never be loaded.
Sort jobs in descending start time to always load latest jobs.

**Current behavior :** #1307 
**New behavior :** Jobs are sorted by start time in descending order.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1311)
<!-- Reviewable:end -->
