### PR TITLE
fix: flyway postgres migration to V0.7.9

### DIFF
--- a/job-server/src/main/scala/db/postgresql/migration/V0_7_9/V0_7_9__jobinfo_contains_uris.scala
+++ b/job-server/src/main/scala/db/postgresql/migration/V0_7_9/V0_7_9__jobinfo_contains_uris.scala
@@ -31,12 +31,10 @@ class V0_7_9__jobinfo_contains_uris extends JdbcMigration{
     try {
       Await.ready(
         for {
-          _ <- db.run(sqlu"""CREATE TEMP TABLE jobs_copy as SELECT "JOB_ID", "BIN_ID" FROM "JOBS";""")
-          _ <- db.run(sqlu"""ALTER TABLE "JOBS" DROP COLUMN "BIN_ID";""")
           _ <- db.run(sqlu"""ALTER TABLE "JOBS" ADD COLUMN "BIN_IDS" TEXT, ADD COLUMN "URIS" TEXT;""")
           _ <- db.run(sqlu"""UPDATE "JOBS" SET "URIS" = '' WHERE "URIS" is null;""")
-          _ <- db.run(sqlu"""UPDATE "JOBS" SET "BIN_IDS" =
-                              (SELECT "BIN_ID" FROM jobs_copy WHERE jobs_copy."JOB_ID" = "JOBS"."JOB_ID");""")
+          _ <- db.run(sqlu"""UPDATE "JOBS" SET "BIN_IDS" = "BIN_ID";""")
+          _ <- db.run(sqlu"""ALTER TABLE "JOBS" DROP COLUMN "BIN_ID";""")
         } yield Unit, timeout
       ).recover{logErrors}
       c.commit()


### PR DESCRIPTION
Use correct syntax to add new columns. Copy existing "BIN_ID" to "BIN_IDS".
Fill "URIS" of existing jobs with empty string.

**Current behavior :** #1306 
**New behavior :** Working migration from schema V0.7.8 to V0.7.9 for postgres

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1312)
<!-- Reviewable:end -->
