### PR TITLE
bug: backward compatibility of "python-archive"

### DIFF
--- a/job-server/src/main/scala/spark/jobserver/io/InfoDefinitions.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/InfoDefinitions.scala
@@ -59,6 +59,7 @@ object BinaryType {
     case m if m.value == Jar.mediaType => Some(Jar)
     case m if m.value == Wheel.mediaType => Some(Wheel)
     case m if m.value == Egg.mediaType => Some(Egg)
+    case m if m.value == "application/python-archive" => Some(Egg) // added for backward compatibility
     case m if m.value == "python-archive" => Some(Egg) // added for backward compatibility
     case _ => None
   }


### PR DESCRIPTION
In the previous versions "application/python-archive" was used as MIME type for python binaries. I mistakenly use "python-archive" for backwards compatibility. This commits maps the correct MIME type to Python eggs.

**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1354)
<!-- Reviewable:end -->
