### PR TITLE
Update lib versions

### DIFF
--- a/akka-app/README.md
+++ b/akka-app/README.md
@@ -13,7 +13,6 @@ akka_app defines a standard stack for Akka applications, as well as traits and u
 ## The included Akka Stack
 
 * Akka 2.2.4 (including remote + testkit)
-* JodaTime
 * Yammer Metrics for stats and instrumentation
 * spray-json for JSON serialization
 * akka-http for embedded web server, with some common routes like /metricz and /statusz

--- a/akka-app/src/test/scala/spark/jobserver/common/akka/ActorMetricsSpec.scala
+++ b/akka-app/src/test/scala/spark/jobserver/common/akka/ActorMetricsSpec.scala
@@ -1,12 +1,14 @@
 package spark.jobserver.common.akka
 
-import org.scalatest.{BeforeAndAfterAll, Matchers, FunSpec}
+import org.scalatest.BeforeAndAfterAll
 import akka.testkit.{TestKit, TestActorRef}
 
 import akka.actor.{Actor, ActorSystem}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class ActorMetricsSpec extends FunSpec with Matchers with BeforeAndAfterAll {
+class ActorMetricsSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll {
   implicit val system = ActorSystem("test")
 
   override def afterAll(): Unit = {

--- a/akka-app/src/test/scala/spark/jobserver/common/akka/ActorStackSpec.scala
+++ b/akka-app/src/test/scala/spark/jobserver/common/akka/ActorStackSpec.scala
@@ -1,9 +1,11 @@
 package spark.jobserver.common.akka
 
-import org.scalatest.{BeforeAndAfterAll, Matchers, FunSpec}
+import org.scalatest.BeforeAndAfterAll
 import akka.testkit.{TestKit, TestActorRef}
 
 import akka.actor.{Actor, ActorSystem}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 
 class DummyActor extends ActorStack {
@@ -22,7 +24,7 @@ trait AddPrefix extends ActorStack {
   }
 }
 
-class ActorStackSpec extends FunSpec with Matchers with BeforeAndAfterAll {
+class ActorStackSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll {
   implicit val system = ActorSystem("test")
 
   override def afterAll(): Unit = {

--- a/akka-app/src/test/scala/spark/jobserver/common/akka/actor/ReaperSpec.scala
+++ b/akka-app/src/test/scala/spark/jobserver/common/akka/actor/ReaperSpec.scala
@@ -2,8 +2,10 @@ package spark.jobserver.common.akka.actor
 
 import akka.actor.{ActorSystem, Props, ActorRef}
 import akka.testkit.{TestKit, ImplicitSender, TestProbe}
-import org.scalatest.{MustMatchers, FunSpecLike, BeforeAndAfterAll}
+import org.scalatest.BeforeAndAfterAll
 import spark.jobserver.common.akka.AkkaTestUtils
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.must.Matchers
 
 // Our test reaper.  Sends the snooper a message when all
 // the souls have been reaped
@@ -12,9 +14,9 @@ class TestReaper(snooper: ActorRef) extends Reaper {
 }
 
 class ReaperSpec extends TestKit(ActorSystem("ReaperSpec")) with ImplicitSender
-    with FunSpecLike
+    with AnyFunSpecLike
     with BeforeAndAfterAll
-    with MustMatchers {
+    with Matchers {
 
   import Reaper._
   import scala.concurrent.duration._

--- a/akka-app/src/test/scala/spark/jobserver/common/akka/web/CommonRoutesSpec.scala
+++ b/akka-app/src/test/scala/spark/jobserver/common/akka/web/CommonRoutesSpec.scala
@@ -3,14 +3,15 @@ package spark.jobserver.common.akka.web
 import java.util.concurrent.TimeUnit
 
 import akka.testkit.TestKit
-import org.scalatest.{FunSpec, Matchers}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.yammer.metrics.Metrics
 import com.yammer.metrics.core.Gauge
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes.OK
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class CommonRoutesSpec extends FunSpec with Matchers with ScalatestRouteTest with CommonRoutes {
+class CommonRoutesSpec extends AnyFunSpec with Matchers with ScalatestRouteTest with CommonRoutes {
   def actorRefFactory: ActorSystem = system
 
   val metricCounter = Metrics.newCounter(getClass, "test-counter")

--- a/akka-app/src/test/scala/spark/jobserver/common/akka/web/JsonUtilsSpec.scala
+++ b/akka-app/src/test/scala/spark/jobserver/common/akka/web/JsonUtilsSpec.scala
@@ -1,11 +1,12 @@
 package spark.jobserver.common.akka.web
 
-import org.scalatest.{FunSpec, Matchers}
 import spray.json.JsonParser.ParsingException
 
 import java.time.ZonedDateTime
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class JsonUtilsSpec extends FunSpec with Matchers {
+class JsonUtilsSpec extends AnyFunSpec with Matchers {
   import spray.json._
   import spray.json.DefaultJsonProtocol._
 

--- a/akka-app/src/test/scala/spark/jobserver/common/akka/web/JsonUtilsSpec.scala
+++ b/akka-app/src/test/scala/spark/jobserver/common/akka/web/JsonUtilsSpec.scala
@@ -1,8 +1,9 @@
 package spark.jobserver.common.akka.web
 
-import org.joda.time.DateTime
-import org.scalatest.{Matchers, FunSpec}
+import org.scalatest.{FunSpec, Matchers}
 import spray.json.JsonParser.ParsingException
+
+import java.time.ZonedDateTime
 
 class JsonUtilsSpec extends FunSpec with Matchers {
   import spray.json._
@@ -65,7 +66,7 @@ class JsonUtilsSpec extends FunSpec with Matchers {
     it("should serialize unknown types to their string representations") {
       val expected = "[1,2,\"" + Dt1 + "\"]"
       import JsonUtils._
-      Seq(1, 2, DateTime.parse(Dt1)).toJson.compactPrint should equal (expected)
+      Seq(1, 2, ZonedDateTime.parse(Dt1)).toJson.compactPrint should equal (expected)
     }
 
     it("should serialize java.util.Maps as similarly to scala Maps") {

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -11,7 +11,6 @@
   - [Job server won't start / cannot bind to 0.0.0.0:8090](#job-server-wont-start--cannot-bind-to-00008090)
   - [Job Server Doesn't Connect to Spark Cluster](#job-server-doesnt-connect-to-spark-cluster)
   - [Exception in thread "main" java.lang.NoSuchMethodError: akka.actor.ActorRefFactory.dispatcher()Lscala/concurrent/ExecutionContextExecutor;](#exception-in-thread-main-javalangnosuchmethoderror-akkaactoractorreffactorydispatcherlscalaconcurrentexecutioncontextexecutor)
-  - [java.lang.NoSuchMethodError: org.joda.time.DateTime.now()](#javalangnosuchmethoderror-orgjodatimedatetimenow)
   - [I am running CDH 5.3 and Job Server doesn't work](#i-am-running-cdh-53-and-job-server-doesnt-work)
   - [I want to run job-server on Windows](#i-want-to-run-job-server-on-windows)
   - [Akka Deadletters / Workers disconnect from Job Server](#akka-deadletters--workers-disconnect-from-job-server)
@@ -98,15 +97,6 @@ after this fixed, I can run jobs submitted from a remote job server successfully
 If you are running CDH 5.3 or older, you may have an incompatible version of Akka bundled together.  :(  Fortunately, one of our users has put together a [branch that works](https://github.com/bjoernlohrmann/spark-jobserver/tree/cdh-5.3) ... try that out!
 
 (Older instructions) Try modifying the version of Akka included with spark-jobserver to match the one in CDH (2.2.4, I think), or upgrade to CDH 5.4.   If you are on CDH 5.4, check that `sparkVersion` in `Dependencies.scala` matches CDH.  Or see [isse #154](https://github.com/spark-jobserver/spark-jobserver/issues/154).
-
-## java.lang.NoSuchMethodError: org.joda.time.DateTime.now()
-
-This time the problem is caused by incompatible class versions of the joda.time package in Hive and the Spark Job Server on Cloudera (java.lang.NoSuchMethodError: org.joda.time.DateTime.now()Lorg/joda/time/DateTime exception in the spark job server log). To solve the problem execute the following two commands on the machine the Job Server is installed:
-
-    sed -i -e 's#--driver-class-path.*SPARK_HOME/../hive/lib/.*##' /opt/spark-job-server/manager_start.sh
-    sed -i -e 's#--driver-class-path.*SPARK_HOME/../hive/lib/.*##' /opt/spark-job-server/server_start.sh  
-
-This removes the problematic driver class path entries from the two spark job server scripts.  (from @koetter)
 
 ## I am running CDH 5.3 and Job Server doesn't work
 

--- a/job-server-api/src/main/scala/spark/jobserver/context/SparkContextFactory.scala
+++ b/job-server-api/src/main/scala/spark/jobserver/context/SparkContextFactory.scala
@@ -2,7 +2,6 @@ package spark.jobserver.context
 
 import com.typesafe.config.Config
 import org.apache.spark.{SparkConf, SparkContext}
-import org.joda.time.DateTime
 import org.scalactic._
 import org.slf4j.LoggerFactory
 import spark.jobserver.{ContextLike, JobCache, SparkJob}

--- a/job-server-api/src/test/scala/util/SparkJobUtilsSpec.scala
+++ b/job-server-api/src/test/scala/util/SparkJobUtilsSpec.scala
@@ -2,9 +2,10 @@ package spark.jobserver.util
 
 import com.typesafe.config.ConfigFactory
 import org.apache.spark.SparkConf
-import org.scalatest.{Matchers, FunSpec}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class SparkJobUtilsSpec extends FunSpec with Matchers {
+class SparkJobUtilsSpec extends AnyFunSpec with Matchers {
   import collection.JavaConverters._
 
   val config = ConfigFactory.parseMap(Map(

--- a/job-server-api/src/test/scala/util/SparkMasterProviderSpec.scala
+++ b/job-server-api/src/test/scala/util/SparkMasterProviderSpec.scala
@@ -2,9 +2,10 @@ package spark.jobserver.util
 
 import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.spark.SparkConf
-import org.scalatest.{Matchers, FunSpec}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class SparkMasterProviderSpec extends FunSpec with Matchers {
+class SparkMasterProviderSpec extends AnyFunSpec with Matchers {
 
   import collection.JavaConverters._
 

--- a/job-server-extras/src/main/scala/spark/jobserver/python/PythonContextFactory.scala
+++ b/job-server-extras/src/main/scala/spark/jobserver/python/PythonContextFactory.scala
@@ -7,7 +7,6 @@ import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql.{SQLContext, SparkSession}
 import org.apache.spark.sql.hive.HiveContext
 import org.apache.spark.{SparkConf, SparkContext}
-import org.joda.time.DateTime
 import org.scalactic.{Bad, Good, Or}
 import org.slf4j.LoggerFactory
 import spark.jobserver._

--- a/job-server-extras/src/test/scala/spark/jobserver/NamedObjectsSpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/NamedObjectsSpec.scala
@@ -7,14 +7,16 @@ import org.apache.spark.sql.{Row, SQLContext}
 import org.apache.spark.sql.types._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import scala.concurrent.duration.{FiniteDuration, _}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
 /**
  * this Spec is a more complex version of the same one in the job-server project,
  * it uses a combination of RDDs and DataFrames instead of just RDDs
  */
-class NamedObjectsSpec extends TestKit(ActorSystem("NamedObjectsSpec")) with FunSpecLike
+class NamedObjectsSpec extends TestKit(ActorSystem("NamedObjectsSpec")) with AnyFunSpecLike
     with ImplicitSender with Matchers with BeforeAndAfter with BeforeAndAfterAll {
 
   implicit def rddPersister: NamedObjectPersister[NamedRDD[Int]] = new RDDPersister[Int]

--- a/job-server-extras/src/test/scala/spark/jobserver/python/PythonSessionContextFactorySpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/python/PythonSessionContextFactorySpec.scala
@@ -1,7 +1,7 @@
 package spark.jobserver.python
 
 import com.typesafe.config.{Config, ConfigFactory}
-import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfter
 import java.nio.file.Files
 import java.nio.file.Paths
 
@@ -13,6 +13,8 @@ import spark.jobserver.util.{JobserverConfig, SparkJobUtils}
 
 import scala.collection.JavaConverters._
 import org.scalatest._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 object PythonSessionContextFactorySpec {
 
@@ -58,7 +60,7 @@ class TestPythonSessionContextFactory extends PythonSessionContextFactory {
   }
 }
 
-class PythonSessionContextFactorySpec extends FunSpec with Matchers with BeforeAndAfter
+class PythonSessionContextFactorySpec extends AnyFunSpec with Matchers with BeforeAndAfter
 with BeforeAndAfterAll {
   import PythonSparkContextFactorySpec._
 

--- a/job-server-extras/src/test/scala/spark/jobserver/python/PythonSessionContextFactorySpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/python/PythonSessionContextFactorySpec.scala
@@ -1,7 +1,6 @@
 package spark.jobserver.python
 
 import com.typesafe.config.{Config, ConfigFactory}
-import org.joda.time.DateTime
 import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
 import java.nio.file.Files
 import java.nio.file.Paths

--- a/job-server-extras/src/test/scala/spark/jobserver/python/PythonSparkContextFactorySpec.scala
+++ b/job-server-extras/src/test/scala/spark/jobserver/python/PythonSparkContextFactorySpec.scala
@@ -4,7 +4,6 @@ import java.io.File
 
 import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.spark.SparkConf
-import org.joda.time.DateTime
 import spark.jobserver._
 import spark.jobserver.api.JobEnvironment
 import spark.jobserver.util.JobserverConfig

--- a/job-server-integration-tests/src/main/scala/spark/jobserver/integrationtests/tests/BasicApiTests.scala
+++ b/job-server-integration-tests/src/main/scala/spark/jobserver/integrationtests/tests/BasicApiTests.scala
@@ -1,17 +1,16 @@
 package spark.jobserver.integrationtests.tests
 
-import org.joda.time.DateTime
 import org.scalatest.BeforeAndAfterAllConfigMap
 import org.scalatest.ConfigMap
 import org.scalatest.FreeSpec
 import org.scalatest.Matchers
-
 import com.softwaremill.sttp._
-
 import play.api.libs.json.JsObject
 import play.api.libs.json.Json
 import spark.jobserver.integrationtests.util.TestHelper
 import com.typesafe.config.Config
+
+import java.time.ZonedDateTime
 
 class BasicApiTests extends FreeSpec with Matchers with BeforeAndAfterAllConfigMap {
 
@@ -37,7 +36,7 @@ class BasicApiTests extends FreeSpec with Matchers with BeforeAndAfterAllConfigM
   val streamingMain = "spark.jobserver.StreamingTestJob"
 
   "/binaries" - {
-    var binaryUploadDate: DateTime = null
+    var binaryUploadDate: ZonedDateTime = null
 
     "POST /binaries/<app> should upload a binary" in {
       val byteArray = TestHelper.fileToByteArray(bin)
@@ -56,7 +55,7 @@ class BasicApiTests extends FreeSpec with Matchers with BeforeAndAfterAllConfigM
       val json = Json.parse(response.body.merge)
       val testbin = (json \ appName)
       testbin.isDefined should equal(true)
-      binaryUploadDate = new DateTime((testbin \ "upload-time").as[String])
+      binaryUploadDate = ZonedDateTime.parse((testbin \ "upload-time").as[String])
     }
 
     "GET /binaries/<app> should retrieve a specific binary" in {
@@ -83,7 +82,8 @@ class BasicApiTests extends FreeSpec with Matchers with BeforeAndAfterAllConfigM
       val json = Json.parse(getresponse.body.merge)
       val testbin = (json \ appName)
       testbin.isDefined should equal(true)
-      val newUploadDate = new DateTime((testbin \ "upload-time").as[String])
+      // TODO check
+      val newUploadDate = ZonedDateTime.parse((testbin \ "upload-time").as[String])
       newUploadDate.isAfter(binaryUploadDate) should equal(true)
     }
 

--- a/job-server-python/src/test/scala/spark/jobserver/python/SubprocessSpec.scala
+++ b/job-server-python/src/test/scala/spark/jobserver/python/SubprocessSpec.scala
@@ -8,12 +8,14 @@ import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.hive.HiveContext
 import org.apache.spark.{SparkConf, SparkContext}
-import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest._
 import spark.jobserver.util.JobserverPy4jGateway
 
 import scala.collection.JavaConverters._
 import scala.sys.process.Process
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 object SubprocessSpec {
   def getPythonDir(pathRelativeToSubProject: String): String = {
@@ -83,7 +85,7 @@ trait IdentifiedContext {
   def contextType: String
 }
 
-class SubprocessSpec extends FunSpec with Matchers with BeforeAndAfter with BeforeAndAfterAll {
+class SubprocessSpec extends AnyFunSpec with Matchers with BeforeAndAfter with BeforeAndAfterAll {
 
   import SubprocessSpec._
   val pythonPathDelimiter : String = if (System.getProperty("os.name").indexOf("Win") >= 0) ";" else ":"

--- a/job-server/src/main/scala/spark/jobserver/BinaryManager.scala
+++ b/job-server/src/main/scala/spark/jobserver/BinaryManager.scala
@@ -1,23 +1,20 @@
 package spark.jobserver
 
-import java.io.File
-import java.net.URI
-
 import akka.actor.ActorRef
 import akka.util.Timeout
 import spark.jobserver.io.JobDAOActor.{
   BinaryInfosForCp, BinaryNotFound, DeleteBinaryResult, GetBinaryInfosForCpFailed, SaveBinaryResult}
 import spark.jobserver.io.{BinaryInfo, BinaryType, JobDAOActor, JobInfo, JobStatus}
 import spark.jobserver.util.{JarUtils, NoSuchBinaryException}
-import org.joda.time.DateTime
-import java.nio.file.{Files, Paths}
 
-import com.typesafe.config.Config
+import java.nio.file.{Files, Paths}
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 import spark.jobserver.common.akka.InstrumentedActor
+
+import java.time.ZonedDateTime
 
 /** Message for storing a JAR for an application given the byte array of the JAR file */
 case class StoreBinary(appName: String, binaryType: BinaryType, binBytes: Array[Byte])
@@ -61,7 +58,7 @@ class BinaryManager(jobDao: ActorRef) extends InstrumentedActor {
   private def saveBinary(appName: String,
                          binaryType: BinaryType,
                          binBytes: Array[Byte]): Future[Try[Unit]] = {
-    val uploadTime = DateTime.now()
+    val uploadTime = ZonedDateTime.now()
     (jobDao ? JobDAOActor.SaveBinary(appName, binaryType, uploadTime, binBytes)).
       mapTo[SaveBinaryResult].map(_.outcome)
   }

--- a/job-server/src/main/scala/spark/jobserver/CommonMessages.scala
+++ b/job-server/src/main/scala/spark/jobserver/CommonMessages.scala
@@ -1,8 +1,9 @@
 package spark.jobserver
 
 import akka.actor.ActorRef
-import org.joda.time.DateTime
 import spark.jobserver.io.JobInfo
+
+import java.time.ZonedDateTime
 
 trait StatusMessage {
   val jobId: String
@@ -12,10 +13,10 @@ trait StatusMessage {
 object CommonMessages {
   // job status messages
   case class JobStarted(jobId: String, jobInfo: JobInfo) extends StatusMessage
-  case class JobFinished(jobId: String, endTime: DateTime) extends StatusMessage
-  case class JobValidationFailed(jobId: String, endTime: DateTime, err: Throwable) extends StatusMessage
-  case class JobErroredOut(jobId: String, endTime: DateTime, err: Throwable) extends StatusMessage
-  case class JobKilled(jobId: String, endTime: DateTime) extends StatusMessage
+  case class JobFinished(jobId: String, endTime: ZonedDateTime) extends StatusMessage
+  case class JobValidationFailed(jobId: String, endTime: ZonedDateTime, err: Throwable) extends StatusMessage
+  case class JobErroredOut(jobId: String, endTime: ZonedDateTime, err: Throwable) extends StatusMessage
+  case class JobKilled(jobId: String, endTime: ZonedDateTime) extends StatusMessage
   case class JobRestartFailed(jobId: String, err: Throwable) extends StatusMessage
 
   /**

--- a/job-server/src/main/scala/spark/jobserver/DataManagerActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/DataManagerActor.scala
@@ -2,8 +2,9 @@ package spark.jobserver
 
 import akka.actor.{ActorRef, Props}
 import spark.jobserver.io.DataFileDAO
-import org.joda.time.DateTime
 import spark.jobserver.common.akka.InstrumentedActor
+
+import java.time.ZonedDateTime
 import scala.collection.mutable
 
 object DataManagerActor {
@@ -63,7 +64,7 @@ class DataManagerActor(fileDao: DataFileDAO) extends InstrumentedActor {
 
     case StoreData(aName, aBytes) =>
       logger.info("Storing data in file prefix {}, {} bytes", aName, aBytes.length)
-      val uploadTime = DateTime.now()
+      val uploadTime = ZonedDateTime.now()
       val fName = fileDao.saveFile(aName, uploadTime, aBytes)
       remoteCaches(fName) = mutable.HashSet.empty[ActorRef]
       sender ! Stored(fName)

--- a/job-server/src/main/scala/spark/jobserver/DependenciesCache.scala
+++ b/job-server/src/main/scala/spark/jobserver/DependenciesCache.scala
@@ -2,7 +2,6 @@ package spark.jobserver
 
 import akka.actor.ActorRef
 import akka.util.Timeout
-import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
 import spark.jobserver.io.{BinaryType, JobDAOActor}
 import spark.jobserver.util.{LRUCache, NoSuchBinaryException}
@@ -11,12 +10,14 @@ import scala.concurrent.duration._
 import scala.concurrent.Await
 import akka.pattern.ask
 
+import java.time.ZonedDateTime
+
 class DependenciesCache(maxEntries: Int, dao: ActorRef) {
-  private val cache = new LRUCache[(String, DateTime, BinaryType), String](maxEntries)
+  private val cache = new LRUCache[(String, ZonedDateTime, BinaryType), String](maxEntries)
   private val logger = LoggerFactory.getLogger(getClass)
   implicit val daoAskTimeout: Timeout = Timeout(60 seconds)
 
-  def getBinaryPath(appName: String, binType: BinaryType, uploadTime: DateTime): String = {
+  def getBinaryPath(appName: String, binType: BinaryType, uploadTime: ZonedDateTime): String = {
     val binPath = cache.get((appName, uploadTime, binType))
     if (binPath.isDefined) {
       binPath.get

--- a/job-server/src/main/scala/spark/jobserver/JobServer.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobServer.scala
@@ -5,12 +5,11 @@ import akka.util.Timeout
 import akka.pattern.ask
 import akka.cluster.Cluster
 import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
+
 import java.io.File
 import java.util.concurrent.{TimeUnit, TimeoutException}
-
 import spark.jobserver.io._
 import spark.jobserver.util._
-import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
@@ -21,6 +20,7 @@ import scala.collection.mutable.ListBuffer
 import com.google.common.annotations.VisibleForTesting
 import spark.jobserver.io.zookeeper.AutoPurgeActor
 
+import java.time.ZonedDateTime
 import scala.util.control.NonFatal
 
 /**
@@ -277,7 +277,7 @@ object JobServer {
     val logMsg = s"Reconnecting to context $ctxName failed ->" +
       s"updating status of context $ctxName and related jobs to error"
     logger.info(logMsg)
-    val updatedContextInfo = contextInfo.copy(endTime = Option(DateTime.now()),
+    val updatedContextInfo = contextInfo.copy(endTime = Option(ZonedDateTime.now()),
         state = ContextStatus.Error, error = Some(ContextReconnectFailedException()))
     jobDaoActor ! JobDAOActor.SaveContextInfo(updatedContextInfo)
     try{
@@ -286,7 +286,8 @@ object JobServer {
         case Success(JobDAOActor.JobInfos(jobInfos)) =>
           jobInfos.foreach(jobInfo => {
           jobDaoActor ! JobDAOActor.SaveJobInfo(jobInfo.copy(state = JobStatus.Error,
-              endTime = Some(DateTime.now()), error = Some(ErrorData(ContextReconnectFailedException()))))
+              endTime = Some(ZonedDateTime.now()),
+              error = Some(ErrorData(ContextReconnectFailedException()))))
           })
         case Success(unknownResponse) =>
           logger.error(s"Received unexpected response: $unknownResponse")

--- a/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/LocalContextSupervisorActor.scala
@@ -5,7 +5,7 @@ import akka.pattern.ask
 import akka.util.Timeout
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import spark.jobserver.JobManagerActor.{GetContexData, ContexData}
+import spark.jobserver.JobManagerActor.{ContexData, GetContexData}
 import spark.jobserver.JobManagerActor.{SparkContextAlive, SparkContextDead, SparkContextStatus}
 import spark.jobserver.util.SparkJobUtils
 
@@ -14,9 +14,10 @@ import scala.concurrent.Await
 import scala.util.{Failure, Success, Try}
 import spark.jobserver.common.akka.InstrumentedActor
 import akka.pattern.gracefulStop
-import org.joda.time.DateTime
 import spark.jobserver.io.JobDAOActor.CleanContextJobInfos
 import spark.jobserver.io.ContextInfo
+
+import java.time.ZonedDateTime
 
 /** Messages common to all ContextSupervisors */
 object ContextSupervisor {
@@ -193,7 +194,7 @@ class LocalContextSupervisorActor(dao: ActorRef, dataManagerActor: ActorRef) ext
       val name = actorRef.path.name
       logger.info("Actor terminated: " + name)
       contexts.remove(name)
-      dao ! CleanContextJobInfos(name, DateTime.now())
+      dao ! CleanContextJobInfos(name, ZonedDateTime.now())
   }
 
   private def startContext(name: String, contextConfig: Config, isAdHoc: Boolean, timeoutSecs: Int = 1)

--- a/job-server/src/main/scala/spark/jobserver/WebApi.scala
+++ b/job-server/src/main/scala/spark/jobserver/WebApi.scala
@@ -12,7 +12,6 @@ import akka.pattern.ask
 import akka.util.Timeout
 import ch.megard.akka.http.cors.scaladsl.CorsDirectives._
 import com.typesafe.config._
-import org.joda.time.DateTime
 import org.slf4j.{Logger, LoggerFactory}
 import spark.jobserver.auth.Permissions._
 import spark.jobserver.auth.SJSAccessControl._
@@ -26,6 +25,8 @@ import spark.jobserver.util.ResultMarshalling._
 import spark.jobserver.util._
 
 import java.net.{MalformedURLException, URLDecoder}
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatterBuilder
 import java.util.NoSuchElementException
 import java.util.concurrent.TimeUnit
 import javax.net.ssl.SSLContext
@@ -35,6 +36,7 @@ import scala.util.Try
 object WebApi extends SprayJsonSupport {
   import spray.json.DefaultJsonProtocol._
 
+  private val df = new DateTimeFormatterBuilder().appendInstant(3).toFormatter()
   val logger: Logger = LoggerFactory.getLogger(getClass)
 
   def completeWithErrorStatus(ctx: RequestContext, errMsg: String, stcode: StatusCode,
@@ -72,8 +74,8 @@ object WebApi extends SprayJsonSupport {
       case contextInfo: ContextInfo =>
         map("id") = contextInfo.id
         map("name") = contextInfo.name
-        map("startTime") = contextInfo.startTime.toString()
-        map("endTime") = if (contextInfo.endTime.isDefined) contextInfo.endTime.get.toString else "Empty"
+        map("startTime") = df.format(contextInfo.startTime)
+        map("endTime") = contextInfo.endTime.map(df.format).getOrElse("Empty")
         map("state") = contextInfo.state
       case name: String =>
         map("name") = name
@@ -238,7 +240,7 @@ class WebApi(system: ActorSystem,
             case LastBinaryInfo(Some(bin)) =>
               val res = Map("app-name" -> bin.appName,
                   "binary-type" -> bin.binaryType.name,
-                  "upload-time" -> bin.uploadTime.toString())
+                  "upload-time" -> df.format(bin.uploadTime))
               ctx.complete(StatusCodes.OK, res)
             case LastBinaryInfo(None) =>
               completeWithErrorStatus(ctx, s"Can't find binary with name $appName", StatusCodes.NotFound)
@@ -258,11 +260,11 @@ class WebApi(system: ActorSystem,
 
         val timer = binGet.time()
         val future = (binaryManager ? ListBinaries(None)).
-          mapTo[collection.Map[String, (BinaryType, DateTime)]]
+          mapTo[collection.Map[String, (BinaryType, ZonedDateTime)]]
         future.flatMap { binTimeMap =>
           val stringTimeMap = binTimeMap.map {
             case (app, (binType, dt)) =>
-              (app, Map("binary-type" -> binType.name, "upload-time" -> dt.toString()))
+              (app, Map("binary-type" -> binType.name, "upload-time" -> df.format(dt)))
           }.toMap
           ctx.complete(stringTimeMap)
         }.recoverWith {

--- a/job-server/src/main/scala/spark/jobserver/io/DataFileDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/DataFileDAO.scala
@@ -1,13 +1,15 @@
 package spark.jobserver.io
 
 import com.typesafe.config._
+
 import java.io._
 import java.nio.file.Files
-
 import org.apache.commons.io.FileUtils
-import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
+import spark.jobserver.util.JsonProtocols
 
+import java.time.format.DateTimeFormatter
+import java.time.{Instant, ZoneId, ZonedDateTime}
 import scala.collection.mutable
 
 object DataFileDAO {
@@ -15,7 +17,7 @@ object DataFileDAO {
   val META_DATA_FILE_NAME = "files.data"
 }
 
-case class DataFileInfo(appName: String, uploadTime: DateTime)
+case class DataFileInfo(appName: String, uploadTime: ZonedDateTime)
 
 class DataFileDAO(config: Config) {
   private val logger = LoggerFactory.getLogger(getClass)
@@ -73,7 +75,7 @@ class DataFileDAO(config: Config) {
     * save the given data into a new file with the given prefix, a time stamp is appended to
     * ensure uniqueness
     */
-  def saveFile(aNamePrefix: String, uploadTime: DateTime, aBytes: Array[Byte]): String = {
+  def saveFile(aNamePrefix: String, uploadTime: ZonedDateTime, aBytes: Array[Byte]): String = {
     // The order is important. Save the file first and then log it into meta data file.
     val outFile = new File(rootDir, createFileName(aNamePrefix, uploadTime) + DataFileDAO.EXTENSION)
     val name = outFile.getAbsolutePath
@@ -96,7 +98,7 @@ class DataFileDAO(config: Config) {
 
   private def writeFileInfo(out: DataOutputStream, aInfo: DataFileInfo) {
     out.writeUTF(aInfo.appName)
-    out.writeLong(aInfo.uploadTime.getMillis)
+    out.writeLong(aInfo.uploadTime.toInstant.toEpochMilli)
   }
 
   def readFile(aName: String): Array[Byte] = {
@@ -134,7 +136,8 @@ class DataFileDAO(config: Config) {
     false
   }
 
-  private def readFileInfo(in: DataInputStream) = DataFileInfo(in.readUTF, new DateTime(in.readLong))
+  private def readFileInfo(in: DataInputStream) = DataFileInfo(in.readUTF,
+    ZonedDateTime.ofInstant(Instant.ofEpochMilli(in.readLong), ZoneId.systemDefault()))
 
   private def addFile(aName: String) {
     files += aName
@@ -142,8 +145,9 @@ class DataFileDAO(config: Config) {
 
   def listFiles: Set[String] = files.toSet
 
-  private def createFileName(aName: String, uploadTime: DateTime): String =
-    aName + "-" + uploadTime.toString().replace(':', '_')
+  private val formatter = DateTimeFormatter.ofPattern(JsonProtocols.DATE_PATTERN)
+  private def createFileName(aName: String, uploadTime: ZonedDateTime): String =
+    aName + "-" + formatter.format(uploadTime).replace(':', '_')
 
   private def readError(in: DataInputStream) = {
     val error = in.readUTF()

--- a/job-server/src/main/scala/spark/jobserver/io/FileCacher.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/FileCacher.scala
@@ -1,10 +1,11 @@
 package spark.jobserver.io
 
 import java.io.{BufferedOutputStream, File, FileOutputStream, FilenameFilter}
-
-import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
 import spark.jobserver.util.Utils
+
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 
 trait FileCacher {
 
@@ -12,16 +13,18 @@ trait FileCacher {
   val rootDirFile: File
 
   private val logger = LoggerFactory.getLogger(getClass)
+  private val df = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss_SSS")
 
 
   // date format
   val Pattern = "\\d{8}_\\d{6}_\\d{3}".r
 
-  def createBinaryName(appName: String, binaryType: BinaryType, uploadTime: DateTime): String = {
-    appName + "-" + uploadTime.toString("yyyyMMdd_HHmmss_SSS") + s".${binaryType.extension}"
+  def createBinaryName(appName: String, binaryType: BinaryType, uploadTime: ZonedDateTime): String = {
+    appName + "-" + df.format(uploadTime) + s".${binaryType.extension}"
   }
 
-  protected def getPath(appName: String, binaryType: BinaryType, uploadTime: DateTime): Option[String] = {
+  protected def getPath(appName: String, binaryType: BinaryType,
+                        uploadTime: ZonedDateTime): Option[String] = {
     val binFile = new File(rootDirPath, createBinaryName(appName, binaryType, uploadTime))
     if(binFile.exists()) {
       Some(binFile.getAbsolutePath)
@@ -33,7 +36,7 @@ trait FileCacher {
   // Cache the binary file into local file system.
   protected def cacheBinary(appName: String,
                             binaryType: BinaryType,
-                            uploadTime: DateTime,
+                            uploadTime: ZonedDateTime,
                             binBytes: Array[Byte]): String = {
     val targetFullBinaryName = createBinaryName(appName, binaryType, uploadTime)
     val tempSuffix = ".tmp"

--- a/job-server/src/main/scala/spark/jobserver/io/JobDAOActorHelper.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/JobDAOActorHelper.scala
@@ -1,12 +1,11 @@
 package spark.jobserver.io
 
 import java.io.File
-
 import com.typesafe.config.Config
-import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
 import spark.jobserver.util._
 
+import java.time.ZonedDateTime
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{Await, Future}
 import scala.util.Success
@@ -23,7 +22,7 @@ class JobDAOActorHelper(metaDataDAO: MetaDataDAO, binaryDAO: BinaryDAO, config: 
   private val defaultAwaitTime = JobserverTimeouts.DAO_DEFAULT_TIMEOUT
   private val logger = LoggerFactory.getLogger(getClass)
 
-  def saveBinary(name: String, binaryType: BinaryType, uploadTime: DateTime,
+  def saveBinary(name: String, binaryType: BinaryType, uploadTime: ZonedDateTime,
                           binaryBytes: Array[Byte]): Unit = {
     Utils.usingTimer(binWrite){ () =>
       val binHash = BinaryDAO.calculateBinaryHashString(binaryBytes)
@@ -105,7 +104,7 @@ class JobDAOActorHelper(metaDataDAO: MetaDataDAO, binaryDAO: BinaryDAO, config: 
     }
   }
 
-  def getBinaryPath(name: String, binaryType: BinaryType, uploadTime: DateTime): String = {
+  def getBinaryPath(name: String, binaryType: BinaryType, uploadTime: ZonedDateTime): String = {
     Utils.usingTimer(binRead){ () =>
       Await.result(Utils.usingTimer(binRead){ () => metaDataDAO.getBinary(name)}, defaultAwaitTime) match {
         case Some(binaryInfo) =>

--- a/job-server/src/main/scala/spark/jobserver/io/MetaDataDAO.scala
+++ b/job-server/src/main/scala/spark/jobserver/io/MetaDataDAO.scala
@@ -1,9 +1,9 @@
 package spark.jobserver.io
 
 import com.typesafe.config._
-import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
 
+import java.time.ZonedDateTime
 import scala.concurrent.Future
 
 object MetaDataDAO {
@@ -122,7 +122,7 @@ trait MetaDataDAO {
     */
   def saveBinary(name: String,
                  binaryType: BinaryType,
-                 uploadTime: DateTime,
+                 uploadTime: ZonedDateTime,
                  binaryStorageId: String): Future[Boolean]
 
   /**

--- a/job-server/src/main/scala/spark/jobserver/util/DAOCleanup.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/DAOCleanup.scala
@@ -1,7 +1,6 @@
 package spark.jobserver.util
 
 import java.util.concurrent.TimeUnit
-
 import scala.concurrent.Await
 import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
@@ -10,11 +9,12 @@ import com.typesafe.config.Config
 import JsonProtocols.ContextInfoJsonFormat
 import JsonProtocols.JobInfoJsonFormat
 import com.google.common.annotations.VisibleForTesting
-import org.joda.time.DateTime
 import spark.jobserver.io._
 import spark.jobserver.io.zookeeper.MetaDataZookeeperDAO
 import spark.jobserver.io.zookeeper.ZookeeperUtils
 import spark.jobserver.io.ContextStatus
+
+import java.time.ZonedDateTime
 
 trait DAOCleanup {
   def cleanup(): Boolean
@@ -102,7 +102,7 @@ class ZKCleanup(config: Config) extends DAOCleanup {
         jobs.map { job =>
           isContextStateFinal(job.contextId) match {
               case true =>
-                val updatedJob = job.copy(endTime = Some(DateTime.now()),
+                val updatedJob = job.copy(endTime = Some(ZonedDateTime.now()),
                     state = JobStatus.Error,
                     error = Some(ErrorData(NoCorrespondingContextAliveException(job.jobId))))
 

--- a/job-server/src/main/scala/spark/jobserver/util/DateUtils.scala
+++ b/job-server/src/main/scala/spark/jobserver/util/DateUtils.scala
@@ -1,31 +1,18 @@
 package spark.jobserver.util
 
-import org.joda.time.format.ISODateTimeFormat
-import org.joda.time.{DateTime, DateTimeComparator, DateTimeZone}
+import java.time.ZonedDateTime
 
 
 object DateUtils {
-  val ZeroTime = dtFromUtcSeconds(0)
-
-  private val iso8601format = ISODateTimeFormat.dateTimeNoMillis()
-  private val iso8601withMillis = ISODateTimeFormat.dateTime()
-  private val dateComparator = DateTimeComparator.getInstance()
-
-  def iso8601(dt: DateTime, fractions: Boolean = false): String =
-    if (fractions) iso8601withMillis.print(dt) else iso8601format.print(dt)
-
-  @inline def dtFromUtcSeconds(seconds: Int): DateTime = new DateTime(seconds * 1000L, DateTimeZone.UTC)
-
-  @inline def dtFromIso8601(isoString: String): DateTime = new DateTime(isoString, DateTimeZone.UTC)
 
   /**
    * Implicit conversions so we can use Scala comparison operators
-   * with JodaTime's DateTime
+   * with ZonedDateTime
    */
-  implicit def dateTimeToScalaWrapper(dt: DateTime): DateTimeWrapper = new DateTimeWrapper(dt)
+  implicit def dateTimeToScalaWrapper(dt: ZonedDateTime): DateTimeWrapper = new DateTimeWrapper(dt)
 
-  class DateTimeWrapper(dt: DateTime) extends Ordered[DateTime] with Ordering[DateTime] {
-    def compare(that: DateTime): Int = dateComparator.compare(dt, that)
-    def compare(a: DateTime, b: DateTime): Int = dateComparator.compare(a, b)
+  class DateTimeWrapper(dt: ZonedDateTime) extends Ordered[ZonedDateTime] with Ordering[ZonedDateTime] {
+    def compare(that: ZonedDateTime): Int = dt.compareTo(that)
+    def compare(a: ZonedDateTime, b: ZonedDateTime): Int = a.compareTo(b)
   }
 }

--- a/job-server/src/test/scala/akka/downing/KeepOldestAutoDownSpec.scala
+++ b/job-server/src/test/scala/akka/downing/KeepOldestAutoDownSpec.scala
@@ -16,10 +16,12 @@ import akka.cluster.ClusterEvent._
 import akka.cluster.MemberStatus._
 import akka.cluster.{Member, TestMember}
 import akka.testkit.{ImplicitSender, TestKit}
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 import scala.collection.immutable
 import scala.concurrent.duration.{FiniteDuration, _}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
 
 case object ShutDownCausedBySplitBrainResolver
@@ -54,7 +56,7 @@ class OldestAutoDownTestActor(address: Address,
 }
 
 class OldestAutoDowningSpec extends TestKit(ActorSystem("OldestAutoDowningSpec")) with ImplicitSender
-  with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll  {
+  with AnyFunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll  {
 
   private val memberA = TestMember(Address("akka.tcp", "sys", "first", 2552), Up, Set("master"))
   private val memberB = TestMember(Address("akka.tcp", "sys", "second", 2552), Up, Set("master"))

--- a/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
@@ -17,7 +17,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.util.Try
 import com.typesafe.config.{Config, ConfigFactory, ConfigRenderOptions}
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 import scala.concurrent.Await
 import scala.reflect.ClassTag
@@ -27,6 +27,8 @@ import akka.util.Timeout
 import spark.jobserver.io.JobDAOActor._
 
 import java.time.ZonedDateTime
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
 object AkkaClusterSupervisorActorSpec {
   // All the Actors System should have the same name otherwise they cannot form a cluster
@@ -240,7 +242,7 @@ class StubbedJobManagerActor(contextConfig: Config) extends Actor {
 }
 
 class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorSpec.system)
-  with ImplicitSender with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
+  with ImplicitSender with AnyFunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
 
   implicit val futureTimeout = Timeout(5.seconds)
   private val daoTimeout = 5.seconds.dilated

--- a/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/AkkaClusterSupervisorActorSpec.scala
@@ -18,15 +18,15 @@ import scala.concurrent.duration._
 import scala.util.Try
 import com.typesafe.config.{Config, ConfigFactory, ConfigRenderOptions}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
-import org.joda.time.DateTime
 
 import scala.concurrent.Await
 import scala.reflect.ClassTag
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicInteger
-
 import akka.util.Timeout
 import spark.jobserver.io.JobDAOActor._
+
+import java.time.ZonedDateTime
 
 object AkkaClusterSupervisorActorSpec {
   // All the Actors System should have the same name otherwise they cannot form a cluster
@@ -271,7 +271,7 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
   }
 
   def saveContextAndJobInRestartingState(contextId: String) : String = {
-    val dt = DateTime.now()
+    val dt = ZonedDateTime.now()
     saveContextInSomeState(contextId, ContextStatus.Restarting)
     val job = JobInfo("specialJobId", contextId, "someContext",
         "com.abc.meme", JobStatus.Restarting, dt, None, None, Seq(BinaryInfo("demo", BinaryType.Jar, dt)))
@@ -280,7 +280,7 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
   }
 
   def saveContextInSomeState(contextId: String, state: String) : ContextInfo = {
-    val dt = DateTime.now()
+    val dt = ZonedDateTime.now()
     val configWithSuperviseMode = ConfigFactory.parseString(
         s"${ManagerLauncher.CONTEXT_SUPERVISE_MODE_KEY}=true, is-adhoc=false, context.name=someContext," +
           s"context.id=$contextId")
@@ -300,7 +300,7 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
 
   def setContextState(contextInfo: ContextInfo, state: String): ContextInfo = {
     val updatedContext = contextInfo.copy(state = state,
-      endTime = Some(DateTime.now()))
+      endTime = Some(ZonedDateTime.now()))
     saveContextInfo(updatedContext)
     updatedContext
   }
@@ -503,13 +503,13 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
 
     it("should set context and nonfinal jobs to error state if actor resolution fails during StopContext"){
       val contextWithoutActor = ContextInfo("contextWithoutActor", "contextWithoutActor", "", None,
-          DateTime.now(), None, ContextStatus.Running, None)
+          ZonedDateTime.now(), None, ContextStatus.Running, None)
       val finalJob = JobInfo("finalJob", "contextWithoutActor", "contextWithoutActor",
-          "", JobStatus.Finished, DateTime.now(),
-          Some(DateTime.now()), None, Seq(BinaryInfo("demo", BinaryType.Jar, DateTime.now())))
+          "", JobStatus.Finished, ZonedDateTime.now(),
+          Some(ZonedDateTime.now()), None, Seq(BinaryInfo("demo", BinaryType.Jar, ZonedDateTime.now())))
       val nonfinalJob = JobInfo("nonfinalJob", "contextWithoutActor", "contextWithoutActor",
-          "", JobStatus.Running, DateTime.now(),
-          None, None, Seq(BinaryInfo("demo", BinaryType.Jar, DateTime.now())))
+          "", JobStatus.Running, ZonedDateTime.now(),
+          None, None, Seq(BinaryInfo("demo", BinaryType.Jar, ZonedDateTime.now())))
       Await.result(daoActor ? SaveContextInfo(contextWithoutActor), daoTimeout)
       Await.result(daoActor ? SaveJobInfo(finalJob), daoTimeout)
       Await.result(daoActor ? SaveJobInfo(nonfinalJob), daoTimeout)
@@ -558,7 +558,7 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
       val deathWatch = TestProbe()
       deathWatch.watch(managerProbe.ref)
       val dummyContext = ContextInfo(contextId, "contextName", "", None,
-          DateTime.now(), None, ContextStatus.Started, None)
+        ZonedDateTime.now(), None, ContextStatus.Started, None)
       Await.result(daoActor ? SaveContextInfo(dummyContext), daoTimeout)
 
       supervisor ! ActorIdentity(unusedDummyInput, Some(managerProbe.ref))
@@ -572,13 +572,13 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
       val deathWatch = TestProbe()
       deathWatch.watch(managerProbe.ref)
       val dummyContext = ContextInfo(contextId, contextId, "", None,
-        DateTime.now(), None, ContextStatus.Stopping, None)
+        ZonedDateTime.now(), None, ContextStatus.Stopping, None)
       val finalJob = JobInfo("finalJob", contextId, contextId,
-        "", JobStatus.Finished, DateTime.now(),
-        Some(DateTime.now()), None, Seq(BinaryInfo("demo", BinaryType.Jar, DateTime.now())))
+        "", JobStatus.Finished, ZonedDateTime.now(),
+        Some(ZonedDateTime.now()), None, Seq(BinaryInfo("demo", BinaryType.Jar, ZonedDateTime.now())))
       val nonfinalJob = JobInfo("nonfinalJob", contextId, contextId,
-        "", JobStatus.Running, DateTime.now(),
-        None, None, Seq(BinaryInfo("demo", BinaryType.Jar, DateTime.now())))
+        "", JobStatus.Running, ZonedDateTime.now(),
+        None, None, Seq(BinaryInfo("demo", BinaryType.Jar, ZonedDateTime.now())))
       Await.result(daoActor ? SaveContextInfo(dummyContext), daoTimeout)
       Await.result(daoActor ? SaveJobInfo(finalJob), daoTimeout)
       Await.result(daoActor ? SaveJobInfo(nonfinalJob), daoTimeout)
@@ -648,8 +648,8 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
       supervisor ! StubbedAkkaClusterSupervisorActor.AddContextToContextInitInfos(contextActorName)
 
       val timedOutContextId = timedOutRejoiningManagerProbe.ref.path.name.replace(JobserverConfig.MANAGER_ACTOR_PREFIX, "")
-      val timedOutContext = ContextInfo(timedOutContextId, "contextName", "", None, DateTime.now(),
-          Some(DateTime.now().plusHours(1)), ContextStatus.Error, Some(ContextJVMInitializationTimeout()))
+      val timedOutContext = ContextInfo(timedOutContextId, "contextName", "", None, ZonedDateTime.now(),
+          Some(ZonedDateTime.now().plusHours(1)), ContextStatus.Error, Some(ContextJVMInitializationTimeout()))
       Await.result(daoActor ? SaveContextInfo(timedOutContext), daoTimeout)
 
       supervisor ! ActorIdentity(unusedDummyInput, Some(timedOutRejoiningManagerProbe.ref))
@@ -675,14 +675,14 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
 
       val timedOutContextId = timedOutRejoiningManagerProbe.ref.path.name.replace(
         JobserverConfig.MANAGER_ACTOR_PREFIX, "")
-      val timedOutContext = ContextInfo(timedOutContextId, "timedOutContext", "", None, DateTime.now(),
-          Some(DateTime.now().plusHours(1)), ContextStatus.Error, Some(ContextJVMInitializationTimeout()))
+      val timedOutContext = ContextInfo(timedOutContextId, "timedOutContext", "", None, ZonedDateTime.now(),
+          Some(ZonedDateTime.now().plusHours(1)), ContextStatus.Error, Some(ContextJVMInitializationTimeout()))
       Await.result(daoActor ? SaveContextInfo(timedOutContext), daoTimeout)
 
       val finishedContextId = finishRejoiningManagerProbe.ref.path.name.replace(
         JobserverConfig.MANAGER_ACTOR_PREFIX, "")
-      val finishedContext = ContextInfo(finishedContextId, "finishedContext", "", None, DateTime.now(),
-          Some(DateTime.now().plusHours(1)), ContextStatus.Finished, None)
+      val finishedContext = ContextInfo(finishedContextId, "finishedContext", "", None, ZonedDateTime.now(),
+          Some(ZonedDateTime.now().plusHours(1)), ContextStatus.Finished, None)
       Await.result(daoActor ? SaveContextInfo(finishedContext), daoTimeout)
 
       supervisor ! ActorIdentity(unusedDummyInput, Some(timedOutRejoiningManagerProbe.ref))
@@ -704,8 +704,8 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
 
       val erroredOutContextId = erroredOutRejoiningManagerProbe.ref.path.name.replace(
         JobserverConfig.MANAGER_ACTOR_PREFIX, "")
-      val erroredOutContext = ContextInfo(erroredOutContextId, "contextName", "", None, DateTime.now(),
-          Some(DateTime.now().plusHours(1)), ContextStatus.Error, Some(new Exception("random error")))
+      val erroredOutContext = ContextInfo(erroredOutContextId, "contextName", "", None, ZonedDateTime.now(),
+          Some(ZonedDateTime.now().plusHours(1)), ContextStatus.Error, Some(new Exception("random error")))
       Await.result(daoActor ? SaveContextInfo(erroredOutContext), daoTimeout)
 
       supervisor ! ActorIdentity(unusedDummyInput, Some(erroredOutRejoiningManagerProbe.ref))
@@ -744,7 +744,7 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
       expectMsg(Seq(contextName)) // Running context
 
       val stoppingContext = runningContext.copy(state = ContextStatus.Stopping,
-        endTime = Some(DateTime.now()))
+        endTime = Some(ZonedDateTime.now()))
       daoActor ! JobDAOActor.SaveContextInfo(stoppingContext)
       expectMsg(JobDAOActor.SavedSuccessfully)
 
@@ -752,7 +752,7 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
       expectMsg(Seq(contextName)) // Stopping context
 
       val restartingContext =  stoppingContext.copy(state = ContextStatus.Restarting,
-        endTime = Some(DateTime.now()))
+        endTime = Some(ZonedDateTime.now()))
       daoActor ! JobDAOActor.SaveContextInfo(restartingContext)
       expectMsg(JobDAOActor.SavedSuccessfully)
 
@@ -852,7 +852,7 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
       val contextName = "restartingContextName"
       val convertedContextConfig = contextConfig.root().render(ConfigRenderOptions.concise())
 
-      val contextInfoPF = ContextInfo(contextId, contextName, convertedContextConfig, None, DateTime.now(),
+      val contextInfoPF = ContextInfo(contextId, contextName, convertedContextConfig, None, ZonedDateTime.now(),
           None, _: String, None)
       val restartingContext = contextInfoPF(ContextStatus.Restarting)
       Await.result(daoActor ? SaveContextInfo(restartingContext), daoTimeout)
@@ -865,7 +865,7 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
 
     it("should not change final state to STOPPING state") {
       val daoProbe = TestProbe()
-      val contextInfo = ContextInfo("id", "name", "", None, DateTime.now(), None, ContextStatus.Finished, None)
+      val contextInfo = ContextInfo("id", "name", "", None, ZonedDateTime.now(), None, ContextStatus.Finished, None)
       var contextToTest: ContextInfo = contextInfo
 
       daoProbe.setAutoPilot(new TestActor.AutoPilot {
@@ -894,7 +894,7 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
     it("should change non final state to STOPPING state") {
       val daoProbe = TestProbe()
       val latch = new CountDownLatch(1)
-      val contextInfo = ContextInfo("id", "name", "", None, DateTime.now(), None, ContextStatus.Running, None)
+      val contextInfo = ContextInfo("id", "name", "", None, ZonedDateTime.now(), None, ContextStatus.Running, None)
       var contextToTest: ContextInfo = contextInfo
 
       daoProbe.setAutoPilot(new TestActor.AutoPilot {
@@ -1115,7 +1115,7 @@ class AkkaClusterSupervisorActorSpec extends TestKit(AkkaClusterSupervisorActorS
       val contextId = "testid2"
       val convertedContextConfig = contextConfig.root().render(ConfigRenderOptions.concise())
 
-      val runningContext = ContextInfo(contextId, "c", convertedContextConfig, None, DateTime.now(),
+      val runningContext = ContextInfo(contextId, "c", convertedContextConfig, None, ZonedDateTime.now(),
         None, ContextStatus.Running, None)
       daoActor ! JobDAOActor.SaveContextInfo(runningContext)
       expectMsg(JobDAOActor.SavedSuccessfully)

--- a/job-server/src/test/scala/spark/jobserver/BinaryManagerSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/BinaryManagerSpec.scala
@@ -2,29 +2,29 @@ package spark.jobserver
 
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
-
 import akka.actor.{ActorSystem, Props}
 import akka.testkit.{ImplicitSender, TestKit}
-import org.joda.time.DateTime
 import org.scalatest.{BeforeAndAfterAll, FunSpecLike, Matchers}
 import spark.jobserver.common.akka.{AkkaTestUtils, InstrumentedActor}
 import spark.jobserver.io.{BinaryInfo, BinaryType, JobInfo, JobStatus}
 import spark.jobserver.io.JobDAOActor.LastBinaryInfo
 
+import java.time.ZonedDateTime
+
 object BinaryManagerSpec {
   val system = ActorSystem("binary-manager-test")
 
-  val dt = DateTime.now
+  val dt = ZonedDateTime.now
   val binaryInfo = BinaryInfo("binary", BinaryType.Jar, dt, None)
 
-  val binInfo = BinaryInfo("demo", BinaryType.Egg, DateTime.now)
+  val binInfo = BinaryInfo("demo", BinaryType.Egg, ZonedDateTime.now)
 
   class DummyDAOActor extends InstrumentedActor {
 
     import spark.jobserver.io.JobDAOActor._
 
     val jobInfo = JobInfo("bar", "cid", "context",
-        "com.abc.meme", JobStatus.Running, DateTime.now, None, None, Seq(binInfo), None)
+        "com.abc.meme", JobStatus.Running, ZonedDateTime.now, None, None, Seq(binInfo), None)
 
     override def wrappedReceive: Receive = {
       case GetLastBinaryInfo("binary") =>

--- a/job-server/src/test/scala/spark/jobserver/BinaryManagerSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/BinaryManagerSpec.scala
@@ -4,12 +4,14 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 import akka.actor.{ActorSystem, Props}
 import akka.testkit.{ImplicitSender, TestKit}
-import org.scalatest.{BeforeAndAfterAll, FunSpecLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
 import spark.jobserver.common.akka.{AkkaTestUtils, InstrumentedActor}
 import spark.jobserver.io.{BinaryInfo, BinaryType, JobInfo, JobStatus}
 import spark.jobserver.io.JobDAOActor.LastBinaryInfo
 
 import java.time.ZonedDateTime
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
 object BinaryManagerSpec {
   val system = ActorSystem("binary-manager-test")
@@ -56,7 +58,7 @@ object BinaryManagerSpec {
 }
 
 class BinaryManagerSpec extends TestKit(BinaryManagerSpec.system) with ImplicitSender
-  with FunSpecLike with Matchers with BeforeAndAfterAll {
+  with AnyFunSpecLike with Matchers with BeforeAndAfterAll {
 
   import spark.jobserver.BinaryManagerSpec._
 

--- a/job-server/src/test/scala/spark/jobserver/DataManagerActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/DataManagerActorSpec.scala
@@ -2,19 +2,21 @@ package spark.jobserver
 
 import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import java.nio.file.{Files, Paths}
 
 import spark.jobserver.common.akka
 import spark.jobserver.common.akka.AkkaTestUtils
 import spark.jobserver.io.DataFileDAO
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
 object DataManagerActorSpec {
   val system = ActorSystem("test")
 }
 
 class DataManagerActorSpec extends TestKit(DataManagerActorSpec.system) with ImplicitSender
-    with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
+    with AnyFunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
 
   import com.typesafe.config._
   import DataManagerActor._

--- a/job-server/src/test/scala/spark/jobserver/HealthzApiSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/HealthzApiSpec.scala
@@ -6,13 +6,15 @@ import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.typesafe.config.{Config, ConfigFactory}
-import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
 import spark.jobserver.io.JobDAOActor.GetJobInfo
 import spark.jobserver.io.{InMemoryBinaryDAO, InMemoryMetaDAO, JobDAOActor}
 import spark.jobserver.util.ActorsHealthCheck
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class HealthzApiSpec extends FunSpec with Matchers with BeforeAndAfterAll
+class HealthzApiSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll
 with ScalatestRouteTest with SprayJsonSupport {
 
   import spray.json._

--- a/job-server/src/test/scala/spark/jobserver/JobManagerActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobManagerActorSpec.scala
@@ -5,7 +5,6 @@ import akka.http.scaladsl.model.Uri
 import akka.pattern.ask
 import akka.testkit.TestProbe
 import akka.util.Timeout
-import org.joda.time.DateTime
 import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.spark.SparkEnv
 import org.slf4j.LoggerFactory
@@ -20,6 +19,7 @@ import spark.jobserver.util._
 
 import java.io.File
 import java.nio.file.{Files, StandardOpenOption}
+import java.time.ZonedDateTime
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -686,7 +686,7 @@ class JobManagerActorSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) 
       val binURI = BinaryInfo( // Additional dependency binary, which contains Empty class
         s"file://${emptyJar.getAbsolutePath}",
         BinaryType.URI,
-        DateTime.now()
+        ZonedDateTime.now()
       )
       manager ! JobManagerActor.StartJob(
         classPrefix + "jobJarDependenciesJob", List(testJar, binURI), emptyConfig, syncEvents ++ errorEvents)
@@ -830,7 +830,7 @@ class JobManagerActorSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) 
       val testJar = uploadTestJar()
 
       daoActor ! JobDAOActor.SaveContextInfo(ContextInfo(contextId, "ctx", "",
-        None, DateTime.now(), None, ContextStatus.Running, None))
+        None, ZonedDateTime.now(), None, ContextStatus.Running, None))
       expectMsg(SavedSuccessfully)
       manager ! JobManagerActor.Initialize(adhocContextConfig, None, emptyActor)
       expectMsgClass(initMsgWait, classOf[JobManagerActor.Initialized])
@@ -1056,7 +1056,7 @@ class JobManagerActorSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) 
       manager ! JobRestartFailed("dummy-id", new Exception(""))
       deathWatcher.expectNoMessage(2.seconds)
 
-      manager ! JobValidationFailed("dummy-id1", DateTime.now(), new Exception(""))
+      manager ! JobValidationFailed("dummy-id1", ZonedDateTime.now(), new Exception(""))
       deathWatcher.expectNoMessage(2.seconds)
 
       manager ! JobRestartFailed("dummy-id2", new Exception(""))
@@ -1069,7 +1069,7 @@ class JobManagerActorSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) 
       deathWatcher.watch(manager)
 
       val dummyJob = JobInfo("dummy-id2", "", "", "", JobStatus.Running,
-        DateTime.now(), None, None, Seq(BinaryInfo("dummy", BinaryType.Jar, DateTime.now())))
+        ZonedDateTime.now(), None, None, Seq(BinaryInfo("dummy", BinaryType.Jar, ZonedDateTime.now())))
 
       manager ! JobRestartFailed("dummy-id", new Exception(""))
       deathWatcher.expectNoMessage(2.seconds)
@@ -1077,7 +1077,7 @@ class JobManagerActorSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) 
       manager ! JobStarted("dummy-id2", dummyJob)
       deathWatcher.expectNoMessage(2.seconds)
 
-      manager ! JobValidationFailed("dummy-id2", DateTime.now(), new Exception(""))
+      manager ! JobValidationFailed("dummy-id2", ZonedDateTime.now(), new Exception(""))
       deathWatcher.expectNoMessage(2.seconds)
     }
 
@@ -1142,9 +1142,9 @@ class JobManagerActorSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) 
       val contextId = "dummy-context"
       val daoProbe = TestProbe()
       val managerWatcher = TestProbe()
-      val binaryInfo = BinaryInfo("dummy", BinaryType.Jar, DateTime.now())
+      val binaryInfo = BinaryInfo("dummy", BinaryType.Jar, ZonedDateTime.now())
       val jobInfo = JobInfo("jobId", contextId, "context-name",
-        "test-class", JobStatus.Running, DateTime.now(), None, None, Seq(binaryInfo))
+        "test-class", JobStatus.Running, ZonedDateTime.now(), None, None, Seq(binaryInfo))
       manager = system.actorOf(JobManagerActorSpy.props(daoProbe.ref, "", defaultSmallTimeout, contextId, TestProbe()))
       managerWatcher.watch(manager)
       manager ! JobManagerActor.RestartExistingJobs
@@ -1172,9 +1172,9 @@ class JobManagerActorSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) 
       val contextId = "dummy-context"
       val daoProbe = TestProbe()
       val managerWatcher = TestProbe()
-      val binaryInfo = BinaryInfo("dummy", BinaryType.Jar, DateTime.now())
+      val binaryInfo = BinaryInfo("dummy", BinaryType.Jar, ZonedDateTime.now())
       val jobInfo = JobInfo("jobId", contextId, "context-name",
-        "test-class", JobStatus.Running, DateTime.now(), None, None, Seq(binaryInfo))
+        "test-class", JobStatus.Running, ZonedDateTime.now(), None, None, Seq(binaryInfo))
       manager = system.actorOf(JobManagerActorSpy.props(daoProbe.ref, "", defaultSmallTimeout, contextId, TestProbe()))
       managerWatcher.watch(manager)
       manager ! JobManagerActor.RestartExistingJobs
@@ -1203,7 +1203,7 @@ class JobManagerActorSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) 
       val contextId = "dummy-context"
       val binaryInfo = uploadTestJar()
       val jobInfo = JobInfo("jobId", contextId, "context-name",
-        wordCountClass, JobStatus.Running, DateTime.now(), None, None, Seq(binaryInfo))
+        wordCountClass, JobStatus.Running, ZonedDateTime.now(), None, None, Seq(binaryInfo))
       manager = system.actorOf(JobManagerActorSpy.props(daoActor, "", defaultSmallTimeout, contextId, spyProbe))
 
       contextConfig = ConfigFactory.parseString(s"context.id=$contextId").withFallback(contextConfig)
@@ -1225,7 +1225,7 @@ class JobManagerActorSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) 
       val contextId = "dummy-context"
       val binaryInfo = uploadTestJar()
       val jobInfo = JobInfo("jobId", contextId, "context-name",
-        wordCountClass, JobStatus.Running, DateTime.now(), None, None, Seq(binaryInfo))
+        wordCountClass, JobStatus.Running, ZonedDateTime.now(), None, None, Seq(binaryInfo))
       manager = system.actorOf(JobManagerActorSpy.props(daoActor, "", defaultSmallTimeout, contextId, spyProbe))
 
       contextConfig = ConfigFactory.parseString(s"context.id=$contextId").withFallback(contextConfig)
@@ -1247,7 +1247,7 @@ class JobManagerActorSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) 
       val contextId = "dummy-context"
       val binaryInfo = uploadTestJar()
       val jobInfo = JobInfo("jobId", contextId, "context-name",
-        wordCountClass, JobStatus.Restarting, DateTime.now(), None, None, Seq(binaryInfo))
+        wordCountClass, JobStatus.Restarting, ZonedDateTime.now(), None, None, Seq(binaryInfo))
       manager = system.actorOf(JobManagerActorSpy.props(daoActor, "", defaultSmallTimeout, contextId, spyProbe))
 
       contextConfig = ConfigFactory.parseString(s"context.id=$contextId").withFallback(contextConfig)
@@ -1268,7 +1268,7 @@ class JobManagerActorSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) 
       val contextId = "dummy-context"
       val binaryInfo = uploadTestJar()
       val jobInfo = JobInfo("jobId", contextId, "context-name",
-        wordCountClass, JobStatus.Running, DateTime.now(), None, None, Seq(binaryInfo))
+        wordCountClass, JobStatus.Running, ZonedDateTime.now(), None, None, Seq(binaryInfo))
       manager = system.actorOf(JobManagerActorSpy.props(daoActor, "", defaultSmallTimeout, contextId, spyProbe))
 
       contextConfig = ConfigFactory.parseString(s"context.id=$contextId").withFallback(contextConfig)
@@ -1296,7 +1296,7 @@ class JobManagerActorSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) 
       val contextName = "context-name"
       val testJar = uploadTestJar("test-jar")
       val jobInfo = JobInfo("jobId", contextId, contextName,
-        wordCountClass, JobStatus.Running, DateTime.now(), None, None, Seq(testJar))
+        wordCountClass, JobStatus.Running, ZonedDateTime.now(), None, None, Seq(testJar))
       val testJarJobConfig = ConfigFactory.parseString("cp = [\"test-jar\"]").withFallback(stringConfig)
       manager = system.actorOf(JobManagerActorSpy.props(daoActor, "", defaultSmallTimeout, contextId, spyProbe))
 
@@ -1337,7 +1337,7 @@ class JobManagerActorSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) 
       val deathWatcher = TestProbe()
       val binaryInfo = uploadTestJar()
       val jobInfo = JobInfo("jobId", contextId, "context-name",
-        wordCountClass, JobStatus.Running, DateTime.now(), None, None, Seq(binaryInfo))
+        wordCountClass, JobStatus.Running, ZonedDateTime.now(), None, None, Seq(binaryInfo))
       manager = system.actorOf(JobManagerActorSpy.props(daoActor, "", defaultSmallTimeout, contextId, spyProbe))
       deathWatcher.watch(manager)
 
@@ -1363,7 +1363,7 @@ class JobManagerActorSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) 
       val contextId = "dummy-context"
       val contextName = "context-name"
       val jobInfo = JobInfo("jobId", contextId, contextName,
-        wordCountClass, JobStatus.Running, DateTime.now(), None, None, Seq.empty)
+        wordCountClass, JobStatus.Running, ZonedDateTime.now(), None, None, Seq.empty)
       manager = system.actorOf(JobManagerActorSpy.props(daoActor, "", defaultSmallTimeout, contextId, spyProbe))
 
       contextConfig = ConfigFactory.parseString(s"context.id=$contextId,context.name=$contextName").withFallback(contextConfig)
@@ -1416,7 +1416,7 @@ class JobManagerActorSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) 
       deathWatcher.watch(manager)
 
       daoActor ! JobDAOActor.SaveContextInfo(ContextInfo(contextId, "ctx", "",
-        None, DateTime.now(), None, ContextStatus.Running, None))
+        None, ZonedDateTime.now(), None, ContextStatus.Running, None))
       expectMsg(SavedSuccessfully)
 
       manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
@@ -1440,7 +1440,7 @@ class JobManagerActorSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) 
       deathWatcher.watch(manager)
 
       daoActor ! JobDAOActor.SaveContextInfo(ContextInfo(contextId, "ctx", "",
-        None, DateTime.now(), None, ContextStatus.Running, None))
+        None, ZonedDateTime.now(), None, ContextStatus.Running, None))
       expectMsg(SavedSuccessfully)
 
       manager ! JobManagerActor.Initialize(contextConfig, None, emptyActor)
@@ -1462,7 +1462,7 @@ class JobManagerActorSpec extends JobSpecBase(JobManagerActorSpec.getNewSystem) 
       manager = system.actorOf(JobManagerActorSpyStateUpdate.props(daoActor, "", defaultSmallTimeout, contextId, self))
       val adhocContextConfig = JobManagerActorSpec.getContextConfig(adhoc = true)
       daoActor ! JobDAOActor.SaveContextInfo(ContextInfo(contextId, "ctx", "",
-        None, DateTime.now(), None, ContextStatus.Running, None))
+        None, ZonedDateTime.now(), None, ContextStatus.Running, None))
       expectMsg(SavedSuccessfully)
 
       manager ! JobManagerActor.Initialize(adhocContextConfig, None, emptyActor)

--- a/job-server/src/test/scala/spark/jobserver/JobManagerSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobManagerSpec.scala
@@ -9,11 +9,13 @@ import akka.cluster.Cluster
 import akka.cluster.ClusterEvent.{InitialStateAsEvents, MemberUp}
 import akka.util.Timeout
 import com.google.common.net.InetAddresses
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 import scala.concurrent.Await
 import spark.jobserver.common.akka.AkkaTestUtils
 import spark.jobserver.util.HDFSCluster
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
 sealed case class JVMExitException(status: Int) extends SecurityException("sys.exit() is not allowed") {
 }
@@ -29,7 +31,7 @@ sealed class NoExitSecurityManager extends SecurityManager {
   }
 }
 
-class JobManagerSpec extends FunSpecLike with Matchers with BeforeAndAfter
+class JobManagerSpec extends AnyFunSpecLike with Matchers with BeforeAndAfter
     with BeforeAndAfterAll with HDFSCluster {
 
   import akka.testkit._

--- a/job-server/src/test/scala/spark/jobserver/JobResultActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobResultActorSpec.scala
@@ -2,9 +2,11 @@ package spark.jobserver
 
 import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.testkit.{ImplicitSender, TestKit}
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import spark.jobserver.common.akka
 import spark.jobserver.common.akka.AkkaTestUtils
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
 
 object JobResultActorSpec {
@@ -12,7 +14,7 @@ object JobResultActorSpec {
 }
 
 class JobResultActorSpec extends TestKit(JobResultActorSpec.system) with ImplicitSender
-with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
+with AnyFunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
 
   import spark.jobserver.CommonMessages._
 

--- a/job-server/src/test/scala/spark/jobserver/JobServerSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobServerSpec.scala
@@ -7,7 +7,7 @@ import akka.cluster.{Cluster, ClusterEvent, MemberStatus}
 import akka.pattern.ask
 import akka.util.Timeout
 import akka.testkit.{TestActor, TestKit, TestProbe}
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 import java.nio.file.{Files, Path}
 import scala.concurrent.duration._
@@ -25,12 +25,14 @@ import com.typesafe.config.Config
 
 import java.time.{Instant, LocalDateTime, ZoneId, ZonedDateTime}
 import java.time.format.DateTimeFormatter
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
 object JobServerSpec {
   val system = ActorSystem("test")
 }
 
-class JobServerSpec extends TestKit(JobServerSpec.system) with FunSpecLike with Matchers
+class JobServerSpec extends TestKit(JobServerSpec.system) with AnyFunSpecLike with Matchers
     with BeforeAndAfter with BeforeAndAfterAll {
 
   import com.typesafe.config._

--- a/job-server/src/test/scala/spark/jobserver/JobServerSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobServerSpec.scala
@@ -1,7 +1,6 @@
 package spark.jobserver
 
 import java.nio.charset.Charset
-
 import scala.util.Try
 import akka.actor.{Actor, ActorRef, ActorSystem, Address, Props}
 import akka.cluster.{Cluster, ClusterEvent, MemberStatus}
@@ -9,8 +8,8 @@ import akka.pattern.ask
 import akka.util.Timeout
 import akka.testkit.{TestActor, TestKit, TestProbe}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
-import java.nio.file.{Files, Path}
 
+import java.nio.file.{Files, Path}
 import scala.concurrent.duration._
 import spark.jobserver.JobServer.InvalidConfiguration
 import spark.jobserver.common.akka
@@ -21,11 +20,11 @@ import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import java.util.UUID
-
-import org.joda.time.DateTime
 import java.util.concurrent.{CountDownLatch, TimeUnit}
-
 import com.typesafe.config.Config
+
+import java.time.{Instant, LocalDateTime, ZoneId, ZonedDateTime}
+import java.time.format.DateTimeFormatter
 
 object JobServerSpec {
   val system = ActorSystem("test")
@@ -205,7 +204,7 @@ class JobServerSpec extends TestKit(JobServerSpec.system) with FunSpecLike with 
 
     def createContext(name: String, status: String, genActor: Boolean): (ContextInfo, Option[ActorRef]) = {
       val uuid = UUID.randomUUID().toString()
-      val ContextInfoPF = ContextInfo(uuid, name, "", _: Option[String], DateTime.now(), None, status, None)
+      val ContextInfoPF = ContextInfo(uuid, name, "", _: Option[String], ZonedDateTime.now(), None, status, None)
 
       genActor match {
         case true =>
@@ -217,7 +216,7 @@ class JobServerSpec extends TestKit(JobServerSpec.system) with FunSpecLike with 
     }
 
     def genJob(jobId: String, ctx: ContextInfo, status: String): JobInfo = {
-      val dt = DateTime.parse("2013-05-29T00Z")
+      val dt = Instant.parse("2013-05-29T00:00:00Z").atZone(ZoneId.systemDefault())
       JobInfo(jobId, ctx.id, ctx.name, "com.abc.meme",
           status, dt, None, None, Seq(BinaryInfo("demo", BinaryType.Jar, dt)), None)
     }

--- a/job-server/src/test/scala/spark/jobserver/JobSpecBase.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobSpecBase.scala
@@ -4,7 +4,7 @@ import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.testkit.ImplicitSender
 import akka.testkit.TestKit
 import com.typesafe.config.{Config, ConfigFactory}
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import spark.jobserver.common.akka.AkkaTestUtils
 import spark.jobserver.context.DefaultSparkContextFactory
 import spark.jobserver.io.JobDAOActor.{GetLastBinaryInfo, LastBinaryInfo, SaveBinary, SaveBinaryResult}
@@ -14,6 +14,8 @@ import spark.jobserver.util.JobserverConfig
 import java.time.ZonedDateTime
 import scala.concurrent.duration._
 import scala.util.Success
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
 /**
  * Provides a base Config for tests.  Override the vals to configure.  Mix into an object.
@@ -81,7 +83,7 @@ trait JobSpecConfig {
 }
 
 abstract class JobSpecBaseBase(system: ActorSystem) extends TestKit(system) with ImplicitSender
-with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
+with AnyFunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
   var inMemoryMetaDAO: MetaDataDAO = _
   var inMemoryBinDAO: BinaryDAO = _
   var daoActor: ActorRef = _

--- a/job-server/src/test/scala/spark/jobserver/JobSpecBase.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobSpecBase.scala
@@ -4,7 +4,6 @@ import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.testkit.ImplicitSender
 import akka.testkit.TestKit
 import com.typesafe.config.{Config, ConfigFactory}
-import org.joda.time.DateTime
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
 import spark.jobserver.common.akka.AkkaTestUtils
 import spark.jobserver.context.DefaultSparkContextFactory
@@ -12,6 +11,7 @@ import spark.jobserver.io.JobDAOActor.{GetLastBinaryInfo, LastBinaryInfo, SaveBi
 import spark.jobserver.io.{BinaryDAO, BinaryInfo, BinaryType, MetaDataDAO}
 import spark.jobserver.util.JobserverConfig
 
+import java.time.ZonedDateTime
 import scala.concurrent.duration._
 import scala.util.Success
 
@@ -103,7 +103,7 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
   protected def uploadBinary(jarFilePath: String,
                              appName: String, binaryType: BinaryType): BinaryInfo = {
     val bytes = scala.io.Source.fromFile(jarFilePath, "ISO-8859-1").map(_.toByte).toArray
-    daoActor ! SaveBinary(appName, binaryType, DateTime.now, bytes)
+    daoActor ! SaveBinary(appName, binaryType, ZonedDateTime.now, bytes)
     expectMsg(SaveBinaryResult(Success({})))
 
     daoActor ! GetLastBinaryInfo(appName)

--- a/job-server/src/test/scala/spark/jobserver/JobStatusActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobStatusActorSpec.scala
@@ -3,20 +3,21 @@ package spark.jobserver
 import akka.actor.{ActorRef, ActorSystem, PoisonPill, Props}
 import akka.testkit.{ImplicitSender, TestActor, TestKit, TestProbe}
 import spark.jobserver.io._
-import org.scalatest.Matchers
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import spark.jobserver.common.akka
 import spark.jobserver.common.akka.AkkaTestUtils
 import spark.jobserver.util.ErrorData
 
 import java.time.ZonedDateTime
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
 object JobStatusActorSpec {
   val system = ActorSystem("test")
 }
 
 class JobStatusActorSpec extends TestKit(JobStatusActorSpec.system) with ImplicitSender
-with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
+with AnyFunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
 
   import CommonMessages._
   import JobStatusActor._

--- a/job-server/src/test/scala/spark/jobserver/JobStatusActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/JobStatusActorSpec.scala
@@ -3,12 +3,13 @@ package spark.jobserver
 import akka.actor.{ActorRef, ActorSystem, PoisonPill, Props}
 import akka.testkit.{ImplicitSender, TestActor, TestKit, TestProbe}
 import spark.jobserver.io._
-import org.joda.time.DateTime
 import org.scalatest.Matchers
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike}
 import spark.jobserver.common.akka
 import spark.jobserver.common.akka.AkkaTestUtils
 import spark.jobserver.util.ErrorData
+
+import java.time.ZonedDateTime
 
 object JobStatusActorSpec {
   val system = ActorSystem("test")
@@ -24,11 +25,11 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
   private val contextId = "contextId"
   private val contextName = "contextName"
   private val appName = "appName"
-  private val jarInfo = BinaryInfo(appName, BinaryType.Jar, DateTime.now)
+  private val jarInfo = BinaryInfo(appName, BinaryType.Jar, ZonedDateTime.now)
   private val classPath = "classPath"
   private val jobInfo = JobInfo(jobId, contextId, contextName, classPath, JobStatus.Running,
-      DateTime.now, None, None, Seq(jarInfo))
-  private val endTime = DateTime.now()
+      ZonedDateTime.now, None, None, Seq(jarInfo))
+  private val endTime = ZonedDateTime.now()
   private val error = new Throwable
 
   override def afterAll() {
@@ -162,14 +163,14 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
       actor ! GetRunningJobStatus
       expectMsg(Seq(jobInfo))
 
-      val jobInfoWithStartTime = jobInfo.copy(startTime=DateTime.now)
+      val jobInfoWithStartTime = jobInfo.copy(startTime=ZonedDateTime.now)
       actor ! JobStarted(jobId, jobInfoWithStartTime)
       daoMsgReceiverProbe.expectMsg(JobDAOActor.SaveJobInfo(jobInfoWithStartTime))
 
       actor ! GetRunningJobStatus
       expectMsg(Seq(jobInfoWithStartTime))
 
-      val finishTime = DateTime.now
+      val finishTime = ZonedDateTime.now
       actor ! JobFinished(jobId, finishTime)
       daoMsgReceiverProbe.expectMsg(JobDAOActor.SaveJobInfo(jobInfoWithStartTime.copy(
           state = JobStatus.Finished, endTime = Some(finishTime))))
@@ -180,7 +181,7 @@ with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
     }
 
     it("should update JobValidationFailed status correctly") {
-      val jobInfoWithInitTime = jobInfo.copy(startTime=DateTime.now)
+      val jobInfoWithInitTime = jobInfo.copy(startTime=ZonedDateTime.now)
       actor ! JobInit(jobInfoWithInitTime)
 
       actor ! JobValidationFailed(jobId, endTime, error)

--- a/job-server/src/test/scala/spark/jobserver/LocalContextSupervisorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/LocalContextSupervisorSpec.scala
@@ -3,13 +3,15 @@ package spark.jobserver
 import akka.actor._
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import spark.jobserver.common.akka
 import spark.jobserver.common.akka.AkkaTestUtils
 import spark.jobserver.io.JobDAOActor.CleanContextJobInfos
 import spark.jobserver.util.SparkJobUtils
 
 import scala.concurrent.duration._
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
 
 object LocalContextSupervisorSpec {
@@ -53,7 +55,7 @@ object LocalContextSupervisorSpec {
 }
 
 class LocalContextSupervisorSpec extends TestKit(LocalContextSupervisorSpec.system) with ImplicitSender
-    with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
+    with AnyFunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
 
   override def afterAll() {
     AkkaTestUtils.shutdownAndWait(LocalContextSupervisorSpec.system)

--- a/job-server/src/test/scala/spark/jobserver/NamedObjectsRDDsOnlySpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/NamedObjectsRDDsOnlySpec.scala
@@ -4,14 +4,16 @@ import akka.actor.ActorSystem
 import akka.testkit.{ImplicitSender, TestKit}
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.storage.StorageLevel
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import spark.jobserver.common.akka.AkkaTestUtils
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
 /**
  * please note that this test only uses RDDs as named objects, there exists another test class
  * in job-server-extras that uses a combination of RDDs and DataFrames
  */
-class NamedObjectsRDDsOnlySpec extends TestKit(ActorSystem("NamedObjectsSpec")) with FunSpecLike
+class NamedObjectsRDDsOnlySpec extends TestKit(ActorSystem("NamedObjectsSpec")) with AnyFunSpecLike
     with ImplicitSender with Matchers with BeforeAndAfter with BeforeAndAfterAll {
   
   val sc = new SparkContext("local[2]", getClass.getSimpleName, new SparkConf)

--- a/job-server/src/test/scala/spark/jobserver/SparkJobSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/SparkJobSpec.scala
@@ -1,8 +1,9 @@
 package spark.jobserver
 
-import org.scalatest.{Matchers, FunSpec}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class SparkJobSpec extends FunSpec with Matchers {
+class SparkJobSpec extends AnyFunSpec with Matchers {
   val validSparkValidation = SparkJobValid
   val invalidSparkValidation = SparkJobInvalid("Sample message 1")
   val invalidSparkValidation2 = SparkJobInvalid("Sample message 2")

--- a/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
@@ -1,13 +1,11 @@
 package spark.jobserver
 
 import java.net.MalformedURLException
-
 import akka.actor.{Actor, ActorSystem, Props}
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.testkit.TestKit
 import com.typesafe.config.ConfigFactory
-import org.joda.time.DateTime
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
@@ -15,6 +13,8 @@ import spark.jobserver.JobManagerActor.JobKilledException
 import spark.jobserver.io.JobDAOActor._
 import spark.jobserver.io._
 import spark.jobserver.util.ErrorData
+
+import java.time.{Instant, ZoneId, ZonedDateTime}
 
 // Tests web response codes and formatting
 // Does NOT test underlying Supervisor / JarManager functionality
@@ -49,7 +49,7 @@ with ScalatestRouteTest with ScalaFutures with SprayJsonSupport {
   val api = new WebApi(system, config, dummyPort, dummyActor, dummyActor, dummyActor, dummyActor, null)
   val routes = api.myRoutes
 
-  val dt = DateTime.parse("2013-05-29T00Z")
+  val dt = Instant.parse("2013-05-29T00:00:00Z").atZone(ZoneId.of("UTC"))
   val binaryInfo = BinaryInfo("demo", BinaryType.Jar, dt)
   val baseJobInfo = JobInfo("foo-1", "cid", "context", "com.abc.meme", JobStatus.Running, dt,
       None, None, Seq(binaryInfo))
@@ -243,7 +243,7 @@ with ScalatestRouteTest with ScalaFutures with SprayJsonSupport {
       case GetJobConfig(_) => sender ! JobConfig(Some(config))
 
       case SaveJobConfig(_, _) => sender ! JobConfigStored
-      case KillJob(jobId) => sender ! JobKilled(jobId, DateTime.now())
+      case KillJob(jobId) => sender ! JobKilled(jobId, ZonedDateTime.now())
 
       case GetSparkContexData("context1") => sender ! SparkContexData(
         "context1", Some("local-1337"), Some("http://spark:4040"))

--- a/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/WebApiSpec.scala
@@ -8,17 +8,19 @@ import akka.testkit.TestKit
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Seconds, Span}
-import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
 import spark.jobserver.JobManagerActor.JobKilledException
 import spark.jobserver.io.JobDAOActor._
 import spark.jobserver.io._
 import spark.jobserver.util.ErrorData
 
 import java.time.{Instant, ZoneId, ZonedDateTime}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 // Tests web response codes and formatting
 // Does NOT test underlying Supervisor / JarManager functionality
-class WebApiSpec extends FunSpec with Matchers with BeforeAndAfterAll
+class WebApiSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll
 with ScalatestRouteTest with ScalaFutures with SprayJsonSupport {
   import scala.collection.JavaConverters._
 

--- a/job-server/src/test/scala/spark/jobserver/auth/LdapGroupRealmSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/auth/LdapGroupRealmSpec.scala
@@ -1,6 +1,6 @@
 package spark.jobserver.auth
 
-import org.scalatest.{ FunSpecLike, FunSpec, BeforeAndAfter, BeforeAndAfterAll, Matchers }
+import org.scalatest.{ BeforeAndAfter, BeforeAndAfterAll }
 import org.apache.shiro.config.IniSecurityManagerFactory
 import org.apache.shiro.mgt.DefaultSecurityManager
 import org.apache.shiro.mgt.SecurityManager
@@ -12,12 +12,14 @@ import javax.naming.ldap.InitialLdapContext
 import javax.naming.ldap.LdapContext
 import javax.naming._
 import javax.naming.directory._
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
 object LdapGroupRealmSpec {
   val memberAttributeName = "memberUid"
 }
 
-class LdapGroupRealmSpec extends FunSpecLike with Matchers {
+class LdapGroupRealmSpec extends AnyFunSpecLike with Matchers {
   import collection.JavaConverters._
 
   private val IniConfig = """

--- a/job-server/src/test/scala/spark/jobserver/auth/SJSAccessControlSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/auth/SJSAccessControlSpec.scala
@@ -6,7 +6,7 @@ import akka.testkit.TestKit
 import com.typesafe.config.{Config, ConfigFactory}
 import io.jsonwebtoken._
 import org.apache.shiro.codec.Base64
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 import java.security.spec.X509EncodedKeySpec
 import java.security.{Key, KeyFactory}
@@ -14,8 +14,10 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
 import Permissions._
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
-class SJSAccessControlSpec extends FunSpecLike
+class SJSAccessControlSpec extends AnyFunSpecLike
     with ScalatestRouteTest with Matchers with BeforeAndAfter with BeforeAndAfterAll {
 
   //set this to true to check your real ldap server

--- a/job-server/src/test/scala/spark/jobserver/auth/WebApiWithAuthenticationSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/auth/WebApiWithAuthenticationSpec.scala
@@ -10,7 +10,7 @@ import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.testkit.TestKit
 import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
-import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
 import spark.jobserver._
 import spark.jobserver.auth.SJSAccessControl.Challenge
 import spark.jobserver.io.JobDAOActor.GetJobInfo
@@ -21,11 +21,13 @@ import java.time.{Instant, ZoneId, ZonedDateTime}
 import scala.collection.mutable.SynchronizedSet
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 // Tests authorization only, actual responses are tested elsewhere
 // Does NOT test underlying Supervisor / JarManager functionality
 // HttpService trait is needed for the seal() which wraps exception handling
-class WebApiWithAuthenticationSpec extends FunSpec with Matchers with BeforeAndAfterAll
+class WebApiWithAuthenticationSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll
     with ScalatestRouteTest with SprayJsonSupport{
   import spray.json._
   import DefaultJsonProtocol._

--- a/job-server/src/test/scala/spark/jobserver/auth/WebApiWithAuthenticationSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/auth/WebApiWithAuthenticationSpec.scala
@@ -10,7 +10,6 @@ import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.testkit.TestKit
 import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
-import org.joda.time.DateTime
 import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 import spark.jobserver._
 import spark.jobserver.auth.SJSAccessControl.Challenge
@@ -18,6 +17,7 @@ import spark.jobserver.io.JobDAOActor.GetJobInfo
 import spark.jobserver.io.{BinaryInfo, BinaryType, JobInfo, JobStatus}
 import spark.jobserver.util.SparkJobUtils
 
+import java.time.{Instant, ZoneId, ZonedDateTime}
 import scala.collection.mutable.SynchronizedSet
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
@@ -117,7 +117,7 @@ class WebApiWithAuthenticationSpec extends FunSpec with Matchers with BeforeAndA
   private val authorizationUnknownUser = new Authorization(new BasicHttpCredentials("whoami", "xxx"))
   private val authorizationRestrictedUser = new Authorization(
     new BasicHttpCredentials(RESTRICTED_USER, "12345"))
-  private val dt = DateTime.parse("2013-05-29T00Z")
+  private val dt = Instant.parse("2013-05-29T00:00:00Z").atZone(ZoneId.systemDefault())
   private val jobInfo = JobInfo("foo-1", "cid", "context", "com.abc.meme",
       JobStatus.Running, dt, None, None, Seq(BinaryInfo("demo", BinaryType.Jar, dt)))
   private val ResultKey = "result"

--- a/job-server/src/test/scala/spark/jobserver/io/BinaryDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/BinaryDAOSpec.scala
@@ -1,8 +1,10 @@
 package spark.jobserver.io
 
-import org.scalatest.{BeforeAndAfterAll, FunSpecLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
-class BinaryDAOSpec extends FunSpecLike with BeforeAndAfterAll with Matchers{
+class BinaryDAOSpec extends AnyFunSpecLike with BeforeAndAfterAll with Matchers{
 
   describe("binary hash conversions") {
     it("should convert byte hash to string and back") {

--- a/job-server/src/test/scala/spark/jobserver/io/BinarySqlDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/BinarySqlDAOSpec.scala
@@ -1,17 +1,19 @@
 package spark.jobserver.io
 
 import com.typesafe.config.{Config, ConfigFactory}
-import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
+import org.scalatest.BeforeAndAfter
 import spark.jobserver.TestJarFinder
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
 abstract class BinarySqlDAOSpecBase {
   def config : Config
 }
 
-class BinarySqlDAOSpec extends  BinarySqlDAOSpecBase with TestJarFinder with FunSpecLike with Matchers
+class BinarySqlDAOSpec extends  BinarySqlDAOSpecBase with TestJarFinder with AnyFunSpecLike with Matchers
   with BeforeAndAfter {
   override def config: Config = ConfigFactory.load("local.test.binarysqldao.conf")
   private val timeout = 60 seconds

--- a/job-server/src/test/scala/spark/jobserver/io/DAOTestsHelper.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/DAOTestsHelper.scala
@@ -3,8 +3,8 @@ package spark.jobserver.io
 import akka.actor.ActorSystem
 import akka.testkit.TestProbe
 import com.typesafe.config.Config
-import org.joda.time.DateTime
 
+import java.time.ZonedDateTime
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -16,7 +16,7 @@ object DAOTestsHelper {
   val binaryDAOSuccessId: String = BinaryDAO.calculateBinaryHashString(binaryDAOBytesSuccess)
   val binaryDAOBytesFail: Array[Byte] = "To test failures BinaryDAO".toCharArray.map(_.toByte)
   val binaryDAOFailId: String = BinaryDAO.calculateBinaryHashString(binaryDAOBytesFail)
-  val defaultDate: DateTime = DateTime.now()
+  val defaultDate: ZonedDateTime = ZonedDateTime.now()
   val someBinaryName: String = "name-del-info-success"
   val someBinaryId = BinaryDAO.calculateBinaryHashString(Array(10, 11, 12))
   val someBinaryInfo: BinaryInfo = BinaryInfo(someBinaryName, BinaryType.Jar, defaultDate, Some(someBinaryId))
@@ -73,7 +73,7 @@ class DummyMetaDataDAO(config: Config) extends MetaDataDAO {
 
   override def saveBinary(name: String,
                           binaryType: BinaryType,
-                          uploadTime: DateTime,
+                          uploadTime: ZonedDateTime,
                           id: String): Future[Boolean] = {
     name match {
       case message if message.contains("save-info-success") || message == "success" =>
@@ -123,7 +123,7 @@ class DummyMetaDataDAO(config: Config) extends MetaDataDAO {
       case message if message.contains("get-info-success") || message == "success" =>
         DAOTestsHelper.testProbe.ref ! "MetaDataDAO: getBinary success"
         Future.successful(Some(
-          BinaryInfo("success", BinaryType.Jar, DateTime.now(), Some(DAOTestsHelper.binaryDAOSuccessId)))
+          BinaryInfo("success", BinaryType.Jar, ZonedDateTime.now(), Some(DAOTestsHelper.binaryDAOSuccessId)))
         )
       case _ =>
         DAOTestsHelper.testProbe.ref ! "MetaDataDAO: getBinary failed"
@@ -161,7 +161,7 @@ class DummyMetaDataDAO(config: Config) extends MetaDataDAO {
       case message if message.contains("get-info-success") || message == "success" =>
         DAOTestsHelper.testProbe.ref ! "MetaDataDAO: getBinariesByStorageId success yes"
         Future.successful(Seq(
-          BinaryInfo("success", BinaryType.Jar, DateTime.now(), Some(DAOTestsHelper.binaryDAOSuccessId)))
+          BinaryInfo("success", BinaryType.Jar, ZonedDateTime.now(), Some(DAOTestsHelper.binaryDAOSuccessId)))
         )
       case _ =>
         DAOTestsHelper.testProbe.ref ! "MetaDataDAO: getBinariesByStorageId success"

--- a/job-server/src/test/scala/spark/jobserver/io/FileCacherRandomDirSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/FileCacherRandomDirSpec.scala
@@ -1,11 +1,12 @@
 package spark.jobserver.io
 
 import java.io.File
-import org.scalatest.{FunSpecLike, Matchers}
 
 import java.time.ZonedDateTime
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
-class FileCacherRandomDirSpec extends FileCacher with FunSpecLike with Matchers {
+class FileCacherRandomDirSpec extends FileCacher with AnyFunSpecLike with Matchers {
   override val rootDirPath: String = s"/tmp/spark-jobserver/${util.Random.alphanumeric.take(30).mkString}"
   override val rootDirFile: File = new File(rootDirPath)
 

--- a/job-server/src/test/scala/spark/jobserver/io/FileCacherRandomDirSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/FileCacherRandomDirSpec.scala
@@ -1,9 +1,9 @@
 package spark.jobserver.io
 
 import java.io.File
-
-import org.joda.time.DateTime
 import org.scalatest.{FunSpecLike, Matchers}
+
+import java.time.ZonedDateTime
 
 class FileCacherRandomDirSpec extends FileCacher with FunSpecLike with Matchers {
   override val rootDirPath: String = s"/tmp/spark-jobserver/${util.Random.alphanumeric.take(30).mkString}"
@@ -12,7 +12,7 @@ class FileCacherRandomDirSpec extends FileCacher with FunSpecLike with Matchers 
   it("should create cache directory if it doesn't exist") {
     val bytes = "some test content".toCharArray.map(_.toByte)
     val appName = "test-file-cached"
-    val currentTime = DateTime.now
+    val currentTime = ZonedDateTime.now
     val targetBinName = createBinaryName(appName, BinaryType.Jar, currentTime)
     cacheBinary(appName, BinaryType.Jar, currentTime, bytes)
     val file = new File(rootDirPath, targetBinName)

--- a/job-server/src/test/scala/spark/jobserver/io/FileCacherSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/FileCacherSpec.scala
@@ -1,9 +1,9 @@
 package spark.jobserver.io
 
 import java.io.File
-
-import org.joda.time.DateTime
 import org.scalatest.{FunSpecLike, Matchers}
+
+import java.time.ZonedDateTime
 
 class FileCacherSpec extends FileCacher with FunSpecLike with Matchers {
 
@@ -11,7 +11,7 @@ class FileCacherSpec extends FileCacher with FunSpecLike with Matchers {
   override val rootDirFile: File = new File(rootDirPath)
 
   it("produces binary name") {
-    val appName = createBinaryName("job", BinaryType.Jar, DateTime.parse("2016-10-10T13:00:00Z"))
+    val appName = createBinaryName("job", BinaryType.Jar, ZonedDateTime.parse("2016-10-10T13:00:00Z"))
     appName should be("job-20161010_130000_000.jar")
   }
 
@@ -24,7 +24,7 @@ class FileCacherSpec extends FileCacher with FunSpecLike with Matchers {
   it("should cache binary in current directory (default '.')") {
     val bytes = "some test content".toCharArray.map(_.toByte)
     val appName = "test-file-cached"
-    val currentTime = DateTime.now
+    val currentTime = ZonedDateTime.now
     val targetBinName = createBinaryName(appName, BinaryType.Jar, currentTime)
     cacheBinary(appName, BinaryType.Jar, currentTime, bytes)
     val file = new File(rootDirPath, targetBinName)

--- a/job-server/src/test/scala/spark/jobserver/io/FileCacherSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/FileCacherSpec.scala
@@ -1,11 +1,12 @@
 package spark.jobserver.io
 
 import java.io.File
-import org.scalatest.{FunSpecLike, Matchers}
 
 import java.time.ZonedDateTime
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
-class FileCacherSpec extends FileCacher with FunSpecLike with Matchers {
+class FileCacherSpec extends FileCacher with AnyFunSpecLike with Matchers {
 
   override val rootDirPath: String = "."
   override val rootDirFile: File = new File(rootDirPath)

--- a/job-server/src/test/scala/spark/jobserver/io/HdfsBinaryDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/HdfsBinaryDAOSpec.scala
@@ -1,15 +1,17 @@
 package spark.jobserver.io
 
 import com.typesafe.config.{Config, ConfigFactory}
-import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
 import spark.jobserver.util.HadoopFSFacade
 import spark.jobserver.JobServer.InvalidConfiguration
 import spark.jobserver.util.HDFSCluster
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class HdfsBinaryDAOSpec extends FunSpec with Matchers with BeforeAndAfterAll with HDFSCluster {
+class HdfsBinaryDAOSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll with HDFSCluster {
   private var hdfsDAO: HdfsBinaryDAO = _
   private var testDir: String = _
   private val testFileName = "test_file"

--- a/job-server/src/test/scala/spark/jobserver/io/InMemoryMetaDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/InMemoryMetaDAOSpec.scala
@@ -1,14 +1,16 @@
 package spark.jobserver.io
 
 import java.util.concurrent.TimeUnit
-import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
+import org.scalatest.BeforeAndAfter
 
 import java.time.ZonedDateTime
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
-class InMemoryMetaDAOSpec extends FunSpecLike with Matchers with BeforeAndAfter {
+class InMemoryMetaDAOSpec extends AnyFunSpecLike with Matchers with BeforeAndAfter {
 
   private var inMemoryMetaDao: InMemoryMetaDAO = _
 

--- a/job-server/src/test/scala/spark/jobserver/io/InMemoryMetaDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/InMemoryMetaDAOSpec.scala
@@ -1,10 +1,9 @@
 package spark.jobserver.io
 
 import java.util.concurrent.TimeUnit
-
-import org.joda.time.DateTime
 import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
 
+import java.time.ZonedDateTime
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -19,7 +18,7 @@ class InMemoryMetaDAOSpec extends FunSpecLike with Matchers with BeforeAndAfter 
 
   describe("Get binaries tests") {
     it("should return latest binaries for each name group if uploaded with same name") {
-      val current = DateTime.now()
+      val current = ZonedDateTime.now()
 
       val binariesFuture = for {
         _ <- inMemoryMetaDao.saveBinary("test", BinaryType.Jar, current, "")
@@ -37,7 +36,7 @@ class InMemoryMetaDAOSpec extends FunSpecLike with Matchers with BeforeAndAfter 
     }
 
     it("should get the latest one if multiple binaries are uploaded with the same name") {
-      val current = DateTime.now()
+      val current = ZonedDateTime.now()
 
       val binariesFuture = for {
         _ <- inMemoryMetaDao.saveBinary("test", BinaryType.Jar, current, "")
@@ -54,7 +53,7 @@ class InMemoryMetaDAOSpec extends FunSpecLike with Matchers with BeforeAndAfter 
     }
 
     it("should delete binary") {
-      val current = DateTime.now()
+      val current = ZonedDateTime.now()
 
       val binariesFuture = for {
         _ <- inMemoryMetaDao.saveBinary("test", BinaryType.Jar, current, "")
@@ -72,7 +71,7 @@ class InMemoryMetaDAOSpec extends FunSpecLike with Matchers with BeforeAndAfter 
     }
 
     it("should get binaries based on storage id") {
-      val current = DateTime.now()
+      val current = ZonedDateTime.now()
 
       val binariesFuture = for {
         _ <- inMemoryMetaDao.saveBinary("test", BinaryType.Jar, current, "s1")

--- a/job-server/src/test/scala/spark/jobserver/io/JobDAOActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/JobDAOActorSpec.scala
@@ -6,7 +6,7 @@ import akka.pattern.ask
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import akka.util.Timeout
 import com.typesafe.config.{Config, ConfigFactory}
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import spark.jobserver.JobManagerActor.ContextTerminatedException
 import spark.jobserver.io.JobDAOActor._
 import spark.jobserver.common.akka.AkkaTestUtils
@@ -17,6 +17,8 @@ import java.time.format.DateTimeFormatter
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
 object JobDAOActorSpec {
   val system = ActorSystem("dao-test")
@@ -31,7 +33,7 @@ object JobDAOActorSpec {
 }
 
 class JobDAOActorSpec extends TestKit(JobDAOActorSpec.system) with ImplicitSender
-  with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
+  with AnyFunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
 
   import JobDAOActorSpec._
   implicit val futureTimeout = Timeout(10.seconds)

--- a/job-server/src/test/scala/spark/jobserver/io/MetaDataSqlDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/MetaDataSqlDAOSpec.scala
@@ -8,18 +8,20 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import java.io.File
 import com.google.common.io.Files
 import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
-import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
+import org.scalatest.BeforeAndAfter
 import spark.jobserver.TestJarFinder
 import spark.jobserver.util.{ErrorData, JobserverConfig}
 
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
 abstract class MetaDataSqlDAOSpecBase {
   def config : Config
 }
 
-class MetaDataSqlDAOSpec extends MetaDataSqlDAOSpecBase with TestJarFinder with FunSpecLike with Matchers
+class MetaDataSqlDAOSpec extends MetaDataSqlDAOSpecBase with TestJarFinder with AnyFunSpecLike with Matchers
   with BeforeAndAfter {
   val df = DateTimeFormatter.ofPattern("yyyyMMdd_hhmmss_SSS")
   override def config: Config = ConfigFactory.load("local.test.metadatasqldao.conf")

--- a/job-server/src/test/scala/spark/jobserver/io/zookeeper/AutoPurgeActorSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/zookeeper/AutoPurgeActorSpec.scala
@@ -2,7 +2,7 @@ package spark.jobserver.io.zookeeper
 
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import akka.actor.ActorRef
@@ -23,6 +23,8 @@ import spark.jobserver.io.JobInfo
 import spark.jobserver.util.{CuratorTestCluster, ErrorData, JobserverConfig, Utils}
 
 import java.time.ZonedDateTime
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
 object AutoPurgeActorSpec {
   val system = ActorSystem("test")
@@ -40,7 +42,7 @@ class DummyZookeeperDAOActor(dao : MetaDataZookeeperDAO) extends InstrumentedAct
   }
 }
 
-class AutoPurgeActorSpec extends TestKit(AutoPurgeActorSpec.system) with FunSpecLike with Matchers
+class AutoPurgeActorSpec extends TestKit(AutoPurgeActorSpec.system) with AnyFunSpecLike with Matchers
   with BeforeAndAfter with BeforeAndAfterAll with ImplicitSender{
 
   /*

--- a/job-server/src/test/scala/spark/jobserver/io/zookeeper/MetaDataZookeeperDAOSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/zookeeper/MetaDataZookeeperDAOSpec.scala
@@ -1,7 +1,7 @@
 package spark.jobserver.io.zookeeper
 
 import com.typesafe.config.{Config, ConfigFactory}
-import org.scalatest.{BeforeAndAfter, FunSpec, FunSpecLike, Matchers}
+import org.scalatest.BeforeAndAfter
 import spark.jobserver.io._
 import spark.jobserver.util.{ContextJVMInitializationTimeout, ContextReconnectFailedException, CuratorTestCluster, ErrorData, ResolutionFailedOnStopContextException, Utils}
 import spark.jobserver.TestJarFinder
@@ -9,8 +9,10 @@ import spark.jobserver.TestJarFinder
 import java.time.{Instant, ZoneId, ZonedDateTime}
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
+import org.scalatest.funspec.{ AnyFunSpec, AnyFunSpecLike }
+import org.scalatest.matchers.should.Matchers
 
-class MetaDataZookeeperDAOSpec extends FunSpec with TestJarFinder with FunSpecLike
+class MetaDataZookeeperDAOSpec extends AnyFunSpec with TestJarFinder with AnyFunSpecLike
       with Matchers with BeforeAndAfter {
 
   /*

--- a/job-server/src/test/scala/spark/jobserver/io/zookeeper/ZookeeperUtilsSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/io/zookeeper/ZookeeperUtilsSpec.scala
@@ -2,14 +2,16 @@ package spark.jobserver.io.zookeeper
 
 import com.typesafe.config.{Config, ConfigFactory}
 import spark.jobserver.io.{BinaryInfo, BinaryType}
-import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfter
 import spark.jobserver.util.{CuratorTestCluster, JsonProtocols}
 import org.apache.curator.framework.CuratorFramework
 import spark.jobserver.JobServer.InvalidConfiguration
 
 import java.time.ZonedDateTime
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class ZookeeperUtilsSpec extends FunSpec with Matchers with BeforeAndAfter {
+class ZookeeperUtilsSpec extends AnyFunSpec with Matchers with BeforeAndAfter {
   private val testServer = new CuratorTestCluster()
 
   def config: Config = ConfigFactory.parseString(

--- a/job-server/src/test/scala/spark/jobserver/util/DAOCleanupSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/util/DAOCleanupSpec.scala
@@ -2,7 +2,6 @@ package spark.jobserver.io.zookeeper
 
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
-import org.joda.time.DateTime
 import org.scalatest.BeforeAndAfter
 import org.scalatest.FunSpecLike
 import org.scalatest.Matchers
@@ -10,6 +9,8 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import spark.jobserver.io._
 import spark.jobserver.util.{CuratorTestCluster, NoCorrespondingContextAliveException, Utils, ZKCleanup}
+
+import java.time.{Instant, ZoneId, ZonedDateTime}
 
 class DAOCleanupSpec extends FunSpecLike with Matchers with BeforeAndAfter {
 
@@ -44,8 +45,8 @@ class DAOCleanupSpec extends FunSpecLike with Matchers with BeforeAndAfter {
    * Test data
    */
 
-  val date = new DateTime(1548683342369L)
-  val otherDate = new DateTime(1548683342370L)
+  val date = ZonedDateTime.ofInstant(Instant.ofEpochMilli(1548683342369L), ZoneId.systemDefault())
+  val otherDate = ZonedDateTime.ofInstant(Instant.ofEpochMilli(1548683342370L), ZoneId.systemDefault())
   val bin = BinaryInfo("binaryWithJar", BinaryType.Jar, date, Some(BinaryDAO.calculateBinaryHashString("1".getBytes)))
 
   val runningJob = JobInfo("1", "someContextId", "someContextName",

--- a/job-server/src/test/scala/spark/jobserver/util/DAOCleanupSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/util/DAOCleanupSpec.scala
@@ -3,16 +3,16 @@ package spark.jobserver.io.zookeeper
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 import org.scalatest.BeforeAndAfter
-import org.scalatest.FunSpecLike
-import org.scalatest.Matchers
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import spark.jobserver.io._
 import spark.jobserver.util.{CuratorTestCluster, NoCorrespondingContextAliveException, Utils, ZKCleanup}
 
 import java.time.{Instant, ZoneId, ZonedDateTime}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
-class DAOCleanupSpec extends FunSpecLike with Matchers with BeforeAndAfter {
+class DAOCleanupSpec extends AnyFunSpecLike with Matchers with BeforeAndAfter {
 
   /*
    * Setup

--- a/job-server/src/test/scala/spark/jobserver/util/ForcefulKillSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/util/ForcefulKillSpec.scala
@@ -7,17 +7,19 @@ import akka.testkit.TestKit
 import com.typesafe.config.{Config, ConfigFactory}
 
 import collection.JavaConverters._
-import org.scalatest.{BeforeAndAfterAll, FunSpecLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
 import spark.jobserver.io.ContextInfo
 
 import java.time.ZonedDateTime
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
 object ForcefulKillSpec {
   val PRIMARY_MASTER = 0
   val SECONDARY_MASTER = 1
 }
 
-class ForcefulKillSpec extends TestKit(ActorSystem("test")) with FunSpecLike
+class ForcefulKillSpec extends TestKit(ActorSystem("test")) with AnyFunSpecLike
   with Matchers with BeforeAndAfterAll {
 
   override def afterAll(): Unit = {

--- a/job-server/src/test/scala/spark/jobserver/util/ForcefulKillSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/util/ForcefulKillSpec.scala
@@ -1,16 +1,16 @@
 package spark.jobserver.util
 
 import java.nio.charset.Charset
-
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{HttpEntity, HttpMethods, HttpRequest, HttpResponse, StatusCodes}
 import akka.testkit.TestKit
 import com.typesafe.config.{Config, ConfigFactory}
 
 import collection.JavaConverters._
-import org.joda.time.DateTime
 import org.scalatest.{BeforeAndAfterAll, FunSpecLike, Matchers}
 import spark.jobserver.io.ContextInfo
+
+import java.time.ZonedDateTime
 
 object ForcefulKillSpec {
   val PRIMARY_MASTER = 0
@@ -48,7 +48,7 @@ class ForcefulKillSpec extends TestKit(ActorSystem("test")) with FunSpecLike
     ConfigFactory.parseMap(configMap.asJava).withFallback(ConfigFactory.defaultOverrides())
   }
 
-  val unusedContextInfo = ContextInfo("a", "a", "", None, DateTime.now(), None, "", None)
+  val unusedContextInfo = ContextInfo("a", "a", "", None, ZonedDateTime.now(), None, "", None)
 
   describe("Spark standalone forceful UI kill") {
     it("should be able to kill the application") {

--- a/job-server/src/test/scala/spark/jobserver/util/HadoopFSFacadeSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/util/HadoopFSFacadeSpec.scala
@@ -5,9 +5,11 @@ import java.io.{File, InputStream}
 import com.typesafe.config.Config
 import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
-import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class HadoopFSFacadeSpec extends FunSpec with Matchers with BeforeAndAfterAll with HDFSCluster {
+class HadoopFSFacadeSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll with HDFSCluster {
   private var config: Config = _
   private var testClusterUrl: String = _
   private var hdfsFacade: HadoopFSFacade = _

--- a/job-server/src/test/scala/spark/jobserver/util/JsonProtocolsSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/util/JsonProtocolsSpec.scala
@@ -1,18 +1,14 @@
 package spark.jobserver.util
 
-import org.joda.time.DateTime
 import org.scalatest.BeforeAndAfter
 import org.scalatest.FunSpec
-import org.scalatest.Matchers
-
-import spark.jobserver.io.BinaryInfo
-import spark.jobserver.io.BinaryType
-import spark.jobserver.io.JobInfo
+import org.scalatest.matchers.should.Matchers
+import spark.jobserver.io.{BinaryInfo, BinaryType, ContextInfo, JobInfo}
 import spark.jobserver.util.JsonProtocols._
 import spray.json._
-import DefaultJsonProtocol._
-import spark.jobserver.io.ContextInfo
-import java.text.SimpleDateFormat
+
+import java.time.{ZoneId, ZonedDateTime}
+import java.util.TimeZone
 
 class JsonProtocolsSpec extends FunSpec with Matchers with BeforeAndAfter {
 
@@ -21,11 +17,11 @@ class JsonProtocolsSpec extends FunSpec with Matchers with BeforeAndAfter {
    */
 
   // Date formatting
-  val df = new SimpleDateFormat("yyyy-MM-dd HH-mm-ss SS Z")
-  val earlyDate = new DateTime().minusHours(1)
-  val date = new DateTime()
-  val earlyDateStr = df.format(earlyDate.getMillis)
-  val dateStr = df.format(date.getMillis)
+  val earlyDate = ZonedDateTime.of(2021, 5, 11, 12, 15, 0, 250000000, ZoneId.of("Europe/Berlin"))
+  val date = ZonedDateTime.of(2021, 5, 11, 13, 15, 0, 250000000, ZoneId.of("Europe/Berlin"))
+  val earlyDateStr = "2021-05-11T12:15:00.250+02:00"
+  val dateStr = "2021-05-11T13:15:00.250+02:00"
+  val legacyDateStr = "2021-05-11 13-15-00 250 +0200"
 
   // BinaryInfo
   val testBinaryInfo = BinaryInfo("SomeName", BinaryType.Jar, earlyDate, Some("SomeStorId"))
@@ -37,10 +33,10 @@ class JsonProtocolsSpec extends FunSpec with Matchers with BeforeAndAfter {
 
   // JobInfo
   val testJobInfo = JobInfo("SomeJobId", "SomeContextId", "SomeContextName",
-      "SomeClassPath", "SomeState", earlyDate, Some(date), Some(ErrorData("SomeMessage",
+    "SomeClassPath", "SomeState", earlyDate, Some(date), Some(ErrorData("SomeMessage",
       "SomeClass", "SomeTrace")), Seq.empty, None)
   val testJobInfo2 = JobInfo("SomeJobId", "SomeContextId", "SomeContextName",
-      "SomeClassPath", "SomeState", earlyDate, None, None, Seq.empty, None)
+    "SomeClassPath", "SomeState", earlyDate, None, None, Seq.empty, None)
   val testJobInfoWithCp = JobInfo("SomeJobId", "SomeContextId", "SomeContextName",
     "SomeClassPath", "SomeState", earlyDate, Some(date), Some(ErrorData("SomeMessage",
       "SomeClass", "SomeTrace")), Seq(testBinaryInfo, testBinaryInfo2), None)
@@ -51,11 +47,24 @@ class JsonProtocolsSpec extends FunSpec with Matchers with BeforeAndAfter {
   val testJobInfoWithBinInfoJson = f"""{"binaryInfo":{"appName":"SomeName","binaryType":"Jar","uploadTime":"${earlyDateStr}","binaryStorageId":"SomeStorId"},"classPath":"SomeClassPath","contextId":"SomeContextId","contextName":"SomeContextName","cp":[],"endTime":"${dateStr}","error":{"message":"SomeMessage","errorClass":"SomeClass","stackTrace":"SomeTrace"},"jobId":"SomeJobId","startTime":"${earlyDateStr}","state":"SomeState"}"""
   // ContextInfo
   val testContextInfo = ContextInfo("someId", "someName", "someConfig", Some("ActorAddress"),
-      earlyDate, Some(date), "someState", Some(new Throwable("message")))
+    earlyDate, Some(date), "someState", Some(new Throwable("message")))
   val testContextInfo2 = ContextInfo("someId", "someName", "someConfig", None, earlyDate, None,
-      "someState", None)
+    "someState", None)
+  val testContextInfo3 = ContextInfo("someId", "someName", "someConfig", None, date, None,
+    "someState", None)
   val testContextInfoJson = f"""{"actorAddress":"ActorAddress","config":"someConfig","endTime":"${dateStr}","error":"message","id":"someId","name":"someName","startTime":"${earlyDateStr}","state":"someState"}"""
   val testContextInfo2Json = f"""{"actorAddress":null,"config":"someConfig","endTime":null,"error":null,"id":"someId","name":"someName","startTime":"${earlyDateStr}","state":"someState"}"""
+  val testContextInfo3Json = f"""{"actorAddress":null,"config":"someConfig","endTime":null,"error":null,"id":"someId","name":"someName","startTime":"${legacyDateStr}","state":"someState"}"""
+
+  private val originalTimezone = TimeZone.getDefault
+
+  before {
+    TimeZone.setDefault(TimeZone.getTimeZone("Europe/Berlin"))
+  }
+
+  after {
+    TimeZone.setDefault(originalTimezone)
+  }
 
   /*
    * Test: BinaryInfo
@@ -147,6 +156,13 @@ class JsonProtocolsSpec extends FunSpec with Matchers with BeforeAndAfter {
       a should equal(b)
     }
 
+    it("should deserialize ContextInfo with old timestamps") {
+      val deserial = testContextInfo3Json.parseJson.convertTo[ContextInfo]
+      val a = deserial
+      val b = testContextInfo3
+      a should equal(b)
+    }
+
     it("should handle the absence of optional ContextInfo values correctly") {
       val serial = testContextInfo2.toJson
       serial.compactPrint should equal(testContextInfo2Json)
@@ -154,5 +170,20 @@ class JsonProtocolsSpec extends FunSpec with Matchers with BeforeAndAfter {
       deserial should equal(testContextInfo2)
     }
 
+  }
+
+  describe("Joda Time") {
+    it("should serialize a UTC timestamp like Joda") {
+      val date = ZonedDateTime.of(2015, 10, 16, 3, 17, 3, 127000000, ZoneId.of("UTC"))
+      JsonProtocols.fromDateTime(date) should equal("2015-10-16T03:17:03.127Z")
+    }
+
+    it("should serialize a timestamp with timezone like Joda") {
+      val date1 = ZonedDateTime.of(2016, 6, 19, 16, 27, 12, 196000000, ZoneId.of("+05:30"))
+      JsonProtocols.fromDateTime(date1) should equal("2016-06-19T16:27:12.196+05:30")
+
+      val date2 = ZonedDateTime.of(2016, 8, 1, 15, 15, 52, 250000000, ZoneId.of("+01:00"))
+      JsonProtocols.fromDateTime(date2) should equal("2016-08-01T15:15:52.250+01:00")
+    }
   }
 }

--- a/job-server/src/test/scala/spark/jobserver/util/JsonProtocolsSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/util/JsonProtocolsSpec.scala
@@ -1,7 +1,7 @@
 package spark.jobserver.util
 
 import org.scalatest.BeforeAndAfter
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import spark.jobserver.io.{BinaryInfo, BinaryType, ContextInfo, JobInfo}
 import spark.jobserver.util.JsonProtocols._
@@ -10,7 +10,7 @@ import spray.json._
 import java.time.{ZoneId, ZonedDateTime}
 import java.util.TimeZone
 
-class JsonProtocolsSpec extends FunSpec with Matchers with BeforeAndAfter {
+class JsonProtocolsSpec extends AnyFunSpec with Matchers with BeforeAndAfter {
 
   /*
    * Test data

--- a/job-server/src/test/scala/spark/jobserver/util/ManagerLauncherSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/util/ManagerLauncherSpec.scala
@@ -1,14 +1,16 @@
 package spark.jobserver.util
 
-import org.scalatest.{ Matchers, FunSpec, BeforeAndAfter}
+import org.scalatest.BeforeAndAfter
 import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.commons.collections.map.MultiValueMap
 import scala.collection.mutable.HashMap
 import collection.JavaConverters._
 import java.io.File
 import org.apache.spark.launcher.{SparkLauncher, SparkAppHandle}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class ManagerLauncherSpec extends FunSpec with Matchers with BeforeAndAfter with HDFSCluster {
+class ManagerLauncherSpec extends AnyFunSpec with Matchers with BeforeAndAfter with HDFSCluster {
     val stubbedSparkLauncher = new StubbedSparkLauncher()
     val environment = new InMemoryEnvironment
 

--- a/job-server/src/test/scala/spark/jobserver/util/SSLContextFactorySpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/util/SSLContextFactorySpec.scala
@@ -2,11 +2,12 @@ package spark.jobserver.util
 
 import com.typesafe.config.{ ConfigFactory, ConfigValueFactory }
 import org.apache.spark.SparkConf
-import org.scalatest.{ Matchers, FunSpec }
 import java.io.FileNotFoundException
 import javax.net.ssl.SSLContext
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class SSLContextFactorySpec extends FunSpec with Matchers {
+class SSLContextFactorySpec extends AnyFunSpec with Matchers {
   import collection.JavaConverters._
 
   val config = ConfigFactory.parseMap(Map(

--- a/job-server/src/test/scala/spark/jobserver/util/StartJobSerializerSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/util/StartJobSerializerSpec.scala
@@ -7,16 +7,17 @@ import org.scalatest.{FunSpecLike, Matchers}
 import spark.jobserver.JobManagerActor.StartJob
 import spark.jobserver.CommonMessages.{JobErroredOut, JobValidationFailed}
 import com.typesafe.config._
-import org.joda.time.DateTime
 import spark.jobserver.io.{BinaryInfo, BinaryType}
+
+import java.time.ZonedDateTime
 
 class StartJobSerializerSpec extends FunSpecLike with Matchers {
 
-  val binInfo: BinaryInfo = BinaryInfo("name", BinaryType.Jar, DateTime.now(), None)
+  val binInfo: BinaryInfo = BinaryInfo("name", BinaryType.Jar, ZonedDateTime.now(), None)
 
   describe("StartJobSerializer") {
     it("should match StartJob after serialize and deserialize") {
-      val binInfo = BinaryInfo("name", BinaryType.Jar, DateTime.now(), None)
+      val binInfo = BinaryInfo("name", BinaryType.Jar, ZonedDateTime.now(), None)
       val startJob = StartJob("spark.jobserver.test.ClassPath", List(binInfo),
         ConfigFactory.parseString("a=2"), Set(classOf[JobErroredOut], classOf[JobValidationFailed]),
         None, Some(Uri("http://example.com")))

--- a/job-server/src/test/scala/spark/jobserver/util/StartJobSerializerSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/util/StartJobSerializerSpec.scala
@@ -3,15 +3,16 @@ package spark.jobserver.util
 import akka.http.scaladsl.model.Uri
 
 import java.io.File
-import org.scalatest.{FunSpecLike, Matchers}
 import spark.jobserver.JobManagerActor.StartJob
 import spark.jobserver.CommonMessages.{JobErroredOut, JobValidationFailed}
 import com.typesafe.config._
 import spark.jobserver.io.{BinaryInfo, BinaryType}
 
 import java.time.ZonedDateTime
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
-class StartJobSerializerSpec extends FunSpecLike with Matchers {
+class StartJobSerializerSpec extends AnyFunSpecLike with Matchers {
 
   val binInfo: BinaryInfo = BinaryInfo("name", BinaryType.Jar, ZonedDateTime.now(), None)
 

--- a/job-server/src/test/scala/spark/jobserver/util/UtilsSpec.scala
+++ b/job-server/src/test/scala/spark/jobserver/util/UtilsSpec.scala
@@ -2,10 +2,12 @@ package spark.jobserver.util
 
 import akka.actor.Address
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
+import org.scalatest.BeforeAndAfter
 import spark.jobserver.JobServer
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
-class UtilsSpec extends FunSpecLike with Matchers
+class UtilsSpec extends AnyFunSpecLike with Matchers
   with BeforeAndAfter {
 
   describe("getHASeedNodes tests") {

--- a/project/Assembly.scala
+++ b/project/Assembly.scala
@@ -4,17 +4,17 @@ import sbtassembly.AssemblyPlugin.autoImport._
 
 object Assembly {
   lazy val settings = Seq(
-    assemblyJarName in assembly := "spark-job-server.jar",
+    assembly / assemblyJarName := "spark-job-server.jar",
       // uncomment below to exclude tests
     // test in assembly := {},
-    assemblyExcludedJars in assembly := (fullClasspath in assembly).map(_.filter { cp =>
+    assembly / assemblyExcludedJars := (assembly / fullClasspath).map(_.filter { cp =>
       List("servlet-api", "guice-all", "junit", "uuid",
         "jetty", "jsp-api-2.0", "antlr", "avro", "slf4j-log4j", "log4j-1.2",
         "scala-actors", "commons-cli", "stax-api", "mockito").exists(cp.data.getName.startsWith(_))
     }).value,
     // We don't need the Scala library, Spark already includes it
-    assembleArtifact in assemblyPackageScala := false,
-    assemblyMergeStrategy in assembly := {
+    assemblyPackageScala / assembleArtifact := false,
+    assembly / assemblyMergeStrategy := {
       case m if m.toLowerCase.endsWith("manifest.mf") => MergeStrategy.discard
       case m if m.toLowerCase.matches("meta-inf.*\\.sf$") => MergeStrategy.discard
       case "reference.conf" => MergeStrategy.concat
@@ -23,7 +23,7 @@ object Assembly {
     // NOTE(velvia): Some users have reported NoClassDefFound errors due to this shading.
     // java.lang.NoClassDefFoundError: sjs/shapeless/Poly2$Case2Builder$$anon$3
     // This is disabled for now, if you really need it, re-enable it and good luck!
-    // assemblyShadeRules in assembly := Seq(
+    // assembly / assemblyShadeRules := Seq(
     //   ShadeRule.rename("shapeless.**" -> "sjs.shapeless.@1").inAll
     // )
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,9 +10,7 @@ object Dependencies {
 
   lazy val miscDeps = Seq(
     "org.scalactic" %% "scalactic" % scalactic,
-    "org.mockito" % "mockito-core" % mockito,
-    "org.joda" % "joda-convert" % jodaConvert,
-    "joda-time" % "joda-time" % jodaTime
+    "org.mockito" % "mockito-core" % mockito
   )
 
   lazy val akkaDeps = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   lazy val yammerDeps = "com.yammer.metrics" % "metrics-core" % metrics
 
   lazy val miscDeps = Seq(
-    "org.scalactic" %% "scalactic" % scalatic,
+    "org.scalactic" %% "scalactic" % scalactic,
     "org.mockito" % "mockito-core" % mockito,
     "org.joda" % "joda-convert" % jodaConvert,
     "joda-time" % "joda-time" % jodaTime

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,38 +1,33 @@
-import scala.util.Properties.isJavaAtLeast
-
 object Versions {
-  lazy val spark = sys.env.getOrElse("SPARK_VERSION", "2.4.4")
+  lazy val spark = sys.env.getOrElse("SPARK_VERSION", "2.4.7")
 
   lazy val akka = "2.5.32"
-  lazy val akkaHttp = "10.1.13"
+  lazy val akkaHttp = "10.1.14"
   lazy val akkaHttpCors = "0.4.2"
-  lazy val cassandra = "3.3.0"
   lazy val commons = "1.4"
   lazy val derby = "10.12.1.1"
-  lazy val flyway = "3.2.1"
-  lazy val hadoop = "2.7.3"
+  lazy val flyway = "4.2.0"
+  lazy val hadoop = "2.7.7"
   lazy val h2 = "1.3.176"
   lazy val java = sys.env.getOrElse("JAVA_VERSION", "8-jdk")
   lazy val jjwt = "0.9.1"
   lazy val jwksRsa = "0.15.0"
   lazy val jodaConvert = "1.8.1"
   lazy val jodaTime = "2.9.3"
-  lazy val logback = "1.0.7"
-  lazy val mesos = sys.env.getOrElse("MESOS_VERSION", "1.0.0-2.0.89.ubuntu1404")
+  lazy val logback = "1.2.3"
   lazy val metrics = "2.2.0"
-  lazy val postgres = "9.4.1209"
-  lazy val mysql = "5.1.42"
-  lazy val py4j = "0.10.7"
-  lazy val scalaTest = "3.0.1"
-  lazy val scalatic = "3.0.1"
-  lazy val slf4j = "1.7.25"
-  lazy val mockito = "2.21.0"
-  lazy val shiro = "1.2.4"
+  lazy val postgres = "42.2.19"
+  lazy val mysql = "8.0.23"
+  lazy val py4j = "0.10.9.2"
+  lazy val scalaTest = "3.1.4"
+  lazy val scalactic = "3.1.4"
+  lazy val slf4j = "1.7.30"
+  lazy val mockito = "2.28.2"
+  lazy val shiro = "1.7.1"
   lazy val slick = "3.3.3"
-  lazy val typeSafeConfig = if (isJavaAtLeast("1.8")) "1.3.0" else "1.2.1"
-  lazy val cassandraConnector = "2.4.3"
+  lazy val typeSafeConfig = "1.4.1"
+  lazy val cassandraConnector = "2.5.1"
   lazy val curator = "4.2.0"
   lazy val curatorTest = "4.2.0"
-  lazy val xerces = "2.9.1"
   lazy val commonConfigurations = "1.10"
 }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -12,8 +12,6 @@ object Versions {
   lazy val java = sys.env.getOrElse("JAVA_VERSION", "8-jdk")
   lazy val jjwt = "0.9.1"
   lazy val jwksRsa = "0.15.0"
-  lazy val jodaConvert = "1.8.1"
-  lazy val jodaTime = "2.9.3"
   lazy val logback = "1.2.3"
   lazy val metrics = "2.2.0"
   lazy val postgres = "42.2.19"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.6
+sbt.version=1.5.2

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.11.2-SNAPSHOT"
+ThisBuild / version := "0.11.2-SNAPSHOT"


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

Most referenced libraries are quite outdated. This PR upgrades most of them to the latest compatible version. I also decided to replace joda DateTime with java.time.ZonedDataTime as joda should not be used for Java 8+ projects (see https://www.joda.org/joda-time/). 

I tried to check to the best of my abilities that the behavior did not change at all. Yet, I surely missed some corner cases. It would be great if you can also give it a test.

**Other information**:
derby, h4 and flyway are still quite outdated but updating them are breaking stuff. Therefore, I decided to bump them to the latest non-breaking version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1356)
<!-- Reviewable:end -->
