### PR TITLE
fix(test): fix Python style guide checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Spark Job Server is included in Datastax Enterprise!
 - [Target](http://www.target.com/)
 - [Branch](http://branch.io)
 - [Informatica](https://www.informatica.com/)
+= [Cadenz.ai](https://cadenz.ai/)
 
 ## Features
 

--- a/ci/install-python-dependencies.sh
+++ b/ci/install-python-dependencies.sh
@@ -4,3 +4,4 @@ pip install --upgrade pip
 pip install --user pyhocon
 pip3 install --user pyhocon
 pip install --user pep8
+pip install --user pycodestyle

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "Running sbt test and coverage report"
 sbt clean coverage testPython test coverageReport
-echo "Running pep8 over .py files"
+echo "Running pycodestyle over .py files"
 find job-server-python/src/python -name *.py -exec $HOME/.local/bin/pycodestyle {} +
 
 # report results

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -5,7 +5,7 @@ set -e
 echo "Running sbt test and coverage report"
 sbt clean coverage testPython test coverageReport
 echo "Running pep8 over .py files"
-find job-server-python/src/python -name *.py -exec $HOME/.local/bin/pep8 {} +
+find job-server-python/src/python -name *.py -exec $HOME/.local/bin/pycodestyle {} +
 
 # report results
 echo "Publishing code coverage report codecov.io"


### PR DESCRIPTION
* pep8 has been renamed to pycodestyle (GitHub issue #466)

**New behavior :**
pycodestyle is applied for code style guiding

This fixes issue #1320

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1321)
<!-- Reviewable:end -->
