### PR TITLE
feat(launcher): Pass extraJavaOptions to executor

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/util/ManagerLauncher.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/ManagerLauncher.scala
@@ -30,6 +30,7 @@ class ManagerLauncher(systemConfig: Config, contextConfig: Config, masterAddress
   var loggingOpts = getEnvironmentVariable("MANAGER_LOGGING_OPTS")
   val configOverloads = getEnvironmentVariable("CONFIG_OVERRIDES")
   val extraSparkConfigurations = getEnvironmentVariable("MANAGER_EXTRA_SPARK_CONFS")
+  val executorExtraOpts = getEnvironmentVariable("EXECUTOR_EXTRA_SPARK_CONFS")
   val extraJavaOPTS = getEnvironmentVariable("MANAGER_EXTRA_JAVA_OPTIONS")
   var gcOPTS = baseGCOPTS
   lazy val contextSuperviseModeEnabled: Option[Boolean] = Try(Some(
@@ -52,7 +53,7 @@ class ManagerLauncher(systemConfig: Config, contextConfig: Config, masterAddress
       launcher.setMaster(contextSparkMaster)
       launcher.setMainClass("spark.jobserver.JobManager")
       launcher.addAppArgs(masterAddress, contextActorName, getEnvironmentVariable("MANAGER_CONF_FILE"))
-      launcher.addSparkArg("--conf", s"spark.executor.extraJavaOptions=$loggingOpts")
+      launcher.addSparkArg("--conf", s"spark.executor.extraJavaOptions=$loggingOpts $executorExtraOpts")
       launcher.addSparkArg("--driver-java-options",
           s"$gcOPTS $baseJavaOPTS $loggingOpts $configOverloads $extraJavaOPTS")
 


### PR DESCRIPTION
The ManagerLauncher passes logging options to spark using the
config parameter spark.executor.extraJavaOptions.
This essentially overwrites all other extra java options
configured for the executor in other places (e.g. from the spark
defaults).

Therefore add another environment variable EXECUTOR_EXTRA_SPARK_CONFS
in which you can specify further extra java options that are
appended to the spark.executor.extraJavaOptions (after logging
opts).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1319)
<!-- Reviewable:end -->
