### PR TITLE
fix(test): fix Python style guide checker

### DIFF
--- a/ci/install-python-dependencies.sh
+++ b/ci/install-python-dependencies.sh
@@ -4,3 +4,4 @@ pip install --upgrade pip
 pip install --user pyhocon
 pip3 install --user pyhocon
 pip install --user pep8
+pip install --user pycodestyle

--- a/ci/install-python-dependencies.sh
+++ b/ci/install-python-dependencies.sh
@@ -3,5 +3,4 @@ set -e
 pip install --upgrade pip
 pip install --user pyhocon
 pip3 install --user pyhocon
-pip install --user pep8
 pip install --user pycodestyle

--- a/job-server-python/src/python/test/apitests.py
+++ b/job-server-python/src/python/test/apitests.py
@@ -146,5 +146,6 @@ class TestSJSApi(unittest.TestCase):
         result = job.run_job(sqlContext, None, jobData)
         self.assertEqual([(20, 1250), (21, 1500)], result)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -4,8 +4,8 @@ set -e
 
 echo "Running sbt test and coverage report"
 sbt clean coverage testPython test coverageReport
-echo "Running pep8 over .py files"
-find job-server-python/src/python -name *.py -exec $HOME/.local/bin/pep8 {} +
+echo "Running pycodestyle over .py files"
+find job-server-python/src/python -name *.py -exec $HOME/.local/bin/pycodestyle {} +
 
 # report results
 echo "Publishing code coverage report codecov.io"


### PR DESCRIPTION
* pep8 has been renamed to pycodestyle

New behavior:
pycodestyle is applied for code style guiding

This fixes issue #1320

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1327)
<!-- Reviewable:end -->
