### PR TITLE
Fix Travis CI build: remove pip2, downgrade python 3, update Travis base image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: required
 
+dist: bionic
+
 env:
   global:
     - DOCKER_IMAGE="spark-jobserver:ci"

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -2,11 +2,21 @@ FROM openjdk:8-jdk
 
 USER root
 
+# Python version shoule be < 3.8 as it is the last Python version, which works with Spark 2.4
+ARG PYTHON_VERSION=3.6.0
+
+RUN apt-get -qq update && apt-get install -y --force-yes libssl-dev openssl build-essential zlib1g-dev && \
+    wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz && \
+    tar xzvf Python-${PYTHON_VERSION}.tgz && \
+    cd Python-${PYTHON_VERSION} && \
+    ./configure && make && make install && \
+    ln -s ./python /usr/bin/python
+
 # install and cache sbt, python
 RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
     curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add && \
     apt-get -qq update && \
-    apt-get install -y --force-yes python3 python3-pip sbt=1.1.6
+    apt-get install -y --force-yes python3-pip sbt=1.1.6
 
 WORKDIR /usr/src/app/
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -3,7 +3,6 @@ FROM openjdk:8-jdk
 USER root
 
 # install and cache sbt, python
-
 RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
     curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add && \
     apt-get -qq update && \

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,12 +1,13 @@
 FROM openjdk:8-jdk
 
 USER root
+
 # install and cache sbt, python
 
 RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
     curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add && \
     apt-get -qq update && \
-    apt-get install -y --force-yes python3 python3-pip python-pip sbt=1.1.6
+    apt-get install -y --force-yes python3 python3-pip sbt=1.1.6
 
 WORKDIR /usr/src/app/
 

--- a/ci/install-python-dependencies.sh
+++ b/ci/install-python-dependencies.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
 pip3 install --upgrade pip
+pip3 install --user wheel
 pip3 install --user pyhocon
 pip3 install --user pycodestyle


### PR DESCRIPTION
**Current behavior :** 
Travis CI build doesn't work anymore, due to a number of reasons:

1. `pip2` can't be installed. `apt-get` is not allowing to install `python-pip` anymore. 
2.  Once `pip2` issue was solved, build started to fail with the following error: 
```
    Step 10/14 : RUN sbt update
     ---> Running in a6a25da779e7 
    ls: cannot access '/usr/local/bin/sbt': Operation not permitted 
    Could not find launcher jar: /usr/bin/sbt-launch.jar
 ```
   The reason is an underlying Travis CI image, which should be changed to `bionic`.
3. Spark 2.4 can work only with Python versions < 3.8. Currently `apt-get` installs Python 3.9 by default.  Build tools (`wheel` package) now needs to be installed explicitly.

**New behavior :**
1. Remove installation of `pip2`. SJS was already migrated to use Python 3.
2. Change Travis CI image to bionic.
3. Install Python `3.6.0`
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spark-jobserver/spark-jobserver/1384)
<!-- Reviewable:end -->
