### PR TITLE
fix(build): Change typesafe repository to https

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -107,7 +107,7 @@ object Dependencies {
   lazy val apiDeps = sparkDeps ++ miscDeps :+ typeSafeConfigDeps :+ scalaTestDep
 
   val repos = Seq(
-    "Typesafe Repo" at "http://repo.typesafe.com/typesafe/releases/",
+    "Typesafe Repo" at "https://repo.typesafe.com/typesafe/releases/",
     "sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/",
     "spray repo" at "http://repo.spray.io"
   )


### PR DESCRIPTION
Currently the build is broken and `sbt update` step doesn't work. This PR should fix the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1323)
<!-- Reviewable:end -->
