### PR TITLE
fix(docker): Adapt docker config to updated library versions

### DIFF
--- a/job-server/config/docker.conf
+++ b/job-server/config/docker.conf
@@ -2,6 +2,8 @@
 # You can easily override the spark master through SPARK_MASTER env variable
 #
 # Spark Cluster / Job Server configuration
+flyway.locations="db/h2/migration"
+
 spark {
   # spark.master will be passed to each job's JobContext
   # local[...], yarn, mesos://... or spark://...
@@ -27,7 +29,7 @@ spark {
     }
     sqldao {
           # Slick database driver, full classpath
-          slick-driver = slick.driver.H2Driver
+          slick-driver = slick.jdbc.H2Profile
 
           # JDBC driver, full classpath
           jdbc-driver = org.h2.Driver

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,6 +16,6 @@ addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")
 
-addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.5.0")
+addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.8.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.4.0")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Current behavior :** 

After the upgrade to Scala 2.12 configuration file for Docker image is incorrect.
Also, version of `sbt-docker` plugin should be bumped because of the following exception:
```
java.lang.RuntimeException: Could not parse image id
```


**Other information**:

To run Jobserver with Scala 2.12 in Docker Spark 2.4.2 should be used, because it's the only Spark 2.4.x version, which was compiled with Scala 2.12. 
There is also a compiled version of Spark with Scala 2.12 for other releases, but without Hadoop. Docker image has some dependency issues in this case. Will address this issue in upcoming PRs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1336)
<!-- Reviewable:end -->
