### PR TITLE
fix(dao): Jobs endpoint should return jobs in desc order

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/io/MetaDataSqlDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/MetaDataSqlDAO.scala
@@ -262,7 +262,7 @@ class MetaDataSqlDAO(config: Config) extends MetaDataDAO {
     } else {
       jobs
     }
-    val limitQuery = baseQuery.sortBy(_.startTime).take(limit)
+    val limitQuery = baseQuery.sortBy(_.startTime.desc).take(limit)
     // Transform the each row of the table into a map of JobInfo values
     for (r <- dbUtils.db.run(limitQuery.result)) yield {
       r.map(jobInfoFromRow)


### PR DESCRIPTION
This change implements the same change as PR https://github.com/spark-jobserver/spark-jobserver/pull/1311, but for the master branch.
`/jobs` endpoint should return jobs in desc order.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1325)
<!-- Reviewable:end -->
