### PR TITLE
doc(readme): Add hotfix release 0.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Spark Job Server is included in Datastax Enterprise!
 
 | Version     | Spark Version | Scala Version |
 |-------------|---------------|---------------|
+| 0.8.1       | 2.2.0         | 2.11          |
 | 0.10.2      | 2.4.4         | 2.11          |
 | 0.11.1      | 2.4.4         | 2.11, 2.12    |
 


### PR DESCRIPTION
Add release `0.8.1` to the list of releases.
`0.8.x` releases support Spark 2.2 and needed to be republished due to the sunset of Bintray.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1366)
<!-- Reviewable:end -->
