### PR TITLE
Add dockerfile and docker compose setups

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,4 @@
 /target
-*/target
-**/target
 .git
 .ensime
 .ensime_cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+#
+# Stage 1 : Build
+#
+FROM openjdk:8-jdk-alpine AS build
+
+# Dependency/environment versions
+ARG SBT_VERSION=1.2.8
+ARG SCALA_VERSION=2.11.8
+ARG SPARK_VERSION=2.4.5
+ARG HADOOP_VERSION=2.7
+
+# Install dependencies
+RUN apk add --no-cache bash curl
+
+# Download sbt
+RUN curl -sL "https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz" | gunzip | tar -x -C /usr/local && \
+    ln -s /usr/local/sbt/bin/sbt /usr/local/bin/sbt && \
+    chmod 0755 /usr/local/bin/sbt
+
+RUN mkdir -p /tmp/spark && \
+    mkdir -p /tmp/sparkjobserver
+
+# Install spark
+RUN curl -L -o /tmp/spark.tgz http://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz && \
+    tar -xvzf /tmp/spark.tgz -C /tmp/spark --strip-components 1
+
+# Build jobserver
+COPY . /tmp/sparkjobserver
+WORKDIR /tmp/sparkjobserver
+RUN echo "Building job server..." && \
+    sbt clean job-server-extras/assembly
+
+#
+# Stage 2 : Run
+#
+FROM openjdk:8-jdk-alpine AS jobserver
+
+    # Jobserver settings
+ENV SPARK_JOBSERVER_MEMORY=1G \
+    LOGGING_OPTS="-Dlog4j.configuration=file:/opt/sparkjobserver/config/log4j.properties" \
+    # JobManager settings
+    MANAGER_JAR_FILE=/opt/sparkjobserver/bin/spark-job-server.jar \
+    MANAGER_CONF_FILE=/opt/sparkjobserver/config/jobserver.conf
+
+RUN apk add --no-cache bash
+COPY --from=build /tmp/spark /opt/spark
+COPY --from=build /tmp/sparkjobserver/job-server-extras/target/scala-*/spark-job-server.jar /opt/sparkjobserver/bin/spark-job-server.jar
+
+# 8090: API
+# 9999: JMX
+EXPOSE 8090 9999
+
+# Run jobserver
+CMD /opt/spark/bin/spark-submit \
+    --class spark.jobserver.JobServer \
+    --driver-memory "${SPARK_JOBSERVER_MEMORY}" \
+    --conf "spark.executor.extraJavaOptions=${LOGGING_OPTS}" \
+    --driver-java-options "${LOGGING_OPTS}" \
+    /opt/sparkjobserver/bin/spark-job-server.jar \
+    /opt/sparkjobserver/config/jobserver.conf

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -1,118 +1,77 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
-
-- [Docker](#docker)
-  - [Configuration](#configuration)
-  - [Jars / Passing Arguments to the Start Script](#jars--passing-arguments-to-the-start-script)
-  - [Database, Persistence, Logs](#database-persistence-logs)
-  - [Marathon](#marathon)
-  - [Building docker image from the master branch](#building-docker-image-from-the-master-branch)
-  - [Issues](#issues)
-    - [I can't access a textfile](#i-cant-access-a-textfile)
-    - [Timeouts](#timeouts)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 # Docker
 
-Spark-jobserver is available as a Docker container!  This might be the easiest way to get started and deploy.
+The [Dockerfile](../Dockerfile) in the root directory of this project creates a jobserver container.
+It is the baseline for various [docker setups](../docker-setups/) that simplify development, testing and deployment.
 
-To get started:
+## Build
+You can build the jobserver container image by invoking
+```
+docker build -t jobserver .
+```
+in the project root directory.
 
-    docker run -d -p 8090:8090 sparkjobserver/spark-jobserver:0.7.0.mesos-0.25.0.spark-1.6.2 
-
-This will start job server on port 8090 in a container, with H2 database and Mesos support, and expose that port to the host on which you run the container.
-
-If you would like to debug job server using JMX / VisualVM etc., then also expose port 9999.
-
-## Configuration
-
-By default, the container has an embedded Spark distro and runs using Spark local mode (`local[4]`).
-
-To change the spark master the container runs against, set SPARK_MASTER when you start the container:
-
-    docker run -d -p 8090:8090 -e SPARK_MASTER=mesos://zk://mesos.master:5050 sparkjobserver/spark-jobserver:0.7.0.mesos-0.25.0.spark-1.6.2
-
-You can easily change the amount of memory job server uses with `JOBSERVER_MEMORY`, or replace the entire config job server uses at startup with `JOBSERVER_CONFIG`.
-
-The standard way to replace the config is to derive a custom Docker image from the job server one by overwriting the default config at `app/docker.conf`.  The Dockerfile would look like this:
-
-    from sparkjobserver/spark-jobserver:0.7.0.mesos-0.25.0.spark-1.6.2
-    add /path/to/my/jobserver.conf /app/docker.conf
-
-Similarly, to change the logging configuration, inherit from this container and overwrite `/app/log4j-server.properties`.
-
-## Jars / Passing Arguments to the Start Script
-
-Any `spark-submit` arguments can be passed to the tail of the `docker run` command.  A very common use of this is to add custom jars to your Spark job environment.  For example, to add the Datastax Spark-Cassandra Connector to your job:
-
-    docker run -d -p 8090:8090 sparkjobserver/spark-jobserver:0.7.0.mesos-0.25.0.spark-1.6.2 --packages com.datastax.spark:spark-cassandra-connector_2.10:1.6.1
-
-## Database, Persistence, Logs
-
-Docker containers are usually stateless, but it wouldn't be very useful to have the jars and job config reset every time you had to kill and restart a container.
-
-The job server docker image is configured to use H2 database by default and to write the database to a Docker volume at `/database`, which will be persisted between container restarts, and can even be shared amongst multiple job server containers on the same host. Note that in order to persist them to new containers, you need to create a local directory, something like this:
-
-    docker run -d -p 8090:8090 -v /opt/job-server-db:/database sparkjobserver/spark-jobserver:0.7.0.mesos-0.25.0.spark-1.6.2
-
-See the [Docker Volumes Guide](http://docs-stage.docker.com/userguide/dockervolumes/#volume) for more info.
-
-Another option is to configure job server to persist metadata in PostGres, MySQL, or similar database.  To do that, create a new config, pass it into the docker container as above using `JOBSERVER_CONFIG` and the `/config` volume, and point to your shared database, perhaps using `--link` to a PostGres or MySQL container.
-
-Logging goes to stdout, as per standard Docker conventions.  Therefore:
-
-* Use `docker logs -f <containerHash>` to follow logs
-* Use `docker logs --tail=100 <containerHash>` to list the last 100 lines
-* Use Docker logging drivers to redirect logs to syslog, SumoLogic, etc.
-
-## Marathon
-
-Example Marathon config, thanks to @peterklipfel:
-
-```json
-{
-  "id": "spark.jobserver",
-  "container": {
-    "type": "DOCKER",
-    "docker": {
-      "image": "sparkjobserver/spark-jobserver:0.7.0.mesos-0.25.0.spark-1.6.2",
-      "network": "BRIDGE",
-      "portMappings": [{
-        "containerPort": 8090,
-        "hostPort": 0,
-        "protocol": "tcp"
-      }],
-      "privileged": false
-    }
-  },
-  "args": [
-    "--packages", "com.datastax.spark:spark-cassandra-connector_2.10:1.6.1,com.github.sstone:amqp-client_2.10:1.5,com.rabbitmq:amqp-client:3.2.1, com.typesafe.akka:akka-actor_2.10:2.3.11,com.github.nscala-time:nscala-time_2.10:1.6.0,com.fasterxml.jackson.core:jackson-core:2.2.2, com.fasterxml.jackson.core:jackson-databind:2.2.2,com.fasterxml.jackson.module:jackson-module-scala_2.10:2.2.2,org.scalaj:scalaj-http_2.10:1.1.4,org.elasticsearch:elasticsearch-spark_2.10:2.1.0.Beta3,spark.jobserver:job-server-api:0.6.2,spark.jobserver:job-server-extras:0.6.2"
-  ],
-  "env": {
-    "SPARK_MASTER": "mesos.ourcluster.internal:5050"
-  },
-  "cpus": 0.5,
-  "mem": 100,
-  "instances": 1
-}
+### Arguments
+The Dockerfile defaults to the following build arguments:
+```
+SBT_VERSION=1.2.8
+SCALA_VERSION=2.11.8
+SPARK_VERSION=2.4.5
+HADOOP_VERSION=2.7
+```
+You can override these arguments on `build` with the `--build-arg` parameter:
+```
+docker build --build-arg SCALA_VERSION=2.12.12 -t jobserver .
 ```
 
-## Building docker image from the master branch
-
-If you want to build your docker version based on current master branch:
-
+## Usage
+Having built the container image, you can use it by invoking
 ```
-sbt docker
+docker run -v <config-folder>:/opt/sparkjobserver/config jobserver
+```
+(i.e. bind-mount a config folder inside)
+assuming `config-folder` is an (absolute) path to a directory containing jobserver configuration files.
+You can find examples for configs and config folders under [docker-setups](../docker-setups/).
+
+### Environment variables
+
+The Dockerfile default to the following environment variables:
+```
+# Jobserver settings
+SPARK_JOBSERVER_MEMORY=1G
+JOBSERVER_CONF_DIR=/opt/sparkjobserver/config
+LOGGING_OPTS="-Dlog4j.configuration=file:/opt/sparkjobserver/config/log4j.properties"
+# JobManager settings
+MANAGER_JAR_FILE=/opt/sparkjobserver/bin/spark-job-server.jar
+MANAGER_CONF_FILE=/opt/sparkjobserver/config/jobserver.conf
+```
+You can override these arguments on `run` with the `--env` parameter:
+```
+docker run --env SPARK_JOBSERVER_MEMORY=1G -v <config-folder>:/opt/sparkjobserver/config: jobserver
 ```
 
-## Issues
+## Customize
+Apart from the above mentioned build arguments and environment variables the docker image can be extended as desired by using the docker `FROM` instruction.
 
-### I can't access a textfile
+An important use case for the customization is for example providing a custom built spark, which could be solved e.g. with the following custom `Dockerfile`:
+```
+FROM jobserver
 
-You might not be able to access HDFS, or whatever shared file system your data files are on.  Make sure the right ports are open.  Also see https://github.com/spark-jobserver/spark-jobserver/issues/243#issuecomment-168242345.
+# Install dependencies
+RUN apk add --no-cache bash curl
 
-### Timeouts
+# Replace spark binary with custom one
+# (lying in the build context locally)
+COPY spark.tgz /tmp/spark.tgz
+RUN mkdir -p /tmp/spark && \
+    tar -xvzf /tmp/spark.tgz -C /tmp/spark --strip-components 1 && \
+    mv /tmp/spark /opt/spark
 
-You may need to enable host-only networking to get Docker to work in AWS.
+# Run jobserver
+CMD /opt/spark/bin/spark-submit \
+    --class spark.jobserver.JobServer \
+    --driver-memory "${SPARK_JOBSERVER_MEMORY}" \
+    --conf "spark.executor.extraJavaOptions=${LOGGING_OPTS}" \
+    --driver-java-options "${LOGGING_OPTS}" \
+    /opt/sparkjobserver/bin/spark-job-server.jar \
+    /opt/sparkjobserver/config/jobserver.conf
+```

--- a/docker-setups/README.md
+++ b/docker-setups/README.md
@@ -25,5 +25,5 @@ The following setups are available:
   Spark Standalone, scala 2.11, spark 2.4.6, hadoop 2.7, single Jobserver, SQL (H2 local) Metadata and Binary Dao, Client mode
 * [PostgreSQL](postgres):
   Spark Standalone, scala 2.11, spark 2.4.6, hadoop 2.7, single Jobserver, SQL (Postgresql) Metadata and Binary Dao, Client mode
-
-
+* [HDFS with Zookeeper](hdfs_with_zookeeper):
+  Spark Standalone, scala 2.11, spark 2.4.6, hadoop 2.7, single Jobserver, Zookeeper Metadata and HDFS Binary Dao, Client mode

--- a/docker-setups/README.md
+++ b/docker-setups/README.md
@@ -1,0 +1,29 @@
+# Docker setups
+Jobserver setups are vastly different depending on the usage and configuration scenario.
+To enable users of spark jobserver with a reference setup and to allow easier integration testing of setup variants, some exemplary setups have been dockerized in this folder.
+
+Contributions of (e.g. your own particular) docker setups are always welcome.
+
+## Usage
+Docker setups should come with a **docker-compose** file providing everything you need to start the jobserver including environment.
+For example you can run a minimal setup with
+```
+docker compose -f docker-setups/minimal/docker-compose.yml up
+```
+
+## Testing
+You can leverage the [job-server-integration-tests](../job-server-integration-tests) to test against a dockerized setup.
+An example test configuration is supplied within this folder.
+```
+sbt clean job-server-integration-tests/assembly
+java -jar job-server-integration-tests/target/scala-*/job-server-integration-tests-assembly-*.jar docker-setups/integration-test.conf
+```
+
+## Available dockerized setups
+The following setups are available:
+* [Minimal](minimal)
+  Spark Standalone, scala 2.11, spark 2.4.6, hadoop 2.7, single Jobserver, SQL (H2 local) Metadata and Binary Dao, Client mode
+* [PostgreSQL](postgres):
+  Spark Standalone, scala 2.11, spark 2.4.6, hadoop 2.7, single Jobserver, SQL (Postgresql) Metadata and Binary Dao, Client mode
+
+

--- a/docker-setups/hdfs_with_zookeeper/config/jobserver.conf
+++ b/docker-setups/hdfs_with_zookeeper/config/jobserver.conf
@@ -1,0 +1,129 @@
+spark {
+  # spark.master will be passed to each job's JobContext
+  master = "spark://spark-master:7077"
+  submit.deployMode = "client"
+  driver.supervise = false
+
+  # Default # of CPUs for jobs to use for Spark standalone cluster
+  job-number-cpus = 1
+
+  jobserver {
+    port = 8090
+
+    context-per-jvm = true
+
+    dao-timeout = 10s
+
+    kill-context-on-supervisor-down = true
+    network-address-resolver =  auto
+    daorootdir = "/opt/sparkjobserver/data"
+
+    # If set to false, the binary will be cached on job start only.
+    cache-on-upload = true
+
+    startup_dao_cleanup_class = "spark.jobserver.util.ZKCleanup"
+    datadao {
+      rootdir = "/opt/sparkjobserver/upload"
+    }
+
+    binarydao {
+        class = "spark.jobserver.io.HdfsBinaryObjectsDAO"
+        # HDFS absolute path for storing binaries
+        dir = "hdfs://hadoop:9000/jobserver/binaries"
+    }
+    metadatadao {
+        class = spark.jobserver.io.zookeeper.MetaDataZookeeperDAO
+    }
+
+    zookeeperdao {
+      connection-string="zookeeper:2181"
+      dir = "jobserver/db"
+      curator {
+        retries = 3
+        sleepMsBetweenRetries = 1000
+        connectionTimeoutMs = 2350
+        sessionTimeoutMs = 10000
+      }
+      autopurge = false
+      autopurge_after_hours = 168
+    }
+
+    short-timeout = 10 s
+
+    # When using chunked transfer encoding with scala Stream job results, this is the size of each chunk
+    result-chunk-size = 1m
+  }
+
+  # predefined Spark contexts
+  # contexts {
+  #   my-low-latency-context {
+  #     num-cpu-cores = 1           # Number of cores to allocate.  Required.
+  #     memory-per-node = 512m         # Executor memory per node, -Xmx style eg 512m, 1G, etc.
+  #   }
+  #   # define additional contexts here
+  # }
+
+  # universal context configuration.  These settings can be overridden, see README.md
+  context-settings {
+    num-cpu-cores = 2              # Number of cores to allocate.  Required.
+    memory-per-node = 512m         # Executor memory per node, -Xmx style eg 512m, #1G, etc.
+    spark.ui.reverseProxy = false
+    spark.streaming.ui.retainedBatches = 1000
+
+    # in case spark distribution should be accessed from HDFS (as opposed to being installed on every mesos slave)
+    # spark.executor.uri = "hdfs://namenode:8020/apps/spark/spark.tgz"
+
+    # uris of jars to be loaded into the classpath for this context. Uris is a string list, or a string separated by commas ','
+    # dependent-jar-uris = ["file:///some/path/present/in/each/mesos/slave/somepackage.jar"]
+
+    # Timeout for forked JVM to spin up, acquire resources and connect back to jobserver
+    forked-jvm-init-timeout = 45 s
+
+    # If you wish to pass any settings directly to the sparkConf as-is, add them here in passthrough,
+    # such as hadoop connection settings that don't use the "spark." prefix
+    passthrough {
+      #es.nodes = "192.1.1.1"
+    }
+
+    launcher {
+      spark.driver.memory = 1G
+      spark.port.maxRetries = 100
+      spark.metrics.namespace="\\${spark.app.name}"
+
+      # Spark history server configurations
+      spark.eventLog.enabled = false
+      spark.eventLog.compress = true
+      spark.eventLog.dir = "hdfs:///spark-history-server"
+    }
+
+    python {
+      paths = [
+        ${SPARK_HOME}/python,
+        "/var/vcap/packages/python/lib"
+      ]
+      executable = "/var/vcap/packages/python/bin/python"
+    }
+  }
+
+  # This needs to match SPARK_HOME for cluster SparkContexts to be created successfully
+  # home = "/home/spark/spark"
+}
+
+akka {
+  cluster {
+    auto-down-unreachable-after = "off"
+    downing-provider-class = "akka.downing.KeepOldestDowningProvider"
+    allow-weakly-up-members = "off"
+  }
+
+  coordinated-shutdown {
+    run-by-jvm-shutdown-hook = "off"
+  }
+}
+
+akka.http.server {
+  request-timeout = 1200 s
+  idle-timeout = 1201 s
+  parsing.max-content-length = 150M
+  parsing.max-uri-length = 4096
+}

--- a/docker-setups/hdfs_with_zookeeper/config/log4j.properties
+++ b/docker-setups/hdfs_with_zookeeper/config/log4j.properties
@@ -1,0 +1,11 @@
+# Log everything INFO and above to stdout
+log4j.rootLogger=INFO,console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.Threshold=INFO
+log4j.appender.console.Target=System.out
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=[%d] %-5p %.26c [%X{testName}] [%X{akkaSource}] - %m%n
+
+log4j.logger.org.apache.spark.scheduler.TaskSetManager=WARN
+log4j.logger.org.apache.spark.scheduler.DAGScheduler=WARN

--- a/docker-setups/hdfs_with_zookeeper/docker-compose.yml
+++ b/docker-setups/hdfs_with_zookeeper/docker-compose.yml
@@ -1,0 +1,110 @@
+version: "3.8"
+services:
+  spark-jobserver:
+    build: ../../
+    container_name: spark-jobserver
+    depends_on:
+      - spark-master
+      - spark-worker-1
+      - namenode
+      - zookeeper
+      - datanode-1
+    ports:
+      - 8090:8090
+    volumes:
+      - type: bind
+        source: config
+        target: /opt/sparkjobserver/config
+    networks:
+      internal-network:
+        ipv4_address: 10.5.0.30
+
+  zookeeper:
+    container_name: sjs_zookeeper
+    domainname: zookeeper
+    hostname: zookeeper
+    image: zookeeper:3.5.6
+    ports:
+      - "2181:2181"
+    networks:
+      internal-network:
+        ipv4_address: 10.5.0.2
+
+  hadoop:
+    container_name: hadoop
+    image: sequenceiq/hadoop-docker:2.7.1
+    domainname: hadoop
+    hostname: hadoop
+    ports:
+      - 50070:50070
+      - 50075:50075
+    networks:
+      internal-network:
+        ipv4_address: 10.5.0.3
+
+  spark-master:
+    image: bde2020/spark-master:2.4.5-hadoop2.7
+    container_name: sjs_spark-master
+    depends_on:
+      - namenode
+    hostname: spark-master
+    ports:
+      - "58080:8080"
+      - "6066:6066"
+      - "7077:7077"
+    networks:
+      internal-network:
+        ipv4_address: 10.5.0.10
+    environment:
+      - "SPARK_LOCAL_IP=spark-master"
+
+  spark-worker-1:
+    image: bde2020/spark-worker:2.4.5-hadoop2.7
+    container_name: sjs_spark-worker-1
+    depends_on:
+      - spark-master
+    hostname: spark-worker-1
+    ports:
+      - "58081:8081"
+    environment:
+      - "SPARK_LOCAL_IP=spark-worker-1"
+      - "SPARK_MASTER=spark://spark-master:7077"
+      - "SPARK_WORKER_CORES=2"
+      - "SPARK_WORKER_MEMORY=1G"
+      - "SPARK_DRIVER_MEMORY=128m"
+      - "SPARK_EXECUTOR_MEMORY=256m"
+    networks:
+      internal-network:
+        ipv4_address: 10.5.0.20
+
+  spark-worker-2:
+    image: bde2020/spark-worker:2.4.5-hadoop2.7
+    container_name: sjs_spark-worker-2
+    depends_on:
+      - spark-master
+    hostname: spark-worker-2
+    ports:
+      - "58082:8081"
+    environment:
+      - "SPARK_LOCAL_IP=spark-worker-2"
+      - "SPARK_MASTER=spark://spark-master:7077"
+      - "SPARK_WORKER_CORES=2"
+      - "SPARK_WORKER_MEMORY=1G"
+      - "SPARK_DRIVER_MEMORY=128m"
+      - "SPARK_EXECUTOR_MEMORY=256m"
+    networks:
+      internal-network:
+        ipv4_address: 10.5.0.21
+
+volumes:
+  namenode:
+  datanode:
+
+networks:
+  internal-network:
+    name: sjs-network
+    driver: bridge
+    ipam:
+     driver: default
+     config:
+       - subnet: 10.5.0.0/16

--- a/docker-setups/integration-test.conf
+++ b/docker-setups/integration-test.conf
@@ -1,0 +1,10 @@
+{
+
+  jobserverAddresses: ["http://localhost:8090"]
+  useSSL: false
+
+  runTests: [
+    "BasicApiTests",
+    "CornerCasesTests"
+  ]
+}

--- a/docker-setups/minimal/config/jobserver.conf
+++ b/docker-setups/minimal/config/jobserver.conf
@@ -1,0 +1,93 @@
+# Template for a Spark Job Server configuration file
+# When deployed these settings are loaded when job server starts
+#
+# Spark Cluster / Job Server configuration
+
+flyway.locations="db/h2/migration"
+flyway.initOnMigrate="true"
+
+spark {
+  # spark.master will be passed to each job's JobContext
+  # local[...], yarn, mesos://... or spark://...
+  master = "spark://spark-master:7077"
+
+  # client or cluster deployment
+  submit.deployMode = "client"
+  driver.supervise = false
+
+  # Default # of CPUs for jobs to use for Spark standalone cluster
+  job-number-cpus = 4
+
+  jobserver {
+    port = 8090
+    startH2Server = true
+    context-per-jvm = true
+    kill-context-on-supervisor-down = false
+    ignore-akka-hostname = false
+
+    daorootdir = "/tmp/combineddao"
+    binarydao {
+      class = spark.jobserver.io.SqlBinaryObjectsDAO
+      dir = "/tmp/jobserver"
+    }
+    metadatadao {
+      class = spark.jobserver.io.MetaDataSqlDAO
+    }
+
+    sqldao {
+      # Slick database driver, full classpath
+      slick-driver = slick.jdbc.H2Profile
+
+      # JDBC driver, full classpath
+      jdbc-driver = org.h2.Driver
+
+      # Directory where default H2 driver stores its data. Only needed for H2.
+      rootdir = "/tmp/spark-jobserver/sqldao/data"
+
+      jdbc {
+        url = "jdbc:h2:tcp://127.0.0.1//tmp/spark-jobserver/sqldao/data/h2dbsupervise"
+        user = ""
+        password = ""
+      }
+
+      dbcp {
+        maxactive = 20
+        maxidle = 10
+        initialsize = 10
+      }
+    }
+    # When using chunked transfer encoding with scala Stream job results, this is the size of each chunk
+    result-chunk-size = 1m
+  }
+
+  # Predefined Spark contexts
+  # contexts {
+  #   my-low-latency-context {
+  #     num-cpu-cores = 1           # Number of cores to allocate.  Required.
+  #     memory-per-node = 512m         # Executor memory per node, -Xmx style eg 512m, 1G, etc.
+  #   }
+  #   # define additional contexts here
+  # }
+
+  # Universal context configuration.  These settings can be overridden, see README.md
+  context-settings {
+    num-cpu-cores = 2           # Number of cores to allocate.  Required.
+    memory-per-node = 512m         # Executor memory per node, -Xmx style eg 512m, #1G, etc.
+
+    # In case spark distribution should be accessed from HDFS (as opposed to being installed on every Mesos slave)
+    # spark.executor.uri = "hdfs://namenode:8020/apps/spark/spark.tgz"
+
+    # URIs of Jars to be loaded into the classpath for this context.
+    # Uris is a string list, or a string separated by commas ','
+    # dependent-jar-uris = ["file:///some/path/present/in/each/mesos/slave/somepackage.jar"]
+
+    # Add settings you wish to pass directly to the sparkConf as-is such as Hadoop connection
+    # settings that don't use the "spark." prefix
+    passthrough {
+      #es.nodes = "192.1.1.1"
+    }
+  }
+
+  # This needs to match SPARK_HOME for cluster SparkContexts to be created successfully
+  # home = "/home/spark/spark"
+}

--- a/docker-setups/minimal/config/log4j.properties
+++ b/docker-setups/minimal/config/log4j.properties
@@ -1,0 +1,11 @@
+# Log everything INFO and above to stdout
+log4j.rootLogger=INFO,console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.Threshold=INFO
+log4j.appender.console.Target=System.out
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=[%d] %-5p %.26c [%X{testName}] [%X{akkaSource}] - %m%n
+
+log4j.logger.org.apache.spark.scheduler.TaskSetManager=WARN
+log4j.logger.org.apache.spark.scheduler.DAGScheduler=WARN

--- a/docker-setups/minimal/docker-compose.yml
+++ b/docker-setups/minimal/docker-compose.yml
@@ -1,0 +1,59 @@
+version: '3'
+services:
+
+  spark-master:
+    image: bde2020/spark-master:2.4.5-hadoop2.7
+    container_name: spark-master
+    hostname: spark-master
+    ports:
+      - "8080:8080"
+      - "6066:6066"
+      - "7077:7077"
+    environment:
+      - "SPARK_LOCAL_IP=spark-master"
+
+  spark-worker-1:
+    image: bde2020/spark-worker:2.4.5-hadoop2.7
+    container_name: spark-worker-1
+    depends_on:
+      - spark-master
+    hostname: spark-worker-1
+    ports:
+      - "8081:8081"
+    environment:
+      - "SPARK_LOCAL_IP=spark-worker-1"
+      - "SPARK_MASTER=spark://spark-master:7077"
+      - "SPARK_WORKER_CORES=2"
+      - "SPARK_WORKER_MEMORY=1G"
+      - "SPARK_DRIVER_MEMORY=128m"
+      - "SPARK_EXECUTOR_MEMORY=256m"
+
+  spark-worker-2:
+    image: bde2020/spark-worker:2.4.5-hadoop2.7
+    container_name: spark-worker-2
+    depends_on:
+      - spark-master
+    hostname: spark-worker-2
+    ports:
+      - "8082:8081"
+    environment:
+      - "SPARK_LOCAL_IP=spark-worker-2"
+      - "SPARK_MASTER=spark://spark-master:7077"
+      - "SPARK_WORKER_CORES=2"
+      - "SPARK_WORKER_MEMORY=1G"
+      - "SPARK_DRIVER_MEMORY=128m"
+      - "SPARK_EXECUTOR_MEMORY=256m"
+
+  spark-jobserver:
+    build: ../../
+    container_name: spark-jobserver
+    depends_on:
+      - spark-master
+      - spark-worker-1
+      - spark-worker-2
+    ports:
+      - 8090:8090
+    volumes:
+      - type: bind
+        source: ./config
+        target: /opt/sparkjobserver/config

--- a/docker-setups/postgres/Dockerfile
+++ b/docker-setups/postgres/Dockerfile
@@ -1,0 +1,2 @@
+FROM library/postgres
+COPY create-large-object-extension.sh /docker-entrypoint-initdb.d/

--- a/docker-setups/postgres/config/jobserver.conf
+++ b/docker-setups/postgres/config/jobserver.conf
@@ -1,0 +1,93 @@
+# Template for a Spark Job Server configuration file
+# When deployed these settings are loaded when job server starts
+#
+# Spark Cluster / Job Server configuration
+
+flyway.locations="db/postgresql/migration"
+flyway.initOnMigrate="true"
+
+spark {
+  # spark.master will be passed to each job's JobContext
+  # local[...], yarn, mesos://... or spark://...
+  master = "spark://spark-master:7077"
+
+  # client or cluster deployment
+  submit.deployMode = "client"
+  driver.supervise = false
+
+  # Default # of CPUs for jobs to use for Spark standalone cluster
+  job-number-cpus = 4
+
+  jobserver {
+    port = 8090
+    context-per-jvm = true
+    kill-context-on-supervisor-down = false
+    ignore-akka-hostname = false
+
+    daorootdir = "/tmp/spark-jobserver"
+    binarydao {
+      class = spark.jobserver.io.SqlBinaryObjectsDAO
+    }
+
+    metadatadao {
+      class = spark.jobserver.io.MetaDataSqlDAO
+    }
+
+    sqldao {
+      # Slick database driver, full classpath
+      slick-driver = slick.jdbc.PostgresProfile
+
+      # JDBC driver, full classpath
+      jdbc-driver = org.postgresql.Driver
+
+      jdbc {
+        url = "jdbc:postgresql://postgres/spark_jobserver"
+        user = "postgres"
+        password = "secret"
+      }
+
+      dbcp {
+        maxactive = 20
+        maxidle = 10
+        initialsize = 10
+      }
+    }
+    # When using chunked transfer encoding with scala Stream job results, this is the size of each chunk
+    result-chunk-size = 1m
+  }
+
+  # Predefined Spark contexts
+  # contexts {
+  #   my-low-latency-context {
+  #     num-cpu-cores = 1           # Number of cores to allocate.  Required.
+  #     memory-per-node = 512m         # Executor memory per node, -Xmx style eg 512m, 1G, etc.
+  #   }
+  #   # define additional contexts here
+  # }
+
+  # Universal context configuration.  These settings can be overridden, see README.md
+  context-settings {
+    num-cpu-cores = 2           # Number of cores to allocate.  Required.
+    memory-per-node = 512m         # Executor memory per node, -Xmx style eg 512m, #1G, etc.
+
+    # In case spark distribution should be accessed from HDFS (as opposed to being installed on every Mesos slave)
+    # spark.executor.uri = "hdfs://namenode:8020/apps/spark/spark.tgz"
+
+    # URIs of Jars to be loaded into the classpath for this context.
+    # Uris is a string list, or a string separated by commas ','
+    # dependent-jar-uris = ["file:///some/path/present/in/each/mesos/slave/somepackage.jar"]
+
+    # Add settings you wish to pass directly to the sparkConf as-is such as Hadoop connection
+    # settings that don't use the "spark." prefix
+    passthrough {
+      #es.nodes = "192.1.1.1"
+    }
+  }
+
+  # This needs to match SPARK_HOME for cluster SparkContexts to be created successfully
+  # home = "/home/spark/spark"
+}
+
+# Note that you can use this file to define settings not only for job server,
+# but for your Spark jobs as well.  Spark job configuration merges with this configuration file as defaults.
+

--- a/docker-setups/postgres/config/log4j.properties
+++ b/docker-setups/postgres/config/log4j.properties
@@ -1,0 +1,11 @@
+# Log everything INFO and above to stdout
+log4j.rootLogger=INFO,console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.Threshold=INFO
+log4j.appender.console.Target=System.out
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=[%d] %-5p %.26c [%X{testName}] [%X{akkaSource}] - %m%n
+
+log4j.logger.org.apache.spark.scheduler.TaskSetManager=WARN
+log4j.logger.org.apache.spark.scheduler.DAGScheduler=WARN

--- a/docker-setups/postgres/create-large-object-extension.sh
+++ b/docker-setups/postgres/create-large-object-extension.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE EXTENSION lo;
+EOSQL

--- a/docker-setups/postgres/docker-compose.yml
+++ b/docker-setups/postgres/docker-compose.yml
@@ -1,0 +1,69 @@
+version: '3'
+services:
+
+  postgres:
+    build: .
+    container_name: postgres
+    ports:
+      - "5432:5432"
+    environment:
+      - "POSTGRES_DB=spark_jobserver"
+      - "POSTGRES_USER=postgres"
+      - "POSTGRES_PASSWORD=secret"
+
+  spark-master:
+    image: bde2020/spark-master:2.4.5-hadoop2.7
+    container_name: spark-master
+    hostname: spark-master
+    ports:
+      - "8080:8080"
+      - "6066:6066"
+      - "7077:7077"
+    environment:
+      - "SPARK_LOCAL_IP=spark-master"
+
+  spark-worker-1:
+    image: bde2020/spark-worker:2.4.5-hadoop2.7
+    container_name: spark-worker-1
+    depends_on:
+      - spark-master
+    hostname: spark-worker-1
+    ports:
+      - "8081:8081"
+    environment:
+      - "SPARK_LOCAL_IP=spark-worker-1"
+      - "SPARK_MASTER=spark://spark-master:7077"
+      - "SPARK_WORKER_CORES=2"
+      - "SPARK_WORKER_MEMORY=1G"
+      - "SPARK_DRIVER_MEMORY=128m"
+      - "SPARK_EXECUTOR_MEMORY=256m"
+
+  spark-worker-2:
+    image: bde2020/spark-worker:2.4.5-hadoop2.7
+    container_name: spark-worker-2
+    depends_on:
+      - spark-master
+    hostname: spark-worker-2
+    ports:
+      - "8082:8081"
+    environment:
+      - "SPARK_LOCAL_IP=spark-worker-2"
+      - "SPARK_MASTER=spark://spark-master:7077"
+      - "SPARK_WORKER_CORES=2"
+      - "SPARK_WORKER_MEMORY=1G"
+      - "SPARK_DRIVER_MEMORY=128m"
+      - "SPARK_EXECUTOR_MEMORY=256m"
+
+  spark-jobserver:
+    build: ../../
+    container_name: spark-jobserver
+    depends_on:
+      - spark-master
+      - spark-worker-1
+      - spark-worker-2
+    ports:
+      - 8090:8090
+    volumes:
+      - type: bind
+        source: ./config
+        target: /opt/sparkjobserver/config

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,6 +14,4 @@ addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.5.1")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")
 
-addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.8.0")
-
 addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.4.0")


### PR DESCRIPTION
## Proposed changes

* Add actual Dockerfile to the root of the project that makes it
  easy to build, test and get started with spark jobserver.
* Add three docker compose setups (minimal h2, postgres, HDFS + ZK)
* Add documentation
* Remove Dockerfile encoded within the build.sbt

## Background

Currently there are two docker solutions provided:
- a Dockerfile encoded within the build.sbt that can be build with
  sbt docker
- a Dockerfile.test apparently run for the tests

The new Dockerfile provides multiple extension points via ARG, ENV or
can be used as a base docker image, but also includes useful
defaults to get something working out of the box.
An actual Dockerfile also seems to be easier to maintain.

As stated in `docker-setups/README.md` this additionally serves as
a foundation to share and maintain working dev / test / productive setups
in the community, e.g. in form of docker compose files.

This way, setup-specific issues (DAO, resource manager, configuration) 
in the community could be reproduced more easily, automatically
tested for with integration tests and maybe even shared to provide
new users with a working setup very fast.

**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](doc/contribution-guidelines.md#commit-message-format) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?
- [X] Docs have been added / updated (for bug fixes / features) ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1383)
<!-- Reviewable:end -->
