### PR TITLE
Branch 0.10.x: Switch to JFrog instead of Bintray

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Now you could remove example application and start adding your one.
 ### Creating a project manually assuming that you already have sbt project structure
 In your `build.sbt`, add this to use the job server jar:
 
-        resolvers += "Job Server Bintray" at "https://dl.bintray.com/spark-jobserver/maven"
+        resolvers += "Artifactory" at "https://sparkjobserver.jfrog.io/artifactory/jobserver/"
 
         libraryDependencies += "spark.jobserver" %% "job-server-api" % "0.8.0" % "provided"
 

--- a/build.sbt
+++ b/build.sbt
@@ -300,7 +300,8 @@ lazy val scoverageSettings = {
 
 lazy val publishSettings = Seq(
   licenses += ("Apache-2.0", url("http://choosealicense.com/licenses/apache/")),
-  bintrayOrganization := Some("spark-jobserver")
+  publishTo := Some("Artifactory Realm" at "https://sparkjobserver.jfrog.io/artifactory/jobserver"),
+  credentials += Credentials("Artifactory Realm", "sparkjobserver.jfrog.io", System.getenv("JFROG_USERNAME"), System.getenv("JFROG_PASSWORD"))
 )
 
 // This is here so we can easily switch back to Logback when Spark fixes its log4j dependency.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,8 +12,6 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
 addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.5.1")
 
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
-
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")
 
 addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.5.0")


### PR DESCRIPTION
This is a cherry-pick of the commit https://github.com/spark-jobserver/spark-jobserver/commit/15bff806dd4507a35697c2cfd9c4c09e07266816 made for the `master` branch.

If we merge it into `jobserver-0.10.x` branch, then we can make a new hotfix release `0.10.2` to make this release also available on JFrog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1364)
<!-- Reviewable:end -->
