### PR TITLE
Fix installation of SBT in Travis CI

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -3,8 +3,8 @@ FROM openjdk:8-jdk
 USER root
 # install and cache sbt, python
 
-RUN echo 'deb http://dl.bintray.com/sbt/debian /' > /etc/apt/sources.list.d/sbt.list && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 99E82A75642AC823 && \
+RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
+    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add && \
     apt-get -qq update && \
     apt-get install -y --force-yes python3 python3-pip python-pip sbt=1.1.6
 


### PR DESCRIPTION
Currently our Travis CI build is failing due to:
```
gpg: key 99E82A75642AC823: public key "sbt build tool <scalasbt@gmail.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
E: Failed to fetch http://dl.bintray.com/sbt/debian/InRelease  403  Forbidden [IP: 34.212.90.147 80]
```
This seems to be a common issue connected to the Bintray's sunset.
The most common solution is to use https://repo.scala-sbt.org/scalasbt/debian now.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1377)
<!-- Reviewable:end -->
