### PR TITLE
Fix Docker image

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -152,40 +152,22 @@ lazy val dockerSettings = Seq(
   dockerfile in docker := {
     val artifact = (assemblyOutputPath in assembly in jobServerExtras).value
     val artifactTargetPath = s"/app/${artifact.name}"
-
-    val sparkBuild = s"spark-${Versions.spark}"
-    val sparkBuildCmd = scalaBinaryVersion.value match {
-      case "2.11" =>
-        Versions.spark match {
-          case s if s.startsWith("1") => {"./make-distribution.sh -Dscala-2.11 -Phadoop-2.7 -Phive"}
-          case _ => {"./dev/make-distribution.sh -Dscala-2.11 -Phadoop-2.7 -Phive"}
-        }
-      case other => throw new RuntimeException(s"Scala version $other is not supported!")
-    }
-
     new sbtdocker.mutable.Dockerfile {
       from(s"openjdk:${Versions.java}")
       // Dockerfile best practices: https://docs.docker.com/articles/dockerfile_best-practices/
       expose(8090)
       expose(9999) // for JMX
-      env("MESOS_VERSION", Versions.mesos)
+      env("JOBSERVER_MEMORY", "1G")
+      env("SPARK_HOME", "/spark")
+      env("HADOOP_VERSION", Versions.hadoop)
+      env("SPARK_VERSION", Versions.spark)
+      env("SCALA_VERSION", scalaBinaryVersion.value)
       runRaw(
-        """echo "deb http://repos.mesosphere.io/ubuntu/ trusty main" > /etc/apt/sources.list.d/mesosphere.list && \
-                apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
-                apt-get -y update && \
-                apt-get -y install mesos=${MESOS_VERSION} && \
-                apt-get clean
+        """wget --no-verbose http://apache.mirror.iphh.net/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz && \
+        tar -xvzf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz && \
+        mv spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} ${SPARK_HOME} && \
+        rm spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
         """)
-      env("MAVEN_VERSION","3.3.9")
-      runRaw(
-        """mkdir -p /usr/share/maven /usr/share/maven/ref \
-          && curl -fsSL http://apache.osuosl.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz \
-          | tar -xzC /usr/share/maven --strip-components=1 \
-          && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
-        """)
-      env("MAVEN_HOME","/usr/share/maven")
-      env("MAVEN_CONFIG", "/.m2")
-
       copy(artifact, artifactTargetPath)
       copy(baseDirectory(_ / "bin" / "server_start.sh").value, file("app/server_start.sh"))
       copy(baseDirectory(_ / "bin" / "server_stop.sh").value, file("app/server_stop.sh"))
@@ -193,23 +175,9 @@ lazy val dockerSettings = Seq(
       copy(baseDirectory(_ / "config" / "log4j-stdout.properties").value, file("app/log4j-server.properties"))
       copy(baseDirectory(_ / "config" / "docker.conf").value, file("app/docker.conf"))
       copy(baseDirectory(_ / "config" / "docker.sh").value, file("app/settings.sh"))
-      // Including envs in Dockerfile makes it easy to override from docker command
-      env("JOBSERVER_MEMORY", "1G")
-      env("SPARK_HOME", "/spark")
+
       // Use a volume to persist database between container invocations
       run("mkdir", "-p", "/database")
-      runRaw(
-        s"""
-           |wget http://archive.apache.org/dist/spark/$sparkBuild/$sparkBuild.tgz && \\
-           |tar -xvf $sparkBuild.tgz && \\
-           |cd $sparkBuild && \\
-           |$sparkBuildCmd && \\
-           |cd .. && \\
-           |mv $sparkBuild/dist /spark && \\
-           |rm $sparkBuild.tgz && \\
-           |rm -r $sparkBuild
-        """.stripMargin.trim
-      )
       volume("/database")
       entryPoint("app/server_start.sh")
     }
@@ -219,8 +187,8 @@ lazy val dockerSettings = Seq(
       repository = "spark-jobserver",
       tag = Some(
         s"${version.value}" +
-          s".mesos-${Versions.mesos.split('-')(0)}" +
           s".spark-${Versions.spark}" +
+          s".hadoop-${Versions.hadoop}" +
           s".scala-${scalaBinaryVersion.value}" +
           s".jdk-${Versions.java}")
     )

--- a/build.sbt
+++ b/build.sbt
@@ -159,11 +159,11 @@ lazy val dockerSettings = Seq(
       expose(9999) // for JMX
       env("JOBSERVER_MEMORY", "1G")
       env("SPARK_HOME", "/spark")
-      env("HADOOP_VERSION", Versions.hadoop)
+      env("HADOOP_VERSION", Versions.hadoop.slice(0,3))
       env("SPARK_VERSION", Versions.spark)
       env("SCALA_VERSION", scalaBinaryVersion.value)
       runRaw(
-        """wget --no-verbose http://apache.mirror.iphh.net/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz && \
+        """wget --no-verbose http://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz && \
         tar -xvzf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz && \
         mv spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} ${SPARK_HOME} && \
         rm spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
@@ -183,7 +183,7 @@ lazy val dockerSettings = Seq(
     }
   },
   imageNames in docker := Seq(
-    sbtdocker.ImageName(namespace = Some("velvia"),
+    sbtdocker.ImageName(namespace = Some("sparkjobserver"),
       repository = "spark-jobserver",
       tag = Some(
         s"${version.value}" +

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -7,6 +7,7 @@
   - [Jars / Passing Arguments to the Start Script](#jars--passing-arguments-to-the-start-script)
   - [Database, Persistence, Logs](#database-persistence-logs)
   - [Marathon](#marathon)
+  - [Building docker image from the master branch](#building-docker-image-from-the-master-branch)
   - [Issues](#issues)
     - [I can't access a textfile](#i-cant-access-a-textfile)
     - [Timeouts](#timeouts)
@@ -96,6 +97,14 @@ Example Marathon config, thanks to @peterklipfel:
   "mem": 100,
   "instances": 1
 }
+```
+
+## Building docker image from the master branch
+
+If you want to build your docker version based on current master branch:
+
+```
+sbt docker
 ```
 
 ## Issues

--- a/job-server/config/docker.conf
+++ b/job-server/config/docker.conf
@@ -16,19 +16,37 @@ spark {
 
   jobserver {
     port = 8090
-    jobdao = spark.jobserver.io.JobSqlDAO
-
     context-per-jvm = true
 
-
-    sqldao {
-      # Directory where binaries are cached and default H2 driver stores its data
-      rootdir = /database
-
-      # Full JDBC URL / init string.  Sorry, needs to match above.
-      # Substitutions may be used to launch job-server, but leave it out here in the default or tests won't pass
-      jdbc.url = "jdbc:h2:file:/database/h2-db"
+    daorootdir = "/tmp/spark-jobserver"
+    binarydao {
+        class = spark.jobserver.io.BinarySqlDAO
     }
+    metadatadao {
+        class = spark.jobserver.io.MetaDataSqlDAO
+    }
+    sqldao {
+          # Slick database driver, full classpath
+          slick-driver = slick.driver.H2Driver
+
+          # JDBC driver, full classpath
+          jdbc-driver = org.h2.Driver
+
+          # Directory where default H2 driver stores its data. Only needed for H2.
+          rootdir = "/tmp/spark-jobserver/metasqldao/data"
+
+          jdbc {
+            url = "jdbc:h2:file:/tmp/spark-jobserver/metasqldao/data/h2-db"
+            user = "secret"
+            password = "secret"
+          }
+
+          dbcp {
+            maxactive = 20
+            maxidle = 10
+            initialsize = 10
+          }
+      }
   }
 
   # predefined Spark contexts


### PR DESCRIPTION
Currently the Jobserver Docker image build is broken. My assumption was that Mesos is not needed in the Docker image, so this change just makes Docker build much more simple and robust by installing pre-compiled Spark with Hadoop only. 

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**BREAKING CHANGES**
Mesos is removed from the Docker build.


Related issues: https://github.com/spark-jobserver/spark-jobserver/issues/1316, https://github.com/spark-jobserver/spark-jobserver/issues/1259

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1324)
<!-- Reviewable:end -->
