### PR TITLE
fix(zookeeperdao): Remove duplicate list operation

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/io/zookeeper/MetaDataZookeeperDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/zookeeper/MetaDataZookeeperDAO.scala
@@ -312,8 +312,6 @@ class MetaDataZookeeperDAO(config: Config) extends MetaDataDAO {
           client =>
             logger.debug(s"Retrieving jobs by binary name $binName (states: $statuses)")
             zookeeperUtils.sync(client, binariesDir)
-            val jobs = zookeeperUtils.list(client, jobsDir)
-              .flatMap(id => readJobInfo(client, id))
             lazy val jobsUsingBinName = zookeeperUtils.list(client, jobsDir)
               .flatMap(id => readJobInfo(client, id))
               .filter(j => j.cp.map(_.appName).contains(binName))


### PR DESCRIPTION
Within the getJobsByBinaryName there was a call of
zookeeperUtils.list, which was never actually used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1318)
<!-- Reviewable:end -->
